### PR TITLE
Migrate AJAX endpoints to use $method server global (#487)

### DIFF
--- a/app/action/getDataTables.php
+++ b/app/action/getDataTables.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 require_once '../../users/init.php';
 
 // Security: Only process POST requests
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+if ($method !== 'POST') {
     http_response_code(405);
     exit(json_encode(['error' => 'Method not allowed']));
 }

--- a/app/action/location-reverse.php
+++ b/app/action/location-reverse.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 require_once '../../users/init.php';
 
 // Only allow POST requests
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+if ($method !== 'POST') {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 

--- a/app/action/location-search.php
+++ b/app/action/location-search.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 require_once '../../users/init.php';
 
 // Only allow POST requests
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+if ($method !== 'POST') {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 


### PR DESCRIPTION
## Summary
- Replace `$_SERVER['REQUEST_METHOD']` with the validated `$method` server global in 3 AJAX endpoint files: `getDataTables.php`, `location-reverse.php`, `location-search.php`
- Completes migration started in #464, eliminating all direct `$_SERVER['REQUEST_METHOD']` access in `app/action/`

## Test plan
- [x] `composer test:quick` — 614 tests pass
- [x] Pre-commit hooks pass (coding standards, unit tests)
- [x] Grep confirms no remaining `$_SERVER['REQUEST_METHOD']` in `app/action/`
- [ ] Manual: verify DataTables loading, location search, and reverse geocoding work

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)