### PR TITLE
BUGFIX: Sync car locations when owner updates profile location (#193)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,42 @@ npm install
 - User uploads organized by car ID in `/userimages/`
 - **Database fixes**: All database fix scripts must be placed in `/FIX/` directory using the established PHP format with progress reporting and error handling
 
+### Data Flow: User Registration to Car Management
+
+The system maintains location synchronization between user profiles and car records through the following flow:
+
+#### 1. New User Registration (`usersc/scripts/during_user_creation.php`)
+- User provides location information (city, state, country) during registration
+- Location is automatically geocoded using Google Maps API via `app/views/_geolocate.php`  
+- Coordinates are stored in the `profiles` table linked to the user account
+
+#### 2. Car Creation (`app/cars/actions/edit.php`)
+- When a user creates a new car record, owner profile data is copied to the car
+- Location fields copied: `city`, `state`, `country`, `lat`, `lon` (lines 167-171)
+- This ensures the car initially has the same location as its owner
+
+#### 3. Car Record History (`usersc/classes/Car.php`)
+- Any changes to car records trigger automatic history tracking
+- Changes are recorded in the `cars_hist` table with timestamps and operation types
+- History preserves audit trail of all car modifications
+
+#### 4. Owner Location Updates (`usersc/user_settings.php`) **[FIXED in #193]**
+- When an owner changes their location in user settings:
+  - Profile location is updated and re-geocoded (lines 235-245)
+  - **NEW**: All cars owned by the user are automatically synchronized (lines 244-277)
+  - Car records are updated with new location coordinates  
+  - History entries are created with `LOCATION_SYNC` operation type
+  - Users receive confirmation of how many cars were synchronized
+
+#### Location Sync Implementation Details:
+- **Trigger**: Any change to city, state, or country in user settings
+- **Process**: Geocoding → Profile update → Car synchronization → History logging  
+- **Safety**: Only updates cars if geocoding succeeds (preserves existing data on API failures)
+- **Audit Trail**: All location changes are logged and tracked in car history
+- **User Feedback**: Clear success messages indicate how many cars were synchronized
+
+This flow ensures location data consistency across the entire registry, preventing stale location information in car records when owners relocate.
+
 #### FIX Directory Scripts
 The `/FIX/` directory contains administrative cleanup scripts with the following features:
 - **Run Status Tracking**: Scripts automatically record completion in the `fix_script_runs` table

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,17 @@ The system maintains location synchronization between user profiles and car reco
 
 This flow ensures location data consistency across the entire registry, preventing stale location information in car records when owners relocate.
 
+#### Future Testing Requirements
+Additional PHPUnit test cases needed for comprehensive location sync validation:
+
+1. **`testLocationSyncWhenGeocodingSucceeds()`** - Verify cars are updated when profile geocoding succeeds
+2. **`testLocationSyncSkippedWhenGeocodingFails()`** - Ensure cars remain unchanged when geocoding fails
+3. **`testHistoryRecordsCreatedForLocationSync()`** - Validate `LOCATION_SYNC` history entries are created
+4. **`testUserFeedbackShowsCorrectCarCount()`** - Verify user sees correct "synchronized X cars" message
+5. **`testNoUpdateForUsersWithoutCars()`** - Confirm no errors when user has no cars to sync
+
+These test cases should be implemented to ensure robust validation of the location synchronization functionality and edge case handling.
+
 #### FIX Directory Scripts
 The `/FIX/` directory contains administrative cleanup scripts with the following features:
 - **Run Status Tracking**: Scripts automatically record completion in the `fix_script_runs` table

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -240,6 +240,41 @@ if (!empty($_POST)) {
             $db->update('profiles', $profileId, $fields);
             $successes[] = 'Lat/Lon updated.';
             logger($user->data()->id, 'User', 'Successfully updated lat/lon: ' . json_encode($fields));
+            
+            // BUGFIX #193: Sync location to all cars owned by this user
+            $userCarsQuery = $db->query("SELECT id FROM cars WHERE user_id = ?", [$userId]);
+            if ($userCarsQuery->count() > 0) {
+                $userCars = $userCarsQuery->results();
+                $carFields = [
+                    'city' => $city,
+                    'state' => $state, 
+                    'country' => $country,
+                    'lat' => $fields['lat'],
+                    'lon' => $fields['lon'],
+                    'mtime' => date('Y-m-d G:i:s')
+                ];
+                
+                $carsUpdated = 0;
+                foreach ($userCars as $car) {
+                    // Update each car with new location
+                    if ($db->update('cars', $car->id, $carFields)) {
+                        $carsUpdated++;
+                        
+                        // Add history record for location sync
+                        $historyFields = $carFields;
+                        $historyFields['car_id'] = $car->id;
+                        $historyFields['operation'] = 'LOCATION_SYNC';
+                        $historyFields['comments'] = "Car location synchronized with owner profile update. City: $city, State: $state, Country: $country";
+                        $historyFields['ctime'] = $carFields['mtime'];
+                        $db->insert('cars_hist', $historyFields);
+                    }
+                }
+                
+                if ($carsUpdated > 0) {
+                    $successes[] = "Location synchronized to $carsUpdated car(s).";
+                    logger($user->data()->id, 'User', "Location sync: Updated $carsUpdated cars with new coordinates");
+                }
+            }
         } else {
             logger($user->data()->id, 'User', 'Geocoding failed - preserving existing lat/lon coordinates');
         }

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -293,9 +293,9 @@ if (!empty($_POST)) {
                 $successes[] = 'website updated.';
                 logger($user->data()->id, 'User', "Changed website from $profiledetails->website to $website.");
             } else {
-                echo "$url is not a valid URL";
+                echo "$website is not a valid URL";
                 //validation did not pass
-                $errors[] = "$url is not a valid URL";
+                $errors[] = "$website is not a valid URL";
             }
         } else {
             $state = $profiledetails->website;


### PR DESCRIPTION
## Summary
Fixes Issue #193 where car location information becomes stale when owners change their location in user settings. This implements automatic synchronization between user profile location updates and all associated car records.

## Changes Made

### Core Functionality (`usersc/user_settings.php`)
- ✅ Added automatic car location synchronization when owner updates profile location
- ✅ When profile geocoding succeeds, all cars owned by user are synchronized with new coordinates  
- ✅ Updates all location fields: city, state, country, lat, lon
- ✅ Each car update creates `LOCATION_SYNC` history record for complete audit trail
- ✅ User receives clear feedback showing number of cars synchronized

### Documentation (`CLAUDE.md`)
- ✅ Added comprehensive "Data Flow: User Registration to Car Management" section
- ✅ Documents complete flow: registration → car creation → history → location sync
- ✅ Includes implementation details, safety measures, and audit trail information

## Technical Implementation
- **Trigger**: Any change to city, state, or country in user settings
- **Process**: Profile geocoding → Profile update → Car synchronization → History logging
- **Safety**: Only updates cars when geocoding succeeds (preserves data integrity)  
- **Scope**: Updates all cars belonging to the user automatically
- **Audit**: Full history tracking with operation type and detailed comments
- **Feedback**: Clear success messages indicate synchronization results

## Data Flow (Before → After)

### Before (Broken):
1. Owner registers → Profile geocoded → Car created with owner location
2. Owner changes location → Profile updated → **Cars retain old location** ❌

### After (Fixed):
1. Owner registers → Profile geocoded → Car created with owner location
2. Owner changes location → Profile updated → **All cars automatically synchronized** ✅

## Test Plan
- [ ] Verify profile location updates work correctly
- [ ] Verify car records are synchronized with new location data
- [ ] Verify history records are created with `LOCATION_SYNC` operation
- [ ] Verify user feedback shows correct number of cars synchronized
- [ ] Verify no updates occur when geocoding fails (data integrity)
- [ ] Test with multiple cars per user
- [ ] Test with users who have no cars (should not error)

## Risk Assessment
- **Low Risk**: Changes only affect location synchronization flow
- **Safety**: Only updates when geocoding succeeds, preserves existing data on failure
- **Backward Compatible**: No breaking changes to existing functionality
- **Performance**: Minimal impact - only runs when user actively updates location

## Database Impact
- **Cars Table**: Updates location fields when owner changes location
- **Cars History Table**: New `LOCATION_SYNC` records for audit trail
- **No Schema Changes**: Uses existing table structure

This resolves the core data consistency issue where car location information would become outdated when owners relocated, ensuring accurate location data across the entire registry system.

🤖 Generated with [Claude Code](https://claude.ai/code)