### PR TITLE
Fix cars_hist NOT NULL constraint errors in delete() and merge()

### DIFF
--- a/tests/integration/CarDatabaseOperationsTest.php
+++ b/tests/integration/CarDatabaseOperationsTest.php
@@ -133,7 +133,14 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
      */
     public function testCarDeletionRemovesFromDatabase(): void
     {
-        $this->markTestSkipped('Car::delete() has a bug: cars_hist table has NOT NULL columns (model, series, variant, year, type, chassis) that delete() does not provide. This will be fixed during Car.php refactoring. See Issue #248.');
+        $car = new Car($this->testCarId);
+        $result = $car->delete('Integration test deletion');
+
+        $this->assertTrue($result);
+
+        // Verify car no longer exists in database
+        $query = $this->db->query('SELECT * FROM cars WHERE id = ?', [$this->testCarId]);
+        $this->assertEquals(0, $query->count());
     }
 
     /**
@@ -143,7 +150,17 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
      */
     public function testCarDeletionCreatesAuditTrail(): void
     {
-        $this->markTestSkipped('Car::delete() has a bug: cars_hist table has NOT NULL columns (model, series, variant, year, type, chassis) that delete() does not provide. This will be fixed during Car.php refactoring. See Issue #248.');
+        $car = new Car($this->testCarId);
+        $result = $car->delete('Integration test audit trail');
+
+        $this->assertTrue($result);
+
+        // Verify audit trail record exists
+        $historyQuery = $this->db->query(
+            "SELECT * FROM cars_hist WHERE car_id = ? AND operation = 'DELETE'",
+            [$this->testCarId]
+        );
+        $this->assertGreaterThan(0, $historyQuery->count());
     }
 
     /**
@@ -205,7 +222,26 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
      */
     public function testCarMergeTransfersHistoryRecords(): void
     {
-        $this->markTestSkipped('Car::merge() has a bug: cars_hist table has NOT NULL columns (model, series, variant, year, type, chassis) that merge() does not provide. This will be fixed during Car.php refactoring. See Issue #248.');
+        // Create a second test car to merge from
+        $mergeCarId = $this->createTestCar($this->testUserId, [
+            'chassis' => 'DB' . uniqid()
+        ]);
+        $this->db->insert('car_user', [
+            'car_id' => $mergeCarId,
+            'userid' => $this->testUserId
+        ]);
+
+        $car = new Car($this->testCarId);
+        $result = $car->merge($mergeCarId, 'Integration test merge');
+
+        $this->assertTrue($result);
+
+        // Verify merge audit trail exists
+        $historyQuery = $this->db->query(
+            "SELECT * FROM cars_hist WHERE car_id = ? AND operation = 'MERGE'",
+            [$this->testCarId]
+        );
+        $this->assertGreaterThan(0, $historyQuery->count());
     }
 
     /**

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -74,7 +74,10 @@ final class CarMergeTest extends IntegrationTestCase
      */
     public function testMergeCarSuccessWithValidOldCar(): void
     {
-        $this->markTestSkipped('Car::merge() has a bug: cars_hist table has NOT NULL columns (model, series, variant, year, type, chassis) that merge() does not provide. This will be fixed during Car.php refactoring. See Issue #248.');
+        $car = new Car($this->testCarId);
+        $result = $car->merge($this->testMergeCarId, 'Test merge success');
+
+        $this->assertTrue($result);
     }
 
     /**
@@ -123,7 +126,17 @@ final class CarMergeTest extends IntegrationTestCase
      */
     public function testMergeTransfersHistoryRecords(): void
     {
-        $this->markTestSkipped('Car::merge() has a bug: cars_hist table has NOT NULL columns (model, series, variant, year, type, chassis) that merge() does not provide. This will be fixed during Car.php refactoring. See Issue #248.');
+        $car = new Car($this->testCarId);
+        $result = $car->merge($this->testMergeCarId, 'Test merge history transfer');
+
+        $this->assertTrue($result);
+
+        // Verify history records were transferred to surviving car
+        $historyQuery = $this->db->query(
+            "SELECT * FROM cars_hist WHERE car_id = ? AND operation = 'MERGE'",
+            [$this->testCarId]
+        );
+        $this->assertGreaterThan(0, $historyQuery->count());
     }
 
     /**
@@ -133,7 +146,16 @@ final class CarMergeTest extends IntegrationTestCase
      */
     public function testMergeDeletesOldCar(): void
     {
-        $this->markTestSkipped('Car::merge() has a bug: cars_hist table has NOT NULL columns (model, series, variant, year, type, chassis) that merge() does not provide. This will be fixed during Car.php refactoring. See Issue #248.');
+        $oldCarId = $this->testMergeCarId;
+
+        $car = new Car($this->testCarId);
+        $result = $car->merge($oldCarId, 'Test merge deletes old car');
+
+        $this->assertTrue($result);
+
+        // Verify old car no longer exists
+        $query = $this->db->query('SELECT * FROM cars WHERE id = ?', [$oldCarId]);
+        $this->assertEquals(0, $query->count());
     }
 
     /**
@@ -143,7 +165,17 @@ final class CarMergeTest extends IntegrationTestCase
      */
     public function testMergeCreatesAuditTrail(): void
     {
-        $this->markTestSkipped('Car::merge() has a bug: cars_hist table has NOT NULL columns (model, series, variant, year, type, chassis) that merge() does not provide. This will be fixed during Car.php refactoring. See Issue #248.');
+        $car = new Car($this->testCarId);
+        $result = $car->merge($this->testMergeCarId, 'Test merge audit trail');
+
+        $this->assertTrue($result);
+
+        // Verify audit trail record exists with MERGE operation
+        $historyQuery = $this->db->query(
+            "SELECT * FROM cars_hist WHERE car_id = ? AND operation = 'MERGE'",
+            [$this->testCarId]
+        );
+        $this->assertGreaterThan(0, $historyQuery->count());
     }
 
     /**
@@ -175,7 +207,16 @@ final class CarMergeTest extends IntegrationTestCase
      */
     public function testMergeRemovesOldCarRelationships(): void
     {
-        $this->markTestSkipped('Car::merge() has a bug: cars_hist table has NOT NULL columns (model, series, variant, year, type, chassis) that merge() does not provide. This will be fixed during Car.php refactoring. See Issue #248.');
+        $oldCarId = $this->testMergeCarId;
+
+        $car = new Car($this->testCarId);
+        $result = $car->merge($oldCarId, 'Test merge removes relationships');
+
+        $this->assertTrue($result);
+
+        // Verify old car's relationships were removed
+        $query = $this->db->query('SELECT * FROM car_user WHERE car_id = ?', [$oldCarId]);
+        $this->assertEquals(0, $query->count());
     }
 
     /**

--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -505,11 +505,22 @@ class Car
 
             // Create audit trail entry before deletion
             $historyFields = [
+                'operation' => 'DELETE',
                 'car_id' => $carId,
                 'comments' => "Car ID $carId ($chassis) permanently deleted by admin " . $user->data()->id . ". Reason: $reason",
-                'operation' => 'DELETE',
-                'ctime' => date('Y-m-d G:i:s'),
-                'mtime' => date('Y-m-d G:i:s')
+                'ctime' => $this->_data->ctime ?? date('Y-m-d G:i:s'),
+                'mtime' => date('Y-m-d G:i:s'),
+                'model' => $this->_data->model ?? '',
+                'series' => $this->_data->series ?? '',
+                'variant' => $this->_data->variant ?? '',
+                'year' => $this->_data->year ?? '',
+                'type' => $this->_data->type ?? '',
+                'chassis' => $this->_data->chassis ?? '',
+                'color' => $this->_data->color ?? '',
+                'engine' => $this->_data->engine ?? '',
+                'purchasedate' => $this->_data->purchasedate ?? null,
+                'solddate' => $this->_data->solddate ?? null,
+                'image' => $this->_data->image ?? ''
             ];
             
             $historyInserted = $this->_db->insert('cars_hist', $historyFields);
@@ -774,11 +785,22 @@ class Car
 
             // Create audit trail entry for the merge operation
             $historyFields = [
+                'operation' => 'MERGE',
                 'car_id' => $newCarId,
                 'comments' => "Car $oldChassis (ID: $oldCarId) was merged into car $newChassis (ID: $newCarId) by admin " . $user->data()->id . ". Reason: $reason",
-                'operation' => 'MERGE',
-                'ctime' => date('Y-m-d G:i:s'),
-                'mtime' => date('Y-m-d G:i:s')
+                'ctime' => $this->_data->ctime ?? date('Y-m-d G:i:s'),
+                'mtime' => date('Y-m-d G:i:s'),
+                'model' => $this->_data->model ?? '',
+                'series' => $this->_data->series ?? '',
+                'variant' => $this->_data->variant ?? '',
+                'year' => $this->_data->year ?? '',
+                'type' => $this->_data->type ?? '',
+                'chassis' => $this->_data->chassis ?? '',
+                'color' => $this->_data->color ?? '',
+                'engine' => $this->_data->engine ?? '',
+                'purchasedate' => $this->_data->purchasedate ?? null,
+                'solddate' => $this->_data->solddate ?? null,
+                'image' => $this->_data->image ?? ''
             ];
             
             $historyInserted = $this->_db->insert('cars_hist', $historyFields);


### PR DESCRIPTION
## Summary
- Add missing NOT NULL columns (`model`, `series`, `variant`, `year`, `type`, `chassis`, `color`, `engine`, `purchasedate`, `solddate`, `image`) to `cars_hist` inserts in `Car::delete()` and `Car::merge()`, matching the pattern used by `Car::transfer()`
- Unskip and implement 8 integration tests that were blocked by this bug (3 in CarDatabaseOperationsTest, 5 in CarMergeTest)

## Test plan
- [ ] `composer test:quick` — unit tests pass
- [ ] `composer test:medium` — integration tests pass, 8 previously-skipped tests now run
- [ ] Manual test: delete a car via admin and verify cars_hist record is created
- [ ] Manual test: merge two cars via admin and verify cars_hist record is created

Fixes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)