### PR TITLE
Migrate error pages and app files to server globals (#488)

### DIFF
--- a/app/admin/verify/verify_car.php
+++ b/app/admin/verify/verify_car.php
@@ -2,7 +2,7 @@
 require_once '../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
 
-if (!securePage($_SERVER['PHP_SELF'])) {
+if (!securePage($php_self)) {
     die();
 }
 
@@ -30,7 +30,7 @@ if (Input::exists('get') && Input::get('code') && Input::get('action')) {
     // CSRF Protection: Validate token for state-changing operations
     if (!$token || !Token::check($token)) {
         echo "<h2>Security token validation failed</h2><br>";
-        logger(0, LogCategories::LOG_CATEGORY_SECURITY, "CSRF token validation failed for car verification: " . $_SERVER['REQUEST_URI']);
+        logger(0, LogCategories::LOG_CATEGORY_SECURITY, "CSRF token validation failed for car verification: " . $request_uri);
         header('refresh:5;url=' . $base_url . $us_url_root);
         exit;
     }
@@ -39,7 +39,7 @@ if (Input::exists('get') && Input::get('code') && Input::get('action')) {
     $carQ = $db->query('SELECT * FROM cars WHERE vericode = ?', [$code]);
     if ($db->count() != 1) {
         echo "<h2>Verification code not found or invalid</h2><br>";
-        logger(0, LogCategories::LOG_CATEGORY_SECURITY, "Invalid verification code attempted: " . $code . " from IP: " . $_SERVER['REMOTE_ADDR']);
+        logger(0, LogCategories::LOG_CATEGORY_SECURITY, "Invalid verification code attempted: " . $code . " from IP: " . $remote_addr);
         header('refresh:5;url=' . $base_url . $us_url_root);
         exit;
     }

--- a/app/contact/send-owner-email.php
+++ b/app/contact/send-owner-email.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 require_once '../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
 
-if (!securePage($_SERVER['PHP_SELF'])) {
+if (!securePage($php_self)) {
     die();
 }
 // EDIT THE 2 LINES BELOW AS REQUIRED

--- a/docs/view.php
+++ b/docs/view.php
@@ -23,8 +23,8 @@ use ElanRegistry\Documentation\DocumentConfig;
 use DocumentationException;
 
 // Security check - ensure page access is authorized
-if (!securePage($_SERVER['PHP_SELF'])) {
-    logger(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized documentation access attempt: ' . $_SERVER['PHP_SELF']);
+if (!securePage($php_self)) {
+    logger(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized documentation access attempt: ' . $php_self);
     Redirect::to($us_url_root . '403.php');
 }
 

--- a/error/403.php
+++ b/error/403.php
@@ -32,21 +32,22 @@ try {
     $isLoggedIn = false;
 }
 
+// Ensure server globals are available (may not be if init.php failed)
+if (!isset($request_uri)) {
+    require_once __DIR__ . '/users/classes/Server.php';
+    require_once __DIR__ . '/usersc/includes/server_globals.php';
+}
+
 // Log the 403 error for administrator review
 $userId = ($isLoggedIn && isset($userData->id)) ? (int)$userData->id : 0;
-$requestUri = $_SERVER['REQUEST_URI'] ?? 'unknown';
-$referer = $_SERVER['HTTP_REFERER'] ?? 'direct';
-$ipAddress = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-$method = $_SERVER['REQUEST_METHOD'] ?? 'unknown';
-$userAgent = $_SERVER['HTTP_USER_AGENT'] ?? 'unknown';
 
 $logMessage = sprintf(
     "403 Forbidden | URI: %s | Referer: %s | IP: %s | Method: %s | User-Agent: %s",
-    $requestUri,
-    $referer,
-    $ipAddress,
+    $request_uri,
+    $referer ?: 'direct',
+    $remote_addr,
     $method,
-    substr($userAgent, 0, 150)
+    substr($user_agent, 0, 150)
 );
 
 if (function_exists('logger')) {

--- a/error/404.php
+++ b/error/404.php
@@ -32,21 +32,22 @@ try {
     $isLoggedIn = false;
 }
 
+// Ensure server globals are available (may not be if init.php failed)
+if (!isset($request_uri)) {
+    require_once __DIR__ . '/users/classes/Server.php';
+    require_once __DIR__ . '/usersc/includes/server_globals.php';
+}
+
 // Log the 404 error for administrator review
 $userId = ($isLoggedIn && isset($userData->id)) ? (int)$userData->id : 0;
-$requestUri = $_SERVER['REQUEST_URI'] ?? 'unknown';
-$referer = $_SERVER['HTTP_REFERER'] ?? 'direct';
-$ipAddress = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-$method = $_SERVER['REQUEST_METHOD'] ?? 'unknown';
-$userAgent = $_SERVER['HTTP_USER_AGENT'] ?? 'unknown';
 
 $logMessage = sprintf(
     "404 Not Found | URI: %s | Referer: %s | IP: %s | Method: %s | User-Agent: %s",
-    $requestUri,
-    $referer,
-    $ipAddress,
+    $request_uri,
+    $referer ?: 'direct',
+    $remote_addr,
     $method,
-    substr($userAgent, 0, 150)
+    substr($user_agent, 0, 150)
 );
 
 if (function_exists('logger')) {

--- a/error/500.php
+++ b/error/500.php
@@ -38,13 +38,14 @@ try {
     $isLoggedIn = false;
 }
 
+// Ensure server globals are available (may not be if init.php failed)
+if (!isset($request_uri)) {
+    require_once __DIR__ . '/../users/classes/Server.php';
+    require_once __DIR__ . '/../usersc/includes/server_globals.php';
+}
+
 // Log the error for administrator review
 $userId = ($isLoggedIn && isset($userData->id)) ? (int)$userData->id : 0;
-$requestUri = $_SERVER['REQUEST_URI'] ?? 'unknown';
-$referer = $_SERVER['HTTP_REFERER'] ?? 'direct';
-$ipAddress = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-$method = $_SERVER['REQUEST_METHOD'] ?? 'unknown';
-$userAgent = $_SERVER['HTTP_USER_AGENT'] ?? 'unknown';
 
 // Determine log category based on error code
 $logCategoryMap = [
@@ -62,11 +63,11 @@ $logCategory = $logCategoryMap[$statusCode] ?? 'SystemError';
 $logMessage = sprintf(
     "%d Error | URI: %s | Referer: %s | IP: %s | Method: %s | User-Agent: %s",
     $statusCode,
-    $requestUri,
-    $referer,
-    $ipAddress,
+    $request_uri,
+    $referer ?: 'direct',
+    $remote_addr,
     $method,
-    substr($userAgent, 0, 150)
+    substr($user_agent, 0, 150)
 );
 
 if (function_exists('logger')) {


### PR DESCRIPTION
## Summary
- Replace direct `$_SERVER` access with validated server globals across 6 files
- Error pages (403, 404, 500) include fallback loading of `Server.php` + `server_globals.php` in case `init.php` fails
- App pages (`verify_car.php`, `send-owner-email.php`, `docs/view.php`) use globals already available via `init.php`

## Test plan
- [x] `composer test:quick` — 614 tests pass
- [x] Pre-commit hooks pass (coding standards, unit tests)
- [x] Verified no `$_SERVER` remains in modified files (except `REDIRECT_STATUS` in 500.php which is not a server global)
- [ ] Manual: visit error pages (403, 404, 500) and verify logging works
- [ ] Manual: verify car verification flow and contact owner email

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)