### PR TITLE
Fix statistics map pins: display car details, images, and correct links

### DIFF
--- a/app/assets/js/statistics.js
+++ b/app/assets/js/statistics.js
@@ -7,10 +7,8 @@
  * @copyright 2025
  */
 
-
 // Global chart instances to manage cleanup
 window.statisticsCharts = {};
-
 
 // Bootstrap color palette for consistent theming
 const BOOTSTRAP_COLORS = {
@@ -46,36 +44,36 @@ function getColorForName(colorName) {
 
   // Define realistic color mappings
   const colorMap = {
-    'red': '#DC3545',
-    'carnival red': '#DC143C',
-    'dark red': '#8B0000',
-    'blue': '#007BFF',
-    'dark blue': '#0056B3',
-    'light blue': '#87CEEB',
-    'navy blue': '#000080',
-    'white': '#F8F9FA',
-    'off white': '#FFFACD',
-    'pearl white': '#F8F8F8',
-    'cirrus white': '#E6E6FA',
-    'yellow': '#FFC107',
-    'bright yellow': '#FFFF00',
-    'pale yellow': '#FFFFE0',
-    'green': '#28A745',
-    'dark green': '#006400',
-    'light green': '#90EE90',
-    'british racing green': '#004225',
-    'brg': '#004225',
-    'black': '#343A40',
-    'silver': '#C0C0C0',
-    'grey': '#6C757D',
-    'gray': '#6C757D',
-    'orange': '#FD7E14',
-    'purple': '#6F42C1',
-    'brown': '#8B4513',
-    'gold': '#FFD700',
-    'bronze': '#CD7F32',
-    'pink': '#E83E8C',
-    'maroon': '#800000'
+    red: "#DC3545",
+    "carnival red": "#DC143C",
+    "dark red": "#8B0000",
+    blue: "#007BFF",
+    "dark blue": "#0056B3",
+    "light blue": "#87CEEB",
+    "navy blue": "#000080",
+    white: "#F8F9FA",
+    "off white": "#FFFACD",
+    "pearl white": "#F8F8F8",
+    "cirrus white": "#E6E6FA",
+    yellow: "#FFC107",
+    "bright yellow": "#FFFF00",
+    "pale yellow": "#FFFFE0",
+    green: "#28A745",
+    "dark green": "#006400",
+    "light green": "#90EE90",
+    "british racing green": "#004225",
+    brg: "#004225",
+    black: "#343A40",
+    silver: "#C0C0C0",
+    grey: "#6C757D",
+    gray: "#6C757D",
+    orange: "#FD7E14",
+    purple: "#6F42C1",
+    brown: "#8B4513",
+    gold: "#FFD700",
+    bronze: "#CD7F32",
+    pink: "#E83E8C",
+    maroon: "#800000"
   };
 
   // Try exact match first
@@ -91,34 +89,47 @@ function getColorForName(colorName) {
   }
 
   // Smart fallback: try to guess color from common patterns
-  if (name.includes('light') || name.includes('pale')) {
-    return '#D3D3D3'; // Light gray for light variants
+  if (name.includes("light") || name.includes("pale")) {
+    return "#D3D3D3"; // Light gray for light variants
   }
-  if (name.includes('dark') || name.includes('deep')) {
-    return '#2C2C2C'; // Dark gray for dark variants
+  if (name.includes("dark") || name.includes("deep")) {
+    return "#2C2C2C"; // Dark gray for dark variants
   }
-  if (name.includes('metallic') || name.includes('pearl')) {
-    return '#C0C0C0'; // Silver for metallic variants
+  if (name.includes("metallic") || name.includes("pearl")) {
+    return "#C0C0C0"; // Silver for metallic variants
   }
 
   // Consistent fallback colors for unknown colors (deterministic hash)
   const fallbackColors = [
-    '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF',
-    '#FF9F40', '#C9CBCF', '#E74C3C', '#3498DB', '#F39C12',
-    '#27AE60', '#8E44AD', '#E67E22', '#95A5A6'
+    "#FF6384",
+    "#36A2EB",
+    "#FFCE56",
+    "#4BC0C0",
+    "#9966FF",
+    "#FF9F40",
+    "#C9CBCF",
+    "#E74C3C",
+    "#3498DB",
+    "#F39C12",
+    "#27AE60",
+    "#8E44AD",
+    "#E67E22",
+    "#95A5A6"
   ];
 
   // Create deterministic hash for consistent color assignment
   let hash = 0;
   for (let i = 0; i < name.length; i++) {
     const char = name.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
+    hash = (hash << 5) - hash + char;
     hash = hash & hash; // Convert to 32bit integer
   }
 
   // Log unknown colors for admin awareness (only in development)
-  if (typeof console !== 'undefined' && console.warn) {
-    console.warn(`Unknown car color detected: "${colorName}" - using fallback color. Consider adding to color mapping.`);
+  if (typeof console !== "undefined" && console.warn) {
+    console.warn(
+      `Unknown car color detected: "${colorName}" - using fallback color. Consider adding to color mapping.`
+    );
   }
 
   return fallbackColors[Math.abs(hash) % fallbackColors.length];
@@ -128,7 +139,6 @@ function getColorForName(colorName) {
  * Initialize the statistics dashboard
  */
 $(document).ready(function () {
-
   try {
     // Initialize overview tab (load immediately)
     initializeOverviewTab();
@@ -138,7 +148,6 @@ $(document).ready(function () {
 
     // Update overview metrics
     updateOverviewMetrics();
-
   } catch (error) {
     console.error("Error in statistics initialization:", error);
   }
@@ -957,11 +966,13 @@ function createEarlyLateChart(data) {
 function createColorDistributionChart(data) {
   // Normalize color names to handle inconsistent capitalization and spacing
   function normalizeColor(color) {
-    return color.trim().toLowerCase()
-      .replace(/\s+/g, ' ') // Replace multiple spaces with single space
-      .split(' ')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+    return color
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, " ") // Replace multiple spaces with single space
+      .split(" ")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
   }
 
   // Aggregate data by normalized color names
@@ -979,7 +990,9 @@ function createColorDistributionChart(data) {
   const values = Object.values(normalizedData);
 
   // Generate realistic colors for each color name
-  const backgroundColors = labels.map(colorName => getColorForName(colorName));
+  const backgroundColors = labels.map((colorName) =>
+    getColorForName(colorName)
+  );
 
   const ctx = document
     .getElementById("colorDistributionChart")
@@ -1013,11 +1026,13 @@ function createColorDistributionChart(data) {
 function createColorByYearChart(data) {
   // Normalize color names to handle inconsistent capitalization and spacing
   function normalizeColor(color) {
-    return color.trim().toLowerCase()
-      .replace(/\s+/g, ' ') // Replace multiple spaces with single space
-      .split(' ')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+    return color
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, " ") // Replace multiple spaces with single space
+      .split(" ")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
   }
 
   // Group data by normalized color
@@ -1074,11 +1089,13 @@ function createColorByYearChart(data) {
 function createColorBySeriesChart(data) {
   // Normalize color names to handle inconsistent capitalization and spacing
   function normalizeColor(color) {
-    return color.trim().toLowerCase()
-      .replace(/\s+/g, ' ') // Replace multiple spaces with single space
-      .split(' ')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+    return color
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, " ") // Replace multiple spaces with single space
+      .split(" ")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
   }
 
   // Group data by series and normalized color
@@ -1236,7 +1253,6 @@ function loadMapMarkers(map) {
       return response.text();
     })
     .then((xmlText) => {
-
       const parser = new DOMParser();
       const xmlDoc = parser.parseFromString(xmlText, "text/xml");
 
@@ -1285,19 +1301,42 @@ function loadMapMarkers(map) {
             position: { lat: lat, lng: lng },
             map: map,
             icon: iconUrl,
-            title: `${markerData.getAttribute("name") || "Car"} - ${series}`
+            title: `${markerData.getAttribute("name") || "Car"} - ${
+              markerData.getAttribute("city") || ""
+            }`
           });
+
+          // Get car details for info window
+          const carName = markerData.getAttribute("name") || "Elan";
+          const imageUrl = markerData.getAttribute("image");
+
+          // Get car ID for details link
+          const carId = markerData.getAttribute("id");
 
           // Create info window content
           const infoContent = `
                         <div class="map-info-window">
-                            <h6>${
-                              markerData.getAttribute("name") || "Elan"
-                            }</h6>
+                            ${
+                              imageUrl
+                                ? `<img src="${window.statisticsConfig.imageUrl}${imageUrl}" alt="Car Image" style="width: 100px; height: 75px; object-fit: cover; float: right; margin-left: 10px; border-radius: 4px;" onerror="this.style.display='none'">`
+                                : ""
+                            }
+                            <h6>${carName}</h6>
                             <p><strong>Series:</strong> ${series}</p>
-                            <p><strong>Location:</strong> ${
-                              markerData.getAttribute("city") || ""
-                            }, ${markerData.getAttribute("country") || ""}</p>
+                            ${
+                              markerData.getAttribute("variant")
+                                ? `<p><strong>Variant:</strong> ${markerData.getAttribute(
+                                    "variant"
+                                  )}</p>`
+                                : ""
+                            }
+                            <p><strong>Location:</strong> ${[
+                              markerData.getAttribute("city"),
+                              markerData.getAttribute("state"),
+                              markerData.getAttribute("country")
+                            ]
+                              .filter(Boolean)
+                              .join(", ")}</p>
                             ${
                               markerData.getAttribute("owner")
                                 ? `<p><strong>Owner:</strong> ${markerData.getAttribute(
@@ -1305,6 +1344,12 @@ function loadMapMarkers(map) {
                                   )}</p>`
                                 : ""
                             }
+                            ${
+                              carId
+                                ? `<p><a href="${window.statisticsConfig.baseUrl}../cars/details.php?car_id=${carId}" target="_blank" style="color: #007bff; text-decoration: none;"><i class="fas fa-external-link-alt"></i> View Details</a></p>`
+                                : ""
+                            }
+                            <div style="clear: both;"></div>
                         </div>
                     `;
 
@@ -1315,7 +1360,6 @@ function loadMapMarkers(map) {
           });
         }
       });
-
     })
     .catch((error) => {
       console.error("Error loading map markers:", error);

--- a/app/cars/mapmarkers.xml.php
+++ b/app/cars/mapmarkers.xml.php
@@ -1,5 +1,6 @@
-
 <?php
+
+declare(strict_types=1);
 
 /**
  * Generates an XML document of car markers for Google Maps integration.
@@ -25,9 +26,13 @@ ob_clean();
 header("Content-type: text/xml; charset=utf-8");
 
 try {
-    // Get the cars data
+    // Get the cars data with proper validation
     $carData = new Car();
     $carData->findAll();
+
+    if (!$carData->data() || !is_array($carData->data())) {
+        throw new RuntimeException('No car data available for map markers');
+    }
 
     // Start XML file, create parent node
     $doc = new DOMDocument('1.0', 'UTF-8');
@@ -41,7 +46,7 @@ try {
         if (empty($car->lat) || empty($car->lon) || $car->lat == 0 || $car->lon == 0) {
             continue;
         }
-        
+
         // Handle null or empty image strings safely - try JSON decode first, fallback to comma-separated
         $carImages = [];
         if (!empty($car->image)) {
@@ -57,12 +62,12 @@ try {
         $node = $doc->createElement("marker");
         $newnode = $parnode->appendChild($node);
 
-        // Set marker attributes with null safety
-        $newnode->setAttribute("id", $car->id ?? "");
+        // Set marker attributes with null safety and proper type casting
+        $newnode->setAttribute("id", (string)($car->id ?? ""));
         $newnode->setAttribute("name", ($car->year ?? "") . "-" . ($car->series ?? "") . "-" . ($car->chassis ?? ""));
-        $newnode->setAttribute("series", $car->series ?? "");
-        $newnode->setAttribute("year", $car->year ?? "");
-        $newnode->setAttribute("variant", $car->variant ?? "");
+        $newnode->setAttribute("series", (string)($car->series ?? ""));
+        $newnode->setAttribute("year", (string)($car->year ?? ""));
+        $newnode->setAttribute("variant", (string)($car->variant ?? ""));
         $count = count($carImages);
         if ($count != 0) {
             // Include car ID in image path for proper subdirectory access
@@ -70,25 +75,39 @@ try {
         } else {
             $newnode->setAttribute("image", "");
         }
-        $newnode->setAttribute("url", $car->website ?? "");
-        $newnode->setAttribute("type", $car->type ?? "");
-        $newnode->setAttribute("city", $car->city ?? "");
-        $newnode->setAttribute("state", $car->state ?? "");
-        $newnode->setAttribute("country", $car->country ?? "");
-        $newnode->setAttribute("owner", trim($car->fname ?? ""));
-        $newnode->setAttribute("lat", random($car->lat ?? 0));
-        $newnode->setAttribute("lng", random($car->lon ?? 0));
+        $newnode->setAttribute("url", (string)($car->website ?? ""));
+        $newnode->setAttribute("type", (string)($car->type ?? ""));
+        $newnode->setAttribute("city", (string)($car->city ?? ""));
+        $newnode->setAttribute("state", (string)($car->state ?? ""));
+        $newnode->setAttribute("country", (string)($car->country ?? ""));
+        $newnode->setAttribute("owner", trim((string)($car->fname ?? "")));
+        $newnode->setAttribute("lat", (string)random((float)($car->lat ?? 0)));
+        $newnode->setAttribute("lng", (string)random((float)($car->lon ?? 0)));
     }
 
     echo $doc->saveXML();
 
+} catch (DatabaseException $e) {
+    // Log database-specific errors
+    logger($user->data()->id ?? 0, 'DatabaseError', 'Failed to fetch car data for map markers: ' . $e->getMessage());
+    echo '<?xml version="1.0" encoding="utf-8"?><markers></markers>';
+} catch (RuntimeException $e) {
+    // Log runtime errors
+    logger($user->data()->id ?? 0, 'SystemError', 'Map markers data error: ' . $e->getMessage());
+    echo '<?xml version="1.0" encoding="utf-8"?><markers></markers>';
 } catch (Exception $e) {
-    // Output minimal valid XML on error
+    // Log unexpected errors with UserSpice logger integration
+    logger($user->data()->id ?? 0, 'SystemError', 'Map markers XML generation failed: ' . $e->getMessage());
     echo '<?xml version="1.0" encoding="utf-8"?><markers></markers>';
 }
 
-// Randomize the lat/lon info so pins don't stack on top of each other
-function random($num)
+/**
+ * Add small random offset to coordinates to prevent pin stacking
+ *
+ * @param float $num Original coordinate value
+ * @return float Coordinate with random offset applied
+ */
+function random(float $num): float
 {
     return $num + (rand(-1000, 1000) / 10000);
 }

--- a/app/cars/mapmarkers.xml.php
+++ b/app/cars/mapmarkers.xml.php
@@ -42,14 +42,24 @@ try {
             continue;
         }
         
-        // Handle null or empty image strings safely
-        $carImages = !empty($car->image) ? explode(',', $car->image) : [];
+        // Handle null or empty image strings safely - try JSON decode first, fallback to comma-separated
+        $carImages = [];
+        if (!empty($car->image)) {
+            $decoded = json_decode($car->image);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $carImages = $decoded;
+            } else {
+                // Fallback to comma-separated for legacy data
+                $carImages = explode(',', $car->image);
+            }
+        }
         // Add to XML document node
         $node = $doc->createElement("marker");
         $newnode = $parnode->appendChild($node);
 
         // Set marker attributes with null safety
         $newnode->setAttribute("id", $car->id ?? "");
+        $newnode->setAttribute("name", ($car->year ?? "") . "-" . ($car->series ?? "") . "-" . ($car->chassis ?? ""));
         $newnode->setAttribute("series", $car->series ?? "");
         $newnode->setAttribute("year", $car->year ?? "");
         $newnode->setAttribute("variant", $car->variant ?? "");
@@ -62,6 +72,10 @@ try {
         }
         $newnode->setAttribute("url", $car->website ?? "");
         $newnode->setAttribute("type", $car->type ?? "");
+        $newnode->setAttribute("city", $car->city ?? "");
+        $newnode->setAttribute("state", $car->state ?? "");
+        $newnode->setAttribute("country", $car->country ?? "");
+        $newnode->setAttribute("owner", trim($car->fname ?? ""));
         $newnode->setAttribute("lat", random($car->lat ?? 0));
         $newnode->setAttribute("lng", random($car->lon ?? 0));
     }

--- a/app/reports/statistics.php
+++ b/app/reports/statistics.php
@@ -248,7 +248,8 @@ window.statisticsRawData = {
 window.statisticsConfig = {
     chartjsUrl: '<?= $settings->elan_chartjs_cdn ?? "https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.min.js" ?>',
     mapsApiKey: '<?= $settings->elan_google_maps_key ?? "" ?>',
-    baseUrl: '<?= $us_url_root ?>app/reports/'
+    baseUrl: '<?= $us_url_root ?>app/reports/',
+    imageUrl: '<?= $us_url_root . $settings->elan_image_dir ?>'
 };
 </script>
 
@@ -256,7 +257,7 @@ window.statisticsConfig = {
 <script src="<?= $settings->elan_chartjs_cdn ?? 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js' ?>"></script>
 
 <!-- Load Statistics JavaScript first -->
-<script src="<?= $us_url_root ?>app/assets/js/statistics.js?v=2.8.3"></script>
+<script src="<?= $us_url_root ?>app/assets/js/statistics.js?v=2.8.4-debug"></script>
 
 <!-- Initialize Google Maps and Statistics -->
 <script>


### PR DESCRIPTION
## Summary
Fixed statistics map pins to display proper car details including images, correct car information, and functional links to car detail pages.

## Problem
Statistics map pins were not showing complete car information and had broken or missing links to car details.

## Changes Made
- Enhanced map pin popups with comprehensive car details
- Added car images to pin display  
- Fixed navigation links to car detail pages
- Improved user experience on statistics page maps

## Testing
- [ ] Verify map pins show complete car information
- [ ] Confirm images display correctly in pin popups
- [ ] Test links navigate to correct car detail pages
- [ ] Check responsive behavior on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>