### PR TITLE
FIX: Cleanup script bugs - timestamp tracking and return button (Issue #235)

### DIFF
--- a/FIX/Cleanup-Orphaned-Car-User-Records.php
+++ b/FIX/Cleanup-Orphaned-Car-User-Records.php
@@ -200,6 +200,14 @@ $line = 1; // Where messages go
                                     logger($user->data()->id, 'DatabaseCleanup', "Cleaned up {$deletedCount} orphaned car_user records (Issue #35)");
                                 }
                                 
+                                // Record script completion
+                                try {
+                                    $db->query("INSERT INTO fix_script_runs (script_name) VALUES (?)", [basename(__FILE__)]);
+                                    logProgress("Script completion recorded in fix_script_runs table", 'success');
+                                } catch (Exception $e) {
+                                    logProgress("Warning: Could not record script completion: " . $e->getMessage(), 'warning');
+                                }
+                                
                                 logProgress("Cleanup process completed successfully", 'success');
                                 
                             } catch (Exception $e) {
@@ -244,7 +252,7 @@ $line = 1; // Where messages go
                                 <?php endif; ?>
                                 
                                 <div class="mt-3">
-                                    <a href="../" class="btn btn-primary btn-sm">
+                                    <a href="<?= $us_url_root ?>FIX/" class="btn btn-primary btn-sm">
                                         <i class="fa fa-arrow-left"></i> Return to FIX Menu
                                     </a>
                                 </div>


### PR DESCRIPTION
## Summary
Fixes two bugs in the `Cleanup-Orphaned-Car-User-Records.php` script affecting both development and production environments.

## Bug Fixes

### 1. Missing Timestamp Update
- **Problem**: Script completion was not being recorded in the `fix_script_runs` table
- **Impact**: FIX index showed "Never run" even after successful script execution
- **Solution**: Added database insert to record script completion with proper error handling

### 2. Broken Return Button
- **Problem**: "Return to FIX Menu" button used relative path `../` which resolved to site root in production
- **Impact**: Users were redirected to `https://elanregistry.org` instead of FIX directory
- **Solution**: Replaced with absolute URL using `$us_url_root` variable

## Changes Made
- Added script completion tracking after successful cleanup
- Fixed return button URL to work consistently across environments
- Maintained existing error handling and logging patterns

## Test Results
- ✅ PHP syntax validation passed
- ✅ Code follows established FIX script patterns
- ✅ Both issues tested and confirmed fixed

## Files Modified
- `FIX/Cleanup-Orphaned-Car-User-Records.php`

Closes #235

🤖 Generated with [Claude Code](https://claude.ai/code)