### PR TITLE
Optimize DataTables CDN configuration by removing unused extensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ To avoid information overload, follow this structured learning path:
   scripts
 - `docs/development/CLASSES.md` - When working with application classes
 - `docs/development/BACKUP_SYSTEM.md` - When using BackupManager class
+- `docs/development/DATATABLES.md` - When working with DataTables or updating
+  CDN configuration
 - `docs/testing/TESTING.md` - When writing or running tests
 - `docs/development/STRICT_TYPE_HANDLING.md` - When working with strict types
 
@@ -99,6 +101,31 @@ functionality.
 - `car_user`/`car_user_hist` - Many-to-many user-car relationships with audit
 - `car_transfer_requests` - Self-service ownership transfer workflow
 - Database triggers automatically maintain audit trails (cars table only)
+
+### DataTables Configuration
+
+> **For complete DataTables documentation, see
+> [DATATABLES.md](docs/development/DATATABLES.md)**
+
+We use DataTables for searchable, sortable, paginated table views of cars and
+factory data. As of v2.11.0, we load **only 3 extensions** for optimal
+performance.
+
+**Quick Reference:**
+
+- **Active Extensions**: DataTables Core (dt-1.10.23), FixedHeader (fh-3.1.8),
+  Responsive (r-2.2.7)
+- **Server-Side Processing**: All tables use AJAX-based server-side data
+  loading
+- **CDN Configuration**: Stored in `settings` table
+  (`elan_datatables_js_cdn`, `elan_datatables_css_cdn`)
+- **Used In**: `/app/cars/index.php` (car listing), `/app/cars/factory.php`
+  (factory data)
+- **Backend**: `/app/action/getDataTables.php` provides server-side data
+
+**Important**: Before adding new DataTables extensions, verify they support
+server-side processing. SearchPanes and SearchBuilder have poor UX with
+server-side tables without significant backend work.
 
 ### 🔧 FIX Script Creation Guidelines
 

--- a/FIX/19-Add-Select-Extension-DataTables-CDN.php
+++ b/FIX/19-Add-Select-Extension-DataTables-CDN.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Optimize DataTables CDN - Remove Unused Extensions
+ *
+ * Administrative script to optimize DataTables CDN URLs by removing unused extensions.
+ * Issue #168: Enhanced search capability investigation
+ *
+ * Analysis revealed we're loading 5 unused DataTables extensions (RowGroup, Scroller,
+ * Select, SearchBuilder, SearchPanes). This script optimizes the CDN to load only
+ * what we actually use: DataTables Core, FixedHeader, and Responsive.
+ *
+ * DEPLOYMENT INSTRUCTIONS:
+ * 1. Copy this file to FIX/ directory with proper naming: 19-Add-Select-Extension-DataTables-CDN.php
+ * 2. Scripts are accessed via FIX/index.php menu or direct URL
+ * 3. Script uses two-step confirmation for safety
+ * 4. All changes logged to UserSpice audit system
+ * 5. Script auto-logs completion to fix_script_runs table
+ */
+
+// UI Constants for progress output
+define('SECTION_SEPARATOR', '═══════════════════════════════════════════════════════');
+define('LOG_CATEGORY_MAINTENANCE', 'DatabaseMaintenance');
+
+require_once '../users/init.php';
+require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
+require_once $abs_us_root . $us_url_root . 'usersc/classes/exceptions/SchemaException.php';
+
+if (!securePage($_SERVER['PHP_SELF'])) {
+    die();
+}
+
+// Set up custom error handler to log through UserSpice logger
+set_error_handler(function($errno, $errstr, $errfile, $errline) use ($user) {
+    if ($errno !== E_DEPRECATED) {
+        logger(isset($user) ? $user->data()->id : 0, LOG_CATEGORY_MAINTENANCE, "Error [$errno]: $errstr in $errfile:$errline");
+    }
+    return true;
+});
+
+$db = DB::getInstance();
+
+// Initialize BackupManager
+$backupManager = new BackupManager($db, $abs_us_root . $us_url_root . 'backup/', (int) $user->data()->id);
+
+?>
+
+<div id="page-wrapper">
+    <div class="container-fluid">
+        <div class="well">
+
+            <?php if (!isset($_GET['start'])): ?>
+            <!-- Initial Description -->
+            <div class="row">
+                <div class="col-lg-12 mb-4">
+                    <div class="card registry-card">
+                        <div class="card-header">
+                            <h2 class="mb-0">
+                                <i class="fa fa-tachometer"></i> Optimize DataTables CDN Configuration
+                            </h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="mb-3">This script optimizes the DataTables CDN URLs by removing unused extensions, reducing page load size and improving performance.</p>
+
+                            <div class="alert alert-info">
+                                <h5><i class="fa fa-info-circle"></i> What this script does:</h5>
+                                <ul class="mb-0">
+                                    <li>Creates a database backup before making changes</li>
+                                    <li>Updates DataTables JavaScript CDN URL to remove unused extensions</li>
+                                    <li>Updates DataTables CSS CDN URL to remove unused extensions</li>
+                                    <li>Reduces bundle size by removing 5 unused extensions</li>
+                                    <li>Logs all changes to the UserSpice audit system</li>
+                                </ul>
+                            </div>
+
+                            <div class="alert alert-success">
+                                <h5><i class="fa fa-check-circle"></i> Performance Benefits:</h5>
+                                <ul class="mb-0">
+                                    <li><strong>Smaller bundle size</strong>: Faster page loads and reduced bandwidth</li>
+                                    <li><strong>Less JavaScript to parse</strong>: Improved browser performance</li>
+                                    <li><strong>Cleaner configuration</strong>: Only load what we actually use</li>
+                                    <li><strong>Easier maintenance</strong>: Simpler extension list to manage</li>
+                                </ul>
+                            </div>
+
+                            <div class="alert alert-warning">
+                                <h5><i class="fa fa-exclamation-triangle"></i> Current vs. Optimized Configuration:</h5>
+
+                                <p><strong>Current Extensions (8 total):</strong></p>
+                                <ul>
+                                    <li>✅ DataTables Core (dt-1.10.23) - <strong>USED</strong></li>
+                                    <li>✅ FixedHeader (fh-3.1.8) - <strong>USED</strong></li>
+                                    <li>✅ Responsive (r-2.2.7) - <strong>USED</strong></li>
+                                    <li>❌ RowGroup (rg-1.1.2) - <strong class="text-danger">UNUSED</strong></li>
+                                    <li>❌ Scroller (sc-2.0.3) - <strong class="text-danger">UNUSED</strong></li>
+                                    <li>❌ Select (sl-1.3.3) - <strong class="text-danger">UNUSED</strong></li>
+                                    <li>❌ SearchBuilder (sb-1.0.1) - <strong class="text-danger">UNUSED</strong></li>
+                                    <li>❌ SearchPanes (sp-1.2.2) - <strong class="text-danger">UNUSED</strong></li>
+                                </ul>
+
+                                <p><strong>Optimized Extensions (3 total):</strong></p>
+                                <ul class="mb-0">
+                                    <li>✅ DataTables Core (dt-1.10.23)</li>
+                                    <li>✅ FixedHeader (fh-3.1.8)</li>
+                                    <li>✅ Responsive (r-2.2.7)</li>
+                                </ul>
+
+                                <p class="mt-3 mb-0"><strong>Removing:</strong> 5 unused extensions (RowGroup, Scroller, Select, SearchBuilder, SearchPanes)</p>
+                            </div>
+
+                            <div class="alert alert-secondary">
+                                <h5><i class="fa fa-info-circle"></i> Impact:</h5>
+                                <ul class="mb-0">
+                                    <li>Changes affect all users immediately</li>
+                                    <li>No visible UX changes - only performance improvements</li>
+                                    <li>Database backup will be created before making changes</li>
+                                    <li>After running, clear browser cache for best results</li>
+                                </ul>
+                            </div>
+
+                            <div class="text-center">
+                                <a href="?start=1" class="btn btn-success btn-lg">
+                                    <i class="fa fa-play"></i> Continue - Optimize CDN URLs
+                                </a>
+                                <a href="index.php" class="btn btn-secondary btn-lg ml-2">
+                                    <i class="fa fa-times"></i> Cancel
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <?php else:
+                // Processing mode - simple text output
+                ob_end_clean(); // Clear template buffering
+                header('Content-Type: text/html; charset=utf-8');
+                echo str_repeat(' ', 1024); // Pad to force initial flush
+                flush();
+            ?>
+
+            <div class="card registry-card">
+                <div class="card-header">
+                    <h2 class="mb-0">
+                        <i class="fa fa-cogs"></i> Optimizing DataTables CDN Configuration
+                    </h2>
+                    <small class="text-muted">
+                        <i class="fa fa-clock-o"></i> Started: <?php echo date('Y-m-d H:i:s'); ?>
+                    </small>
+                </div>
+                <div class="card-body">
+                    <pre style="background: #f5f5f5; padding: 15px; border-radius: 4px; max-height: 600px; overflow-y: auto; font-family: 'Courier New', monospace; font-size: 13px;"><?php
+
+                    /**
+                     * Helper function for progress output
+                     *
+                     * @param string $message Message to display
+                     * @param string $type Type of message: 'info', 'success', 'error', 'warning', 'step'
+                     */
+                    function logProgress($message, $type = 'info') {
+                        $icons = [
+                            'info' => 'ℹ️',
+                            'success' => '✅',
+                            'error' => '❌',
+                            'warning' => '⚠️',
+                            'step' => '▶️'
+                        ];
+                        $icon = $icons[$type] ?? '•';
+                        echo date('[H:i:s] ') . $icon . ' ' . $message . "\n";
+                        flush();
+                    }
+
+                    // Initialize results tracking
+                    $results = [
+                        'processed' => 0,
+                        'errors' => 0,
+                        'warnings' => 0
+                    ];
+
+                    try {
+                        // STEP 1: Create Database Backup
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 1: Creating Database Backup', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $backupPath = $backupManager->createSchemaBackup(
+                            'FIX #19: Optimize DataTables CDN',
+                            ['settings']
+                        );
+                        logProgress('Backup created: ' . basename($backupPath), 'success');
+                        logger($user->data()->id, LOG_CATEGORY_MAINTENANCE, "FIX #19: Backup created at {$backupPath}");
+                        $results['processed']++;
+
+                        // STEP 2: Update JavaScript CDN URL
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 2: Updating DataTables JavaScript CDN URL', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        // Get current JS CDN
+                        $currentJsCdn = htmlspecialchars_decode($settings->elan_datatables_js_cdn);
+                        logProgress('Current JS CDN includes 8 extensions', 'info');
+                        logProgress('Removing: RowGroup, Scroller, Select, SearchBuilder, SearchPanes', 'info');
+
+                        // Optimized JS CDN - only Core, FixedHeader, Responsive
+                        $newJsCdn = '<script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.23/fh-3.1.8/r-2.2.7/datatables.min.js"></script>';
+
+                        $updateJs = $db->update('settings', 1, [
+                            'elan_datatables_js_cdn' => htmlspecialchars($newJsCdn)
+                        ]);
+
+                        if (!$updateJs) {
+                            throw new SchemaException('Failed to update JavaScript CDN URL');
+                        }
+
+                        logProgress('JavaScript CDN URL updated successfully', 'success');
+                        logProgress('Optimized to 3 extensions (was 8)', 'success');
+                        logger($user->data()->id, LOG_CATEGORY_MAINTENANCE, "FIX #19: Optimized DataTables JS CDN - removed 5 unused extensions");
+                        $results['processed']++;
+
+                        // STEP 3: Update CSS CDN URL
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 3: Updating DataTables CSS CDN URL', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        // Get current CSS CDN
+                        $currentCssCdn = htmlspecialchars_decode($settings->elan_datatables_css_cdn);
+                        logProgress('Current CSS CDN includes 8 extensions', 'info');
+                        logProgress('Removing: RowGroup, Scroller, Select, SearchBuilder, SearchPanes', 'info');
+
+                        // Optimized CSS CDN - only Core, FixedHeader, Responsive
+                        $newCssCdn = '<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.23/fh-3.1.8/r-2.2.7/datatables.min.css" />';
+
+                        $updateCss = $db->update('settings', 1, [
+                            'elan_datatables_css_cdn' => htmlspecialchars($newCssCdn)
+                        ]);
+
+                        if (!$updateCss) {
+                            throw new SchemaException('Failed to update CSS CDN URL');
+                        }
+
+                        logProgress('CSS CDN URL updated successfully', 'success');
+                        logProgress('Optimized to 3 extensions (was 8)', 'success');
+                        logger($user->data()->id, LOG_CATEGORY_MAINTENANCE, "FIX #19: Optimized DataTables CSS CDN - removed 5 unused extensions");
+                        $results['processed']++;
+
+                        // Log script completion
+                        $db->insert('fix_script_runs', [
+                            'script_name' => '19-Add-Select-Extension-DataTables-CDN.php',
+                            'completed_at' => date('Y-m-d H:i:s')
+                        ]);
+
+                        logger($user->data()->id, LOG_CATEGORY_MAINTENANCE,
+                            "FIX #19 completed - Settings optimized: {$results['processed']}, Errors: {$results['errors']}");
+
+                        // Display summary
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('CDN OPTIMIZATION COMPLETED SUCCESSFULLY', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress("Settings Updated: {$results['processed']}", 'success');
+                        logProgress("Errors: {$results['errors']}", $results['errors'] > 0 ? 'error' : 'success');
+                        logProgress('', 'info');
+                        logProgress('Optimizations Applied:', 'info');
+                        logProgress('  • Removed RowGroup extension (rg-1.1.2) - unused', 'success');
+                        logProgress('  • Removed Scroller extension (sc-2.0.3) - unused', 'success');
+                        logProgress('  • Removed Select extension (sl-1.3.3) - unused', 'success');
+                        logProgress('  • Removed SearchBuilder extension (sb-1.0.1) - unused', 'success');
+                        logProgress('  • Removed SearchPanes extension (sp-1.2.2) - unused', 'success');
+                        logProgress('', 'info');
+                        logProgress('Post-Processing Steps:', 'info');
+                        logProgress('  • Clear browser cache (Ctrl+Shift+Delete or Cmd+Shift+Delete)', 'info');
+                        logProgress('  • Hard refresh DataTables pages (Ctrl+Shift+R or Cmd+Shift+R)', 'info');
+                        logProgress('  • Verify DataTables loads correctly with no console errors', 'info');
+                        logProgress('  • Notice improved page load performance', 'info');
+                        logProgress('', 'info');
+                        logProgress('Final Extension Configuration:', 'info');
+                        logProgress('  1. DataTables Core (dt-1.10.23)', 'info');
+                        logProgress('  2. FixedHeader (fh-3.1.8)', 'info');
+                        logProgress('  3. Responsive (r-2.2.7)', 'info');
+
+                    } catch (SchemaException $e) {
+                        logProgress('FATAL ERROR: ' . $e->getMessage(), 'error');
+                        logger($user->data()->id, LOG_CATEGORY_MAINTENANCE, 'FIX #19 fatal error: ' . $e->getMessage());
+                        $results['errors']++;
+                    }
+
+                    ?></pre>
+
+                    <div class="text-center mt-3">
+                        <a href="<?= $us_url_root ?>app/cars/index.php" class="btn btn-success btn-lg">
+                            <i class="fa fa-car"></i> Test Car Listing Page
+                        </a>
+                        <a href="index.php" class="btn btn-primary btn-lg ml-2">
+                            <i class="fa fa-arrow-left"></i> Return to FIX Menu
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <?php endif; ?>
+
+        </div>
+    </div>
+</div>
+
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/docs/development/DATATABLES.md
+++ b/docs/development/DATATABLES.md
@@ -1,0 +1,329 @@
+# DataTables Implementation Guide
+
+## Overview
+
+This document provides comprehensive guidance on our DataTables implementation,
+including which extensions we use, where they're used, and how to manage CDN
+configuration.
+
+## What is DataTables?
+
+DataTables is a jQuery plugin that adds advanced interaction controls to HTML
+tables. We use it throughout the Elan Registry for searchable, sortable,
+paginated table views of cars and factory data.
+
+**Official Documentation**: <https://datatables.net>
+
+## Current Configuration
+
+### Active Extensions (v2.11.0+)
+
+As of v2.11.0, we use **only 3 DataTables extensions** for optimal performance:
+
+| Extension           | Version    | Purpose                  | Usage      |
+| ------------------- | ---------- | ------------------------ | ---------- |
+| **DataTables Core** | dt-1.10.23 | Base table functionality | All tables |
+| **FixedHeader**     | fh-3.1.8   | Sticky table headers     | All tables |
+| **Responsive**      | r-2.2.7    | Mobile-responsive tables | All tables |
+
+## Where DataTables is Used
+
+### Car Listing Pages
+
+**File**: `/app/cars/index.php` (List Cars)
+
+**Configuration**:
+
+```javascript
+const table = $("#cartable").DataTable({
+  fixedHeader: true, // Sticky headers
+  responsive: true, // Mobile responsive
+  pageLength: 15, // 15 rows per page
+  scrollX: true, // Horizontal scroll for wide tables
+  processing: true, // Show "Processing..." indicator
+  serverSide: true, // Server-side data loading
+  serverMethod: "post",
+  ajax: {
+    url: "../action/getDataTables.php",
+    dataSrc: "data"
+  }
+});
+```
+
+**Key Features**:
+
+- Server-side processing (loads 15 rows at a time via AJAX)
+- Searchable across 11 columns (year, type, chassis, series, variant, etc.)
+- Sortable by year, type, chassis
+- Image carousel rendering in "Image" column
+- Details button with link to car details page
+
+### Factory Information Page
+
+**File**: `/app/cars/factory.php` (List Factory)
+
+**Configuration**:
+
+```javascript
+const table = $("#cartable").DataTable({
+  fixedHeader: true,
+  responsive: true,
+  pageLength: 25, // 25 rows per page (factory data)
+  scrollX: true,
+  processing: true,
+  serverSide: true,
+  serverMethod: "post",
+  ajax: {
+    url: "../action/getDataTables.php",
+    dataSrc: "data"
+  }
+});
+```
+
+**Key Features**:
+
+- Server-side processing (loads 25 rows at a time)
+- 14 columns (year, month, batch, type, serial, engine, gearbox, color, etc.)
+- AJAX-based registry link lookup (checks if chassis exists in registry)
+- Custom rendering for "Registry Link" column
+
+### Backend Data Provider
+
+**File**: `/app/action/getDataTables.php`
+
+**Purpose**: Server-side data provider for DataTables AJAX requests
+
+**Tables Supported**:
+
+- `cars` - Car registry data
+- `factory` - Factory information data
+- `findCarByChassis` - Lookup car by chassis number (for factory links)
+
+## CDN Configuration
+
+### Current CDN URLs (v2.11.0+)
+
+**JavaScript CDN**:
+
+```html
+<script
+  type="text/javascript"
+  src="https://cdn.datatables.net/v/bs4/dt-1.10.23/fh-3.1.8/r-2.2.7/datatables.min.js"
+></script>
+```
+
+**CSS CDN**:
+
+```html
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="https://cdn.datatables.net/v/bs4/dt-1.10.23/fh-3.1.8/r-2.2.7/datatables.min.css"
+/>
+```
+
+### CDN URL Structure
+
+DataTables CDN URLs follow this pattern:
+
+```text
+https://cdn.datatables.net/v/{styling}/{extensions}/datatables.min.{js|css}
+```
+
+**Components**:
+
+- `{styling}`: Bootstrap version (we use `bs4` for Bootstrap 4)
+- `{extensions}`: Slash-separated list of extensions with versions
+
+**Extension Format**: `{code}-{version}`
+
+| Extension Code | Full Name       | Example      |
+| -------------- | --------------- | ------------ |
+| `dt`           | DataTables Core | `dt-1.10.23` |
+| `fh`           | FixedHeader     | `fh-3.1.8`   |
+| `r`            | Responsive      | `r-2.2.7`    |
+
+### Building CDN URLs
+
+**Example**: To build a CDN URL with DataTables Core, FixedHeader, and
+Responsive:
+
+1. Start with base: `https://cdn.datatables.net/v/bs4/`
+2. Add extensions: `dt-1.10.23/fh-3.1.8/r-2.2.7/`
+3. Add file: `datatables.min.js`
+4. Result:
+   `https://cdn.datatables.net/v/bs4/dt-1.10.23/fh-3.1.8/r-2.2.7/datatables.min.js`
+
+**Official CDN Builder**: <https://datatables.net/download/>
+
+### Updating CDN Configuration
+
+CDN URLs are stored in the `settings` table and can be updated via:
+
+1. **Admin Panel** (Recommended):
+
+   - Navigate to Admin Panel → System Settings
+   - Find "DataTables JavaScript CDN" setting
+   - Update URL and save
+
+2. **FIX Script** (For systematic changes):
+   - Create FIX script following template pattern
+   - Update both `elan_datatables_js_cdn` and `elan_datatables_css_cdn` fields
+   - Use `htmlspecialchars()` when storing URLs
+   - Use `html_entity_decode()` when rendering URLs
+
+**Example FIX Script Code**:
+
+```php
+// Update JavaScript CDN
+$newJsCdn = '<script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.23/fh-3.1.8/r-2.2.7/datatables.min.js"></script>';
+
+$db->update('settings', 1, [
+    'elan_datatables_js_cdn' => htmlspecialchars($newJsCdn)
+]);
+
+// Update CSS CDN
+$newCssCdn = '<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.23/fh-3.1.8/r-2.2.7/datatables.min.css" />';
+
+$db->update('settings', 1, [
+    'elan_datatables_css_cdn' => htmlspecialchars($newCssCdn)
+]);
+```
+
+## Configuration Best Practices
+
+### Extension Selection
+
+**Only include extensions you actually use**:
+
+1. Audit codebase for actual DataTables configuration
+2. Search for extension-specific options (e.g., `fixedHeader: true`,
+   `responsive: true`)
+3. Remove unused extensions from CDN URLs
+4. Test thoroughly after changes
+
+**Analysis Commands**:
+
+```bash
+# Check for FixedHeader usage
+grep -r "fixedHeader:\s*true" app/cars/
+
+# Check for Responsive usage
+grep -r "responsive:\s*true" app/cars/
+
+# Check for unused extensions
+grep -r "rowGroup\|scroller\|searchBuilder\|searchPanes" app/cars/
+```
+
+### Server-Side vs Client-Side Processing
+
+**We use server-side processing** for all tables because:
+
+- Large datasets (1000+ cars in registry)
+- Better performance (only loads visible page of data)
+- Reduced memory usage on client browsers
+
+**Important Limitation**: Some DataTables extensions (SearchPanes, SearchBuilder)
+are **incompatible** with server-side processing without significant backend
+work. They require ALL data to be loaded at once, which defeats the purpose of
+server-side processing.
+
+**Guideline**: Before adding any new DataTables extension, verify it supports
+server-side processing or assess if the UX trade-offs are acceptable.
+
+### Version Management
+
+**Current versions are stable and battle-tested**:
+
+- DataTables Core: 1.10.23
+- FixedHeader: 3.1.8
+- Responsive: 2.2.7
+
+**When to upgrade**:
+
+- Security vulnerabilities discovered
+- Critical bug fixes needed
+- New features required that aren't in current version
+
+**Upgrade process**:
+
+1. Test on development/staging environment first
+2. Review DataTables release notes for breaking changes
+3. Update CDN URLs via FIX script
+4. Clear browser caches (users may need to hard refresh)
+5. Monitor for JavaScript console errors
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue**: Blank page or JavaScript errors after CDN change
+
+**Solution**:
+
+- Check browser console for specific error messages
+- Verify CDN URLs are correctly formatted (no typos)
+- Ensure all extension dependencies are met (e.g., SearchPanes requires Select)
+- Clear browser cache and hard refresh (Ctrl+Shift+R)
+
+**Issue**: "Processing..." indicator never disappears
+
+**Solution**:
+
+- Check `/app/action/getDataTables.php` for PHP errors
+- Verify CSRF token is being passed correctly
+- Check database connection and query performance
+- Review server error logs
+
+**Issue**: Table columns not rendering properly
+
+**Solution**:
+
+- Verify column count in HTML matches JavaScript configuration
+- Check for responsive breakpoints hiding columns on mobile
+- Ensure CSS CDN URL matches JavaScript CDN URL (same extensions)
+
+### Testing After Changes
+
+**Manual Testing Checklist**:
+
+1. Navigate to List Cars page (`/app/cars/index.php`)
+2. Verify table loads without JavaScript errors
+3. Test search functionality (type in search box)
+4. Test sorting (click column headers)
+5. Test pagination (navigate between pages)
+6. Test responsive layout (resize browser window)
+7. Repeat for Factory Information page (`/app/cars/factory.php`)
+
+**Automated Testing**:
+
+```bash
+# Run Playwright UI tests
+npm run playwright:functionality
+npm run playwright:ui
+```
+
+## References
+
+- **Official Documentation**: <https://datatables.net>
+- **CDN Builder**: <https://datatables.net/download/>
+- **Server-Side Processing**: <https://datatables.net/manual/server-side>
+- **Extensions Reference**: <https://datatables.net/extensions/>
+- **GitHub Issue #168**: SearchPanes/SearchBuilder investigation and removal
+  decision
+- **FIX Script #19**: DataTables CDN optimization implementation
+
+## Version History
+
+| Version | Date    | Changes                                              |
+| ------- | ------- | ---------------------------------------------------- |
+| v2.11.0 | TBD     | Removed 5 unused extensions (62.5% reduction)        |
+| v2.8.1  | 2025-01 | Initial documented configuration (8 extensions)      |
+
+## See Also
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) - Overall application architecture
+- [CODING_STANDARDS.md](CODING_STANDARDS.md) - Code quality requirements
+- [RELEASE_NOTES_V2.11.0.md](RELEASE_NOTES_V2.11.0.md) - v2.11.0 release notes
+  including DataTables optimization
+- [FIX_SCRIPTS.md](FIX_SCRIPTS.md) - FIX script creation guidelines

--- a/docs/development/RELEASE_NOTES_V2.11.0.md
+++ b/docs/development/RELEASE_NOTES_V2.11.0.md
@@ -1,0 +1,123 @@
+# Elan Registry v2.11.0 Release Notes
+
+**Release Date:** TBD
+**Type:** Minor Release - User Experience Enhancements
+
+## 🚨 REQUIRED ACTIONS AFTER DEPLOYMENT
+
+### Performance Optimization: Run FIX Script #19
+
+This script optimizes DataTables CDN by removing 5 unused extensions.
+
+1. **Run FIX Script #19** *(via web browser)*
+   - Navigate to: `/FIX/19-Add-Select-Extension-DataTables-CDN.php`
+   - Review the optimization changes (removes RowGroup, Scroller, Select,
+     SearchBuilder, SearchPanes)
+   - Click "Continue - Optimize CDN URLs"
+   - Confirm successful completion:
+     - Script shows "CDN OPTIMIZATION COMPLETED SUCCESSFULLY"
+     - Database backup was created
+     - Settings table updated with optimized CDN URLs
+
+2. **Clear Browser Cache** *(all users)*
+   - Press Ctrl+Shift+Delete (Windows/Linux) or Cmd+Shift+Delete (Mac)
+   - Clear cached images and files
+   - Hard refresh DataTables pages (Ctrl+Shift+R or Cmd+Shift+R)
+
+**Success Criteria:**
+
+- FIX Script #19 completed successfully *(PENDING - requires manual
+  execution)*
+- DataTables pages load correctly with no console errors *(PENDING - verify
+  after FIX script)*
+- Page load performance improved (fewer resources loaded) *(PENDING - verify
+  after cache clear)*
+
+## 👤 User-Facing Changes
+
+No visible changes for end users in this release.
+
+## 🔧 Admin-Facing Changes
+
+### Performance Optimization
+
+- **DataTables CDN Optimized**: Removed 5 unused extensions from DataTables
+  CDN URLs
+  - **What Changed**: Analyzed actual DataTables usage across all pages
+  - **Removed**: RowGroup, Scroller, Select, SearchBuilder, SearchPanes
+    (unused extensions)
+  - **Kept**: DataTables Core, FixedHeader, Responsive (actively used)
+  - **Impact**: 62.5% reduction in loaded extensions (from 8 to 3)
+  - **Benefits**:
+    - Smaller bundle size → faster page loads
+    - Less JavaScript to parse → improved browser performance
+    - Reduced bandwidth usage
+    - Cleaner, more maintainable configuration
+  - **Action Required**: Run FIX Script #19 after deployment
+
+### Optimized Extension Configuration
+
+DataTables now loads only essential extensions:
+
+1. DataTables Core (dt-1.10.23) - Base functionality
+2. FixedHeader (fh-3.1.8) - Sticky table headers
+3. Responsive (r-2.2.7) - Mobile-responsive tables
+
+**Removed (unused):**
+
+- ~~RowGroup (rg-1.1.2)~~ - Row grouping (not used)
+- ~~Scroller (sc-2.0.3)~~ - Virtual scrolling (not used)
+- ~~Select (sl-1.3.3)~~ - Row selection (not used)
+- ~~SearchBuilder (sb-1.0.1)~~ - Query builder (not used, poor UX with
+  server-side)
+- ~~SearchPanes (sp-1.2.2)~~ - Faceted search (not used, poor UX with
+  server-side)
+
+## 📋 Issues Resolved in This Release
+
+[#168](https://github.com/unibrain1/elanregistry/issues/168) - Feature:
+Enhanced search capability for list_cars and list_factory (Closed as Won't Fix
+after prototyping)
+
+---
+
+## 📝 Development Notes
+
+### Issue #168 Investigation Summary
+
+Prototyped both DataTables SearchPanes and SearchBuilder extensions for
+enhanced search functionality. Both approaches were found to have **significant
+UX issues** with our server-side DataTables implementation:
+
+**SearchPanes Issues:**
+
+- Shows empty filter panes because it requires ALL data to build filters
+- Incompatible with server-side processing without major backend refactoring
+- Depends on Select extension (also unused)
+
+**SearchBuilder Issues:**
+
+- Too complex for average users (requires understanding query logic)
+- Not intuitive compared to simple visual filters
+
+**Resolution:**
+
+- Closed issue #168 as "Won't Fix" for current release
+- Created FIX #19 to optimize DataTables CDN by removing ALL unused extensions
+- Analysis revealed we were loading 5 unused extensions (62.5% of loaded
+  extensions)
+- Optimized to load only what we use: Core, FixedHeader, Responsive
+- Existing global search functionality is sufficient for current user needs
+
+**Performance Impact:**
+
+- Before: 8 extensions loaded (5 unused)
+- After: 3 extensions loaded (0 unused)
+- Result: Faster page loads, reduced bandwidth, cleaner configuration
+
+**Alternative Solutions for Future:**
+
+- Custom dropdown filters above tables
+- Column-specific search boxes
+- Dedicated advanced search page
+- Can be revisited if strong user demand emerges


### PR DESCRIPTION
## Summary

After prototyping SearchPanes and SearchBuilder for issue #168, both extensions were found to have **poor UX** with server-side DataTables. Analysis revealed we were loading 8 extensions but only using 3, resulting in unnecessary overhead.

This PR optimizes the DataTables CDN configuration by removing 5 unused extensions, resulting in a **62.5% reduction** in loaded extensions.

## Changes

### FIX Script #19
- Created automated script to update DataTables CDN URLs in the settings table
- Removes unused extensions: RowGroup, Scroller, Select, SearchBuilder, SearchPanes
- Keeps only actively used extensions: Core (dt-1.10.23), FixedHeader (fh-3.1.8), Responsive (r-2.2.7)
- Includes database backup, progress logging, and audit trail

### Documentation
- **Created**: `docs/development/DATATABLES.md` - Comprehensive DataTables implementation guide
  - Current configuration and extension inventory
  - CDN URL structure and building instructions
  - Server-side vs client-side processing considerations
  - Troubleshooting guide and best practices
- **Updated**: `CLAUDE.md` - Added DataTables quick reference section
- **Created**: `docs/development/RELEASE_NOTES_V2.11.0.md` - Release notes for v2.11.0

## Benefits

- **Performance**: Smaller bundle size → faster page loads
- **Efficiency**: Less JavaScript to parse → improved browser performance
- **Cost**: Reduced bandwidth usage
- **Maintainability**: Cleaner, more focused configuration
- **Documentation**: Clear guidance for future DataTables work

## Testing

- [x] FIX script follows template pattern with two-step confirmation
- [x] All files pass PHP coding standards (specific exception types, type casting)
- [x] All markdown files pass linting
- [x] Documentation is comprehensive and accurate

## Deployment Steps

1. **Run FIX Script #19** via web browser at `/FIX/19-Add-Select-Extension-DataTables-CDN.php`
2. Review the optimization changes
3. Click "Continue - Optimize CDN URLs"
4. Clear browser cache (Ctrl+Shift+Delete)
5. Hard refresh DataTables pages (Ctrl+Shift+R)
6. Verify tables load correctly with no console errors

## References

- Closes #168
- Related: GitHub issue #168 investigation and prototyping work
- FIX Script: `/FIX/19-Add-Select-Extension-DataTables-CDN.php`
- Documentation: `/docs/development/DATATABLES.md`
- Release Notes: `/docs/development/RELEASE_NOTES_V2.11.0.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)