### PR TITLE
Document server globals across developer docs (#490)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,10 +147,58 @@ and migration guide from jQuery.ajax().
 
 ### Server Environment Globals (v2.13.0+)
 
-Validated server globals available: `$scheme`, `$is_https`, `$host`, `$method`,
-`$request_uri`, `$current_url`, `$current_origin`, `$php_self`, `$remote_addr`.
-Use these instead of direct `$_SERVER` access.
-See [PAGE_LOADING_FLOW.md](docs/development/PAGE_LOADING_FLOW.md) for details.
+Use validated server globals instead of direct `$_SERVER` access. These are
+initialized in `usersc/includes/server_globals.php` (Phase 1.11.12) and
+available on every page after `init.php`.
+
+**Available globals:**
+
+| Variable          | Type     | Description                          |
+|-------------------|----------|--------------------------------------|
+| `$scheme`         | `string` | HTTP scheme ('http' or 'https')      |
+| `$is_https`       | `bool`   | Whether request is HTTPS             |
+| `$host`           | `string` | Validated hostname (no port)         |
+| `$method`         | `string` | HTTP method (GET, POST, etc.)        |
+| `$request_uri`    | `string` | Sanitized URI (path + query)         |
+| `$current_url`    | `string` | Full URL (scheme://host/path?query)  |
+| `$current_origin` | `string` | Origin (scheme://host) for CORS      |
+| `$php_self`       | `string` | Script path (for securePage)         |
+| `$remote_addr`    | `string` | Client IP address                    |
+| `$referer`        | `string` | HTTP referer (user-controlled)       |
+| `$user_agent`     | `string` | User agent (sanitized, max 512 chars)|
+
+**Correct usage:**
+
+```php
+// HTTPS detection
+if ($is_https) { /* secure context */ }
+
+// Form method check
+if ($method === 'POST') { /* process form */ }
+
+// Build URLs using origin
+$redirect = $current_origin . '/app/cars/details.php?id=' . $carId;
+
+// Logging with IP
+logger($userId, LogCategories::LOG_CATEGORY_LOGIN, "Login from $remote_addr");
+```
+
+**What NOT to do:**
+
+```php
+// WRONG: Direct $_SERVER access
+$host = $_SERVER['HTTP_HOST'];           // Use $host instead
+$uri  = $_SERVER['REQUEST_URI'];         // Use $request_uri instead
+$ip   = $_SERVER['REMOTE_ADDR'];         // Use $remote_addr instead
+$ssl  = $_SERVER['HTTPS'] === 'on';      // Use $is_https instead
+
+// WRONG: Constructing URLs manually from $_SERVER
+$url = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'];
+// Use $current_origin or $current_url instead
+```
+
+See [PAGE_LOADING_FLOW.md](docs/development/PAGE_LOADING_FLOW.md) for loading
+sequence details.
 
 ### Code Quality
 

--- a/docs/development/PAGE_LOADING_FLOW.md
+++ b/docs/development/PAGE_LOADING_FLOW.md
@@ -1,7 +1,7 @@
 # Page Loading Flow Reference
 
-**Last Updated:** 2026-01-11
-**Version:** 2.11.0
+**Last Updated:** 2026-01-28
+**Version:** 2.13.0
 
 ## Purpose
 
@@ -457,16 +457,55 @@ users/includes/html_footer.php
 After initialization, these global variables are available throughout
 the application:
 
-| Variable       | Type       | Purpose                       | After     |
-|----------------|------------|-------------------------------|-----------|
-| `$db`          | `DB`       | Database singleton instance   | Phase 1.4 |
-| `$user`        | `User`     | Current user object           | Phase 1.6 |
-| `$settings`    | `stdClass` | Site settings from database   | Phase 1.8 |
-| `$abs_us_root` | `string`   | Absolute filesystem root path | Phase 1   |
-| `$us_url_root` | `string`   | Relative URL root path        | Phase 1   |
-| `$lang`        | `array`    | Language strings              | Phase 1.8 |
-| `$usplugins`   | `array`    | Enabled plugins config        | Phase 1.3 |
-| `$config`      | `array`    | Database and system config    | Phase 1.4 |
+| Variable          | Type       | Purpose                               | After          |
+|-------------------|------------|---------------------------------------|----------------|
+| `$db`             | `DB`       | Database singleton instance           | Phase 1.4      |
+| `$user`           | `User`     | Current user object                   | Phase 1.6      |
+| `$settings`       | `stdClass` | Site settings from database           | Phase 1.8      |
+| `$abs_us_root`    | `string`   | Absolute filesystem root path         | Phase 1        |
+| `$us_url_root`    | `string`   | Relative URL root path                | Phase 1        |
+| `$lang`           | `array`    | Language strings                      | Phase 1.8      |
+| `$usplugins`      | `array`    | Enabled plugins config                | Phase 1.3      |
+| `$config`         | `array`    | Database and system config            | Phase 1.4      |
+| `$scheme`         | `string`   | HTTP scheme ('http' or 'https')       | Phase 1.11.12  |
+| `$is_https`       | `bool`     | Whether request is HTTPS              | Phase 1.11.12  |
+| `$host`           | `string`   | Validated hostname (no port)          | Phase 1.11.12  |
+| `$method`         | `string`   | HTTP request method (GET, POST, etc.) | Phase 1.11.12  |
+| `$request_uri`    | `string`   | Sanitized request URI (path + query)  | Phase 1.11.12  |
+| `$current_url`    | `string`   | Full URL (scheme://host/path?query)   | Phase 1.11.12  |
+| `$current_origin` | `string`   | Origin (scheme://host) for CORS       | Phase 1.11.12  |
+| `$php_self`       | `string`   | Current script path (for securePage)  | Phase 1.11.12  |
+| `$remote_addr`    | `string`   | Client IP address                     | Phase 1.11.12  |
+| `$referer`        | `string`   | HTTP referer (user-controlled)        | Phase 1.11.12  |
+| `$user_agent`     | `string`   | User agent string (max 512 chars)     | Phase 1.11.12  |
+
+### Server Globals Usage Examples
+
+Use the validated server globals instead of direct `$_SERVER` access:
+
+```php
+// HTTPS check
+if ($is_https) {
+    // secure context
+}
+
+// Method check for form handling
+if ($method === 'POST') {
+    // process form
+}
+
+// Build redirect URL
+$redirect = $current_origin . '/app/cars/details.php?id=' . $carId;
+
+// Log with IP
+logger($userId, LogCategories::LOG_CATEGORY_LOGIN, "Login from $remote_addr");
+
+// Security check (already done by framework, but available)
+securePage($php_self);
+```
+
+**Do NOT access `$_SERVER` directly.** Use the globals above or `Server::get()`
+for any values not covered by the globals.
 
 ## Common Integration Points
 
@@ -644,11 +683,12 @@ Debug mode shows:
 
 ## Revision History
 
-| Version | Date       | Changes                                    |
-|---------|------------|--------------------------------------------|
-| 1.0.0   | 2026-01-09 | Initial documentation of page loading flow |
+| Version | Date       | Changes                                          |
+|---------|------------|--------------------------------------------------|
+| 1.0.0   | 2026-01-09 | Initial documentation of page loading flow       |
+| 1.1.0   | 2026-01-28 | Add server globals to critical variables table   |
 
 ---
 
 **Note:** This document reflects the loading sequence for UserSpice 5.x and Elan
-Registry v2.10.2. File paths and loading order may vary in different versions.
+Registry v2.13.0. File paths and loading order may vary in different versions.

--- a/docs/development/QUICK_REFERENCE.md
+++ b/docs/development/QUICK_REFERENCE.md
@@ -82,6 +82,12 @@ See [CODING_STANDARDS.md](CODING_STANDARDS.md)
 `logger($userId, LogCategories::LOG_CATEGORY_*, 'message')`
 See [LOG_CATEGORIES.md](LOG_CATEGORIES.md)
 
+**Server Globals (v2.13.0+):**
+Use `$is_https`, `$host`, `$method`, `$current_url`, `$current_origin`,
+`$php_self`, `$remote_addr` instead of `$_SERVER`. For values not covered,
+use `Server::get('KEY', 'default')`.
+See [PAGE_LOADING_FLOW.md](PAGE_LOADING_FLOW.md)
+
 **New PHP Directories:**
 Add path to `$path` array in `/z_us_root.php`, register pages in UserSpice admin
 See [INTEGRATION.md](INTEGRATION.md)
@@ -89,7 +95,7 @@ See [INTEGRATION.md](INTEGRATION.md)
 ## Troubleshooting
 
 | Problem | Solution |
-|---------|----------|
+| --- | --- |
 | `securePage()` redirecting to login | Register page in UserSpice admin; add dir to `z_us_root.php` `$path` array |
 | Database triggers not firing | Only `cars` table has triggers; other tables use app-level logging |
 | Tests failing | Check PHP 8.1+; run `composer install` && `npm install` |


### PR DESCRIPTION
## Summary
- Expanded server globals documentation in CLAUDE.md with full variable table, correct usage examples, and anti-patterns
- Added all 11 server globals to PAGE_LOADING_FLOW.md critical variables table with usage examples section
- Added server globals quick reference entry in QUICK_REFERENCE.md
- Fixed pre-existing markdown table alignment issues in QUICK_REFERENCE.md

## Test plan
- [x] Markdown linting passes (`npx markdownlint-cli2`)
- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm all 11 globals listed consistently across all three files

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)