### PR TITLE
Add ApiResponse class for standardized AJAX responses (#437)

### DIFF
--- a/tests/unit/api/ApiResponseTest.php
+++ b/tests/unit/api/ApiResponseTest.php
@@ -1,0 +1,814 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ApiResponse class
+ *
+ * Tests all factory methods, builder methods, output methods, and edge cases
+ * for the standardized API response system.
+ *
+ * @group fast
+ * @group unit
+ * @group api
+ */
+final class ApiResponseTest extends TestCase
+{
+    /**
+     * Test success factory method with default message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testSuccessWithDefaultMessage(): void
+    {
+        $response = ApiResponse::success();
+
+        $this->assertTrue($response->isSuccess());
+        $this->assertEquals('Operation successful', $response->getMessage());
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Test success factory method with custom message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testSuccessWithCustomMessage(): void
+    {
+        $response = ApiResponse::success('Profile updated successfully!');
+
+        $this->assertTrue($response->isSuccess());
+        $this->assertEquals('Profile updated successfully!', $response->getMessage());
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Test error factory method with default message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testErrorWithDefaultMessage(): void
+    {
+        $response = ApiResponse::error();
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('An error occurred', $response->getMessage());
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * Test error factory method with custom message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testErrorWithCustomMessage(): void
+    {
+        $response = ApiResponse::error('Invalid request data');
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Invalid request data', $response->getMessage());
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    /**
+     * Test error factory method with custom status code
+     *
+     * @group fast
+     * @return void
+     */
+    public function testErrorWithCustomStatusCode(): void
+    {
+        $response = ApiResponse::error('Rate limit exceeded', 429);
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Rate limit exceeded', $response->getMessage());
+        $this->assertEquals(429, $response->getStatusCode());
+    }
+
+    /**
+     * Test validationError factory method with errors
+     *
+     * @group fast
+     * @return void
+     */
+    public function testValidationError(): void
+    {
+        $errors = [
+            'email' => 'Invalid email format',
+            'name' => 'Required field',
+        ];
+
+        $response = ApiResponse::validationError($errors);
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Validation failed', $response->getMessage());
+        $this->assertEquals(422, $response->getStatusCode());
+        $this->assertEquals($errors, $response->getData()['errors']);
+    }
+
+    /**
+     * Test validationError factory method with custom message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testValidationErrorWithCustomMessage(): void
+    {
+        $errors = ['field' => 'Error'];
+        $response = ApiResponse::validationError($errors, 'Please correct the following errors');
+
+        $this->assertEquals('Please correct the following errors', $response->getMessage());
+        $this->assertEquals(422, $response->getStatusCode());
+    }
+
+    /**
+     * Test unauthorized factory method with default message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testUnauthorizedWithDefaultMessage(): void
+    {
+        $response = ApiResponse::unauthorized();
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Authentication required', $response->getMessage());
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    /**
+     * Test unauthorized factory method with custom message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testUnauthorizedWithCustomMessage(): void
+    {
+        $response = ApiResponse::unauthorized('Session expired');
+
+        $this->assertEquals('Session expired', $response->getMessage());
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    /**
+     * Test forbidden factory method with default message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testForbiddenWithDefaultMessage(): void
+    {
+        $response = ApiResponse::forbidden();
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Access denied', $response->getMessage());
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * Test forbidden factory method with custom message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testForbiddenWithCustomMessage(): void
+    {
+        $response = ApiResponse::forbidden('Admin access required');
+
+        $this->assertEquals('Admin access required', $response->getMessage());
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * Test notFound factory method with default message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testNotFoundWithDefaultMessage(): void
+    {
+        $response = ApiResponse::notFound();
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Resource not found', $response->getMessage());
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    /**
+     * Test notFound factory method with custom message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testNotFoundWithCustomMessage(): void
+    {
+        $response = ApiResponse::notFound('Car not found');
+
+        $this->assertEquals('Car not found', $response->getMessage());
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    /**
+     * Test serverError factory method with default message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testServerErrorWithDefaultMessage(): void
+    {
+        $response = ApiResponse::serverError();
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals('Internal server error', $response->getMessage());
+        $this->assertEquals(500, $response->getStatusCode());
+    }
+
+    /**
+     * Test serverError factory method with custom message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testServerErrorWithCustomMessage(): void
+    {
+        $response = ApiResponse::serverError('Database connection failed');
+
+        $this->assertEquals('Database connection failed', $response->getMessage());
+        $this->assertEquals(500, $response->getStatusCode());
+    }
+
+    /**
+     * Test withData adds data to response
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithDataAddsSingleValue(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('quality_score', 85);
+
+        $data = $response->getData();
+        $this->assertArrayHasKey('quality_score', $data);
+        $this->assertEquals(85, $data['quality_score']);
+    }
+
+    /**
+     * Test withData is immutable
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithDataIsImmutable(): void
+    {
+        $original = ApiResponse::success('Done');
+        $modified = $original->withData('key', 'value');
+
+        $this->assertEmpty($original->getData());
+        $this->assertNotEmpty($modified->getData());
+        $this->assertNotSame($original, $modified);
+    }
+
+    /**
+     * Test withData can be chained multiple times
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithDataChaining(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('score', 85)
+            ->withData('level', 'gold')
+            ->withData('items', ['a', 'b', 'c']);
+
+        $data = $response->getData();
+        $this->assertEquals(85, $data['score']);
+        $this->assertEquals('gold', $data['level']);
+        $this->assertEquals(['a', 'b', 'c'], $data['items']);
+    }
+
+    /**
+     * Test withDataArray adds multiple values at once
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithDataArray(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withDataArray([
+                'quality_score' => 85,
+                'missing_fields' => ['city', 'state'],
+            ]);
+
+        $data = $response->getData();
+        $this->assertEquals(85, $data['quality_score']);
+        $this->assertEquals(['city', 'state'], $data['missing_fields']);
+    }
+
+    /**
+     * Test withDataArray is immutable
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithDataArrayIsImmutable(): void
+    {
+        $original = ApiResponse::success('Done');
+        $modified = $original->withDataArray(['key' => 'value']);
+
+        $this->assertEmpty($original->getData());
+        $this->assertNotEmpty($modified->getData());
+    }
+
+    /**
+     * Test withLogging sets pending log
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithLogging(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withLogging(42, 'OwnerActions', 'Profile updated');
+
+        $log = $response->getPendingLog();
+        $this->assertNotNull($log);
+        $this->assertEquals(42, $log['userId']);
+        $this->assertEquals('OwnerActions', $log['category']);
+        $this->assertEquals('Profile updated', $log['message']);
+    }
+
+    /**
+     * Test withLogging is immutable
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithLoggingIsImmutable(): void
+    {
+        $original = ApiResponse::success('Done');
+        $modified = $original->withLogging(1, 'Test', 'Message');
+
+        $this->assertNull($original->getPendingLog());
+        $this->assertNotNull($modified->getPendingLog());
+    }
+
+    /**
+     * Test withStatusCode overrides status code
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithStatusCode(): void
+    {
+        $response = ApiResponse::error('Custom error')
+            ->withStatusCode(418);
+
+        $this->assertEquals(418, $response->getStatusCode());
+    }
+
+    /**
+     * Test withStatusCode is immutable
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithStatusCodeIsImmutable(): void
+    {
+        $original = ApiResponse::error('Error');
+        $modified = $original->withStatusCode(418);
+
+        $this->assertEquals(400, $original->getStatusCode());
+        $this->assertEquals(418, $modified->getStatusCode());
+    }
+
+    /**
+     * Test toArray returns minimal response for success
+     *
+     * @group fast
+     * @return void
+     */
+    public function testToArrayMinimalSuccess(): void
+    {
+        $response = ApiResponse::success('Done');
+        $array = $response->toArray();
+
+        $this->assertEquals([
+            'success' => true,
+            'message' => 'Done',
+        ], $array);
+    }
+
+    /**
+     * Test toArray returns minimal response for error
+     *
+     * @group fast
+     * @return void
+     */
+    public function testToArrayMinimalError(): void
+    {
+        $response = ApiResponse::error('Failed');
+        $array = $response->toArray();
+
+        $this->assertEquals([
+            'success' => false,
+            'message' => 'Failed',
+        ], $array);
+    }
+
+    /**
+     * Test toArray includes additional data
+     *
+     * @group fast
+     * @return void
+     */
+    public function testToArrayWithData(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('quality_score', 85)
+            ->withData('level', 'gold');
+
+        $array = $response->toArray();
+
+        $this->assertTrue($array['success']);
+        $this->assertEquals('Done', $array['message']);
+        $this->assertEquals(85, $array['quality_score']);
+        $this->assertEquals('gold', $array['level']);
+    }
+
+    /**
+     * Test toArray for validation error includes errors
+     *
+     * @group fast
+     * @return void
+     */
+    public function testToArrayForValidationError(): void
+    {
+        $errors = [
+            'email' => 'Invalid email',
+            'name' => 'Required',
+        ];
+
+        $response = ApiResponse::validationError($errors);
+        $array = $response->toArray();
+
+        $this->assertFalse($array['success']);
+        $this->assertEquals('Validation failed', $array['message']);
+        $this->assertEquals($errors, $array['errors']);
+    }
+
+    /**
+     * Test toJson returns valid JSON string
+     *
+     * @group fast
+     * @return void
+     */
+    public function testToJson(): void
+    {
+        $response = ApiResponse::success('Done');
+        $json = $response->toJson();
+
+        $this->assertJson($json);
+        $decoded = json_decode($json, true);
+        $this->assertEquals(['success' => true, 'message' => 'Done'], $decoded);
+    }
+
+    /**
+     * Test toJson with special characters
+     *
+     * @group fast
+     * @return void
+     */
+    public function testToJsonWithSpecialCharacters(): void
+    {
+        $response = ApiResponse::success('Updated "Lotus Elan" & saved <data>');
+        $json = $response->toJson();
+
+        $this->assertJson($json);
+        $decoded = json_decode($json, true);
+        $this->assertEquals('Updated "Lotus Elan" & saved <data>', $decoded['message']);
+    }
+
+    /**
+     * Test response with empty string message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testEmptyStringMessage(): void
+    {
+        $response = ApiResponse::success('');
+
+        $this->assertEquals('', $response->getMessage());
+        $array = $response->toArray();
+        $this->assertEquals('', $array['message']);
+    }
+
+    /**
+     * Test response with null data value
+     *
+     * @group fast
+     * @return void
+     */
+    public function testNullDataValue(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('nullable_field', null);
+
+        $data = $response->getData();
+        $this->assertArrayHasKey('nullable_field', $data);
+        $this->assertNull($data['nullable_field']);
+    }
+
+    /**
+     * Test response with empty array data
+     *
+     * @group fast
+     * @return void
+     */
+    public function testEmptyArrayData(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('items', []);
+
+        $data = $response->getData();
+        $this->assertEquals([], $data['items']);
+    }
+
+    /**
+     * Test response with nested array data
+     *
+     * @group fast
+     * @return void
+     */
+    public function testNestedArrayData(): void
+    {
+        $nestedData = [
+            'user' => [
+                'id' => 1,
+                'profile' => [
+                    'name' => 'John',
+                    'city' => 'Portland',
+                ],
+            ],
+        ];
+
+        $response = ApiResponse::success('Done')
+            ->withData('nested', $nestedData);
+
+        $data = $response->getData();
+        $this->assertEquals($nestedData, $data['nested']);
+    }
+
+    /**
+     * Test response with numeric data
+     *
+     * @group fast
+     * @return void
+     */
+    public function testNumericData(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('integer', 42)
+            ->withData('float', 3.14159)
+            ->withData('negative', -100);
+
+        $data = $response->getData();
+        $this->assertSame(42, $data['integer']);
+        $this->assertSame(3.14159, $data['float']);
+        $this->assertSame(-100, $data['negative']);
+    }
+
+    /**
+     * Test response with boolean data
+     *
+     * @group fast
+     * @return void
+     */
+    public function testBooleanData(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('active', true)
+            ->withData('deleted', false);
+
+        $data = $response->getData();
+        $this->assertTrue($data['active']);
+        $this->assertFalse($data['deleted']);
+    }
+
+    /**
+     * Test getStatusCode for all factory methods
+     *
+     * @group fast
+     * @return void
+     */
+    public function testStatusCodesForAllFactoryMethods(): void
+    {
+        $this->assertEquals(200, ApiResponse::success()->getStatusCode());
+        $this->assertEquals(400, ApiResponse::error()->getStatusCode());
+        $this->assertEquals(422, ApiResponse::validationError([])->getStatusCode());
+        $this->assertEquals(401, ApiResponse::unauthorized()->getStatusCode());
+        $this->assertEquals(403, ApiResponse::forbidden()->getStatusCode());
+        $this->assertEquals(404, ApiResponse::notFound()->getStatusCode());
+        $this->assertEquals(500, ApiResponse::serverError()->getStatusCode());
+    }
+
+    /**
+     * Test isSuccess for all factory methods
+     *
+     * @group fast
+     * @return void
+     */
+    public function testIsSuccessForAllFactoryMethods(): void
+    {
+        $this->assertTrue(ApiResponse::success()->isSuccess());
+        $this->assertFalse(ApiResponse::error()->isSuccess());
+        $this->assertFalse(ApiResponse::validationError([])->isSuccess());
+        $this->assertFalse(ApiResponse::unauthorized()->isSuccess());
+        $this->assertFalse(ApiResponse::forbidden()->isSuccess());
+        $this->assertFalse(ApiResponse::notFound()->isSuccess());
+        $this->assertFalse(ApiResponse::serverError()->isSuccess());
+    }
+
+    /**
+     * Test full builder chain maintains all values
+     *
+     * @group fast
+     * @return void
+     */
+    public function testFullBuilderChain(): void
+    {
+        $response = ApiResponse::success('Profile updated!')
+            ->withData('quality_score', 85)
+            ->withData('missing_fields', ['city'])
+            ->withLogging(42, 'OwnerActions', 'Profile updated for user 42')
+            ->withStatusCode(201);
+
+        $this->assertTrue($response->isSuccess());
+        $this->assertEquals('Profile updated!', $response->getMessage());
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $data = $response->getData();
+        $this->assertEquals(85, $data['quality_score']);
+        $this->assertEquals(['city'], $data['missing_fields']);
+
+        $log = $response->getPendingLog();
+        $this->assertEquals(42, $log['userId']);
+        $this->assertEquals('OwnerActions', $log['category']);
+    }
+
+    /**
+     * Test validation error with empty errors array
+     *
+     * @group fast
+     * @return void
+     */
+    public function testValidationErrorWithEmptyErrors(): void
+    {
+        $response = ApiResponse::validationError([]);
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals(422, $response->getStatusCode());
+        $this->assertEquals([], $response->getData()['errors']);
+    }
+
+    /**
+     * Test withLogging with zero user ID
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithLoggingZeroUserId(): void
+    {
+        $response = ApiResponse::forbidden('Access denied')
+            ->withLogging(0, 'SecurityError', 'Anonymous access attempt');
+
+        $log = $response->getPendingLog();
+        $this->assertEquals(0, $log['userId']);
+    }
+
+    /**
+     * Test response data does not include internal state
+     *
+     * @group fast
+     * @return void
+     */
+    public function testToArrayDoesNotIncludePendingLog(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withLogging(1, 'Test', 'Message');
+
+        $array = $response->toArray();
+
+        $this->assertArrayNotHasKey('pendingLog', $array);
+        $this->assertArrayNotHasKey('statusCode', $array);
+    }
+
+    /**
+     * Test data can overwrite values with same key
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithDataOverwritesSameKey(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('score', 50)
+            ->withData('score', 100);
+
+        $this->assertEquals(100, $response->getData()['score']);
+    }
+
+    /**
+     * Test getMessage getter
+     *
+     * @group fast
+     * @return void
+     */
+    public function testGetMessage(): void
+    {
+        $response = ApiResponse::success('Test message');
+        $this->assertEquals('Test message', $response->getMessage());
+    }
+
+    /**
+     * Test getData returns empty array when no data set
+     *
+     * @group fast
+     * @return void
+     */
+    public function testGetDataReturnsEmptyArrayByDefault(): void
+    {
+        $response = ApiResponse::success('Done');
+        $this->assertEquals([], $response->getData());
+    }
+
+    /**
+     * Test getPendingLog returns null when no log set
+     *
+     * @group fast
+     * @return void
+     */
+    public function testGetPendingLogReturnsNullByDefault(): void
+    {
+        $response = ApiResponse::success('Done');
+        $this->assertNull($response->getPendingLog());
+    }
+
+    /**
+     * Test response with Unicode characters
+     *
+     * @group fast
+     * @return void
+     */
+    public function testUnicodeCharacters(): void
+    {
+        $response = ApiResponse::success('Mise à jour réussie! 日本語 🚗');
+        $json = $response->toJson();
+
+        $this->assertJson($json);
+        $decoded = json_decode($json, true);
+        $this->assertEquals('Mise à jour réussie! 日本語 🚗', $decoded['message']);
+    }
+
+    /**
+     * Test response with very long message
+     *
+     * @group fast
+     * @return void
+     */
+    public function testVeryLongMessage(): void
+    {
+        $longMessage = str_repeat('A', 10000);
+        $response = ApiResponse::success($longMessage);
+
+        $this->assertEquals($longMessage, $response->getMessage());
+        $this->assertEquals(10000, strlen($response->getMessage()));
+    }
+
+    /**
+     * Test withDataArray merges with existing data
+     *
+     * @group fast
+     * @return void
+     */
+    public function testWithDataArrayMergesWithExisting(): void
+    {
+        $response = ApiResponse::success('Done')
+            ->withData('existing', 'value')
+            ->withDataArray(['new1' => 'a', 'new2' => 'b']);
+
+        $data = $response->getData();
+        $this->assertEquals('value', $data['existing']);
+        $this->assertEquals('a', $data['new1']);
+        $this->assertEquals('b', $data['new2']);
+    }
+}

--- a/usersc/classes/ApiResponse.php
+++ b/usersc/classes/ApiResponse.php
@@ -1,0 +1,374 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ApiResponse - Standardized JSON response class for AJAX endpoints
+ *
+ * Provides a consistent, immutable response format for all API endpoints
+ * with factory methods for common response types and integrated logging.
+ *
+ * Pattern: success/message format only (no backward compatibility for Pattern B)
+ *
+ * Usage examples:
+ * ```php
+ * // Success with data
+ * ApiResponse::success('Profile updated!')
+ *     ->withData('quality_score', 85)
+ *     ->withLogging($userId, 'OwnerActions', 'Profile updated')
+ *     ->send();
+ *
+ * // Validation error with field-keyed errors
+ * ApiResponse::validationError([
+ *     'email' => 'Invalid email format',
+ *     'name' => 'Required field'
+ * ])->send();
+ *
+ * // Permission denied with logging
+ * ApiResponse::forbidden('Admin access required')
+ *     ->withLogging(0, 'SecurityError', 'Unauthorized access attempt')
+ *     ->send();
+ * ```
+ *
+ * @author Jim Boone
+ * @version 1.0.0
+ * @since Issue #437
+ */
+class ApiResponse
+{
+    /**
+     * HTTP Status code constants
+     */
+    private const HTTP_OK = 200;
+    private const HTTP_BAD_REQUEST = 400;
+    private const HTTP_UNAUTHORIZED = 401;
+    private const HTTP_FORBIDDEN = 403;
+    private const HTTP_NOT_FOUND = 404;
+    private const HTTP_UNPROCESSABLE_ENTITY = 422;
+    private const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+    /**
+     * @var bool Success status of the response
+     */
+    private bool $success;
+
+    /**
+     * @var string Response message
+     */
+    private string $message;
+
+    /**
+     * @var int HTTP status code
+     */
+    private int $statusCode;
+
+    /**
+     * @var array<string, mixed> Additional data to include in response
+     */
+    private array $data = [];
+
+    /**
+     * @var array<string, mixed>|null Pending log entry
+     */
+    private ?array $pendingLog = null;
+
+    /**
+     * Private constructor - use factory methods instead
+     *
+     * @param bool   $success    Whether the operation was successful
+     * @param string $message    Human-readable message
+     * @param int    $statusCode HTTP status code
+     */
+    private function __construct(bool $success, string $message, int $statusCode)
+    {
+        $this->success = $success;
+        $this->message = $message;
+        $this->statusCode = $statusCode;
+    }
+
+    /**
+     * Create a success response
+     *
+     * @param string $message Success message (default: 'Operation successful')
+     *
+     * @return self New ApiResponse instance
+     */
+    public static function success(string $message = 'Operation successful'): self
+    {
+        return new self(true, $message, self::HTTP_OK);
+    }
+
+    /**
+     * Create an error response
+     *
+     * @param string $message    Error message (default: 'An error occurred')
+     * @param int    $statusCode HTTP status code (default: 400)
+     *
+     * @return self New ApiResponse instance
+     */
+    public static function error(string $message = 'An error occurred', int $statusCode = self::HTTP_BAD_REQUEST): self
+    {
+        return new self(false, $message, $statusCode);
+    }
+
+    /**
+     * Create a validation error response with field-keyed errors
+     *
+     * @param array<string, string> $errors Field-keyed validation errors
+     * @param string                $message Overall error message
+     *
+     * @return self New ApiResponse instance with errors in data
+     */
+    public static function validationError(array $errors, string $message = 'Validation failed'): self
+    {
+        $response = new self(false, $message, self::HTTP_UNPROCESSABLE_ENTITY);
+        $response->data['errors'] = $errors;
+        return $response;
+    }
+
+    /**
+     * Create an unauthorized (401) response
+     *
+     * @param string $message Error message (default: 'Authentication required')
+     *
+     * @return self New ApiResponse instance
+     */
+    public static function unauthorized(string $message = 'Authentication required'): self
+    {
+        return new self(false, $message, self::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * Create a forbidden (403) response
+     *
+     * @param string $message Error message (default: 'Access denied')
+     *
+     * @return self New ApiResponse instance
+     */
+    public static function forbidden(string $message = 'Access denied'): self
+    {
+        return new self(false, $message, self::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * Create a not found (404) response
+     *
+     * @param string $message Error message (default: 'Resource not found')
+     *
+     * @return self New ApiResponse instance
+     */
+    public static function notFound(string $message = 'Resource not found'): self
+    {
+        return new self(false, $message, self::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Create a server error (500) response
+     *
+     * @param string $message Error message (default: 'Internal server error')
+     *
+     * @return self New ApiResponse instance
+     */
+    public static function serverError(string $message = 'Internal server error'): self
+    {
+        return new self(false, $message, self::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Add data to the response (immutable - returns new instance)
+     *
+     * @param string $key   Data key
+     * @param mixed  $value Data value
+     *
+     * @return self New ApiResponse instance with added data
+     */
+    public function withData(string $key, mixed $value): self
+    {
+        $clone = clone $this;
+        $clone->data[$key] = $value;
+        return $clone;
+    }
+
+    /**
+     * Add multiple data items at once (immutable - returns new instance)
+     *
+     * @param array<string, mixed> $data Key-value pairs to add
+     *
+     * @return self New ApiResponse instance with added data
+     */
+    public function withDataArray(array $data): self
+    {
+        $clone = clone $this;
+        $clone->data = array_merge($clone->data, $data);
+        return $clone;
+    }
+
+    /**
+     * Set a pending log entry to be executed when send() is called
+     *
+     * @param int    $userId   User ID for logging
+     * @param string $category Log category (e.g., 'OwnerActions', 'SecurityError')
+     * @param string $message  Log message
+     *
+     * @return self New ApiResponse instance with pending log
+     */
+    public function withLogging(int $userId, string $category, string $message): self
+    {
+        $clone = clone $this;
+        $clone->pendingLog = [
+            'userId' => $userId,
+            'category' => $category,
+            'message' => $message,
+        ];
+        return $clone;
+    }
+
+    /**
+     * Override the HTTP status code (immutable - returns new instance)
+     *
+     * @param int $statusCode HTTP status code
+     *
+     * @return self New ApiResponse instance with new status code
+     */
+    public function withStatusCode(int $statusCode): self
+    {
+        $clone = clone $this;
+        $clone->statusCode = $statusCode;
+        return $clone;
+    }
+
+    /**
+     * Get the response as an array (useful for testing)
+     *
+     * @return array<string, mixed> Response array with success, message, and any additional data
+     */
+    public function toArray(): array
+    {
+        $response = [
+            'success' => $this->success,
+            'message' => $this->message,
+        ];
+
+        // Merge additional data into response
+        foreach ($this->data as $key => $value) {
+            $response[$key] = $value;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Get the HTTP status code
+     *
+     * @return int HTTP status code
+     */
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * Get the pending log entry (useful for testing)
+     *
+     * @return array<string, mixed>|null Pending log entry or null
+     */
+    public function getPendingLog(): ?array
+    {
+        return $this->pendingLog;
+    }
+
+    /**
+     * Get the success status
+     *
+     * @return bool Success status
+     */
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    /**
+     * Get the message
+     *
+     * @return string Response message
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * Get additional data
+     *
+     * @return array<string, mixed> Additional data
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * Send the response as JSON and exit
+     *
+     * Handles:
+     * - Setting Content-Type header
+     * - Setting HTTP status code
+     * - Output buffering cleanup
+     * - Executing pending log entry
+     * - JSON encoding and output
+     * - Script termination
+     *
+     * Gracefully handles cases where headers are already sent by
+     * logging a warning but still outputting the JSON response.
+     *
+     * @return never This method terminates script execution
+     */
+    public function send(): never
+    {
+        // Execute pending log entry before sending response
+        if ($this->pendingLog !== null && function_exists('logger')) {
+            logger(
+                $this->pendingLog['userId'],
+                $this->pendingLog['category'],
+                $this->pendingLog['message']
+            );
+        }
+
+        // Check if headers have already been sent
+        if (headers_sent($file, $line)) {
+            // Log warning but continue with JSON output
+            if (function_exists('logger')) {
+                logger(
+                    0,
+                    'SystemError',
+                    "ApiResponse: Headers already sent in {$file}:{$line}, cannot set response headers"
+                );
+            }
+        } else {
+            // Clean any existing output buffers
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+
+            // Set response headers
+            http_response_code($this->statusCode);
+            header('Content-Type: application/json; charset=utf-8');
+        }
+
+        // Output JSON and exit
+        echo json_encode($this->toArray(), JSON_THROW_ON_ERROR);
+        exit;
+    }
+
+    /**
+     * Convert response to JSON string
+     *
+     * @return string JSON-encoded response
+     *
+     * @throws \JsonException If JSON encoding fails
+     */
+    public function toJson(): string
+    {
+        return json_encode($this->toArray(), JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements standardized `ApiResponse` class for consistent JSON responses across all AJAX endpoints
- Factory methods for common response types with appropriate HTTP status codes
- Builder pattern for adding data and deferred logging
- Full header management with graceful fallback

## Test plan
- [x] 49 unit tests with 124 assertions - all passing
- [ ] Manual verification of toArray() output matches expected format
- [ ] Integration testing when converting first endpoint

## Files Changed
- `usersc/classes/ApiResponse.php` - Main implementation
- `tests/unit/api/ApiResponseTest.php` - Comprehensive test coverage

## Related Issues
- Closes #437
- Created follow-up issues for endpoint conversion: #450, #451, #452, #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)