### PR TITLE
Fix Dropzone 422 validation error display (#533)

### DIFF
--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -59,7 +59,8 @@ if (!empty($_POST)) {
                         ApiResponse::validationError(
                             ['general' => $errors],
                             'Cannot add car: validation errors'
-                        )->withLogging(
+                        )->withData('cardetails', $cardetails)
+                        ->withLogging(
                             $user->data()->id,
                             LogCategories::LOG_CATEGORY_VALIDATION_ERROR,
                             'Car creation validation failed: ' . json_encode($errors)
@@ -111,7 +112,8 @@ if (!empty($_POST)) {
                         ApiResponse::validationError(
                             ['general' => $errors],
                             'Cannot update car: validation errors'
-                        )->withLogging(
+                        )->withData('cardetails', $cardetails)
+                        ->withLogging(
                             $user->data()->id,
                             LogCategories::LOG_CATEGORY_VALIDATION_ERROR,
                             'Car update validation failed: ' . json_encode($errors)

--- a/app/cars/edit.php
+++ b/app/cars/edit.php
@@ -670,6 +670,89 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
             formData.append('comments', $('#comments').val());
         });
 
+        /**
+         * Display validation errors in the results fieldset and repopulate form fields.
+         * Used by both successmultiple (200 with success:false) and error (422) handlers.
+         */
+        function displayValidationErrors(data) {
+            // Advance the page progress indicator
+            $('#message').hide();
+            $('#progressbar li').eq($('fieldset').index(next_fs)).addClass('active');
+
+            //show the next fieldset
+            next_fs.show();
+            //hide the current fieldset with style
+            current_fs.animate({
+                opacity: 0
+            }, {
+                step: function(now) {
+                    // for making fielset appear animation
+                    opacity = 1 - now;
+
+                    current_fs.css({
+                        'display': 'none',
+                        'position': 'relative'
+                    });
+                    next_fs.css({
+                        'opacity': opacity
+                    });
+                },
+                duration: 500
+            });
+            setProgressBar(++current);
+
+            // Build error display table
+            var html = "<table id='resultstable' class='table table-striped table-bordered table-sm text-wrap'>";
+            html += '<tr><td>Status</td><td><strong class="text-danger">ERROR</strong></td></tr>';
+            html += '<tr><td>Message</td><td>' + (data.message || 'An error occurred') + '</td></tr>';
+
+            // Display validation errors if present
+            if (data.errors) {
+                html += '<tr><td>Validation Errors</td><td><ul>';
+                if (Array.isArray(data.errors.general)) {
+                    data.errors.general.forEach(function(error) {
+                        html += '<li>' + error + '</li>';
+                    });
+                } else {
+                    for (var field in data.errors) {
+                        html += '<li><strong>' + field + ':</strong> ' + data.errors[field] + '</li>';
+                    }
+                }
+                html += '</ul></td></tr>';
+            }
+
+            html += '</table>';
+            $("#results").html(html);
+
+            // Repopulate form fields with submitted values to prevent data loss
+            if (data.cardetails) {
+                // Repopulate Year dropdown
+                if (data.cardetails.year) {
+                    $('#year option[value=' + data.cardetails.year + ']').prop('selected', true);
+                    $('#year').trigger('change');
+                }
+
+                // Repopulate Model dropdown
+                if (data.cardetails.model) {
+                    var model = data.cardetails.model.replace(/\|/g, "\\\|")
+                                                     .replace(/ /g, "\\\ ")
+                                                     .replace(/\//g, "\\\/")
+                                                     .replace(/\+/g, "\\\+");
+                    $('#model option[value=' + model + ']').prop('selected', true);
+                    $('#model').trigger('change');
+                }
+
+                // Repopulate other fields as needed
+                if (data.cardetails.chassis) $('#chassis').val(data.cardetails.chassis);
+                if (data.cardetails.color) $('#color').val(data.cardetails.color);
+                if (data.cardetails.engine) $('#engine').val(data.cardetails.engine);
+                if (data.cardetails.comments) $('#comments').val(data.cardetails.comments);
+                if (data.cardetails.website) $('#website').val(data.cardetails.website);
+                if (data.cardetails.purchasedate) $('#purchasedate').val(data.cardetails.purchasedate);
+                if (data.cardetails.solddate) $('#solddate').val(data.cardetails.solddate);
+            }
+        }
+
         myDropzone.on("successmultiple", function(file, message) {
             // Message may already be parsed by Dropzone due to Content-Type header
             const data = (typeof message === 'string') ? JSON.parse(message) : message;
@@ -678,87 +761,22 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
             if (data.success === true) {
                 window.location = '<?= $us_url_root ?>app/cars/details.php?car_id=' + data.cardetails.id;
             } else {
-                // Error case - show validation errors and repopulate form
-                // Advance the page progress indicator
-                $('#message').hide();
-                $('#progressbar li').eq($('fieldset').index(next_fs)).addClass('active');
-
-                //show the next fieldset
-                next_fs.show();
-                //hide the current fieldset with style
-                current_fs.animate({
-                    opacity: 0
-                }, {
-                    step: function(now) {
-                        // for making fielset appear animation
-                        opacity = 1 - now;
-
-                        current_fs.css({
-                            'display': 'none',
-                            'position': 'relative'
-                        });
-                        next_fs.css({
-                            'opacity': opacity
-                        });
-                    },
-                    duration: 500
-                });
-                setProgressBar(++current);
-
-                // Build error display table
-                var html = "<table id='resultstable' class='table table-striped table-bordered table-sm text-wrap'>";
-                html += '<tr><td>Status</td><td><strong class="text-danger">ERROR</strong></td></tr>';
-                html += '<tr><td>Message</td><td>' + (data.message || 'An error occurred') + '</td></tr>';
-
-                // Display validation errors if present
-                if (data.errors) {
-                    html += '<tr><td>Validation Errors</td><td><ul>';
-                    if (Array.isArray(data.errors.general)) {
-                        data.errors.general.forEach(function(error) {
-                            html += '<li>' + error + '</li>';
-                        });
-                    } else {
-                        for (var field in data.errors) {
-                            html += '<li><strong>' + field + ':</strong> ' + data.errors[field] + '</li>';
-                        }
-                    }
-                    html += '</ul></td></tr>';
-                }
-
-                html += '</table>';
-                $("#results").html(html);
-
-                // Repopulate form fields with submitted values to prevent data loss
-                if (data.cardetails) {
-                    // Repopulate Year dropdown
-                    if (data.cardetails.year) {
-                        $('#year option[value=' + data.cardetails.year + ']').prop('selected', true);
-                        $('#year').trigger('change');
-                    }
-
-                    // Repopulate Model dropdown
-                    if (data.cardetails.model) {
-                        var model = data.cardetails.model.replace(/\|/g, "\\\|")
-                                                         .replace(/ /g, "\\\ ")
-                                                         .replace(/\//g, "\\\/")
-                                                         .replace(/\+/g, "\\\+");
-                        $('#model option[value=' + model + ']').prop('selected', true);
-                        $('#model').trigger('change');
-                    }
-
-                    // Repopulate other fields as needed
-                    if (data.cardetails.chassis) $('#chassis').val(data.cardetails.chassis);
-                    if (data.cardetails.color) $('#color').val(data.cardetails.color);
-                    if (data.cardetails.engine) $('#engine').val(data.cardetails.engine);
-                    if (data.cardetails.comments) $('#comments').val(data.cardetails.comments);
-                    if (data.cardetails.website) $('#website').val(data.cardetails.website);
-                    if (data.cardetails.purchasedate) $('#purchasedate').val(data.cardetails.purchasedate);
-                    if (data.cardetails.solddate) $('#solddate').val(data.cardetails.solddate);
-                }
+                displayValidationErrors(data);
             }
         });
 
         myDropzone.on("error", function(data, msg, xhr) {
+            if (xhr && xhr.responseText) {
+                try {
+                    var jsonData = JSON.parse(xhr.responseText);
+                    if (jsonData.success === false) {
+                        displayValidationErrors(jsonData);
+                        return;
+                    }
+                } catch (e) {
+                    // Not JSON, fall through to generic display
+                }
+            }
             $("#message").show().html('<div class="alert alert-primary">' + msg + '</div>');
         });
 

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -194,7 +194,7 @@ final class CarMergeTest extends IntegrationTestCase
             $car->merge(99999, 'Test merge');
         } catch (Exception $e) {
             // After failed merge, original car should still exist
-            $carReloaded = new Car($car->data()->id);
+            $carReloaded = new Car((int) $car->data()->id);
             $this->assertTrue($carReloaded->exists());
             throw $e;
         }

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -175,7 +175,7 @@ final class CarTransferTest extends IntegrationTestCase
         $this->assertTrue($result);
 
         // Verify that car now has target user's profile data
-        $updatedCar = new Car($car->data()->id);
+        $updatedCar = new Car((int) $car->data()->id);
         $this->assertEquals($targetUser->fname ?? '', $updatedCar->data()->fname);
         $this->assertEquals($targetUser->lname ?? '', $updatedCar->data()->lname);
         $this->assertEquals($targetUser->email ?? '', $updatedCar->data()->email);
@@ -198,7 +198,7 @@ final class CarTransferTest extends IntegrationTestCase
             $car->transfer(99999, 'Test transfer', 'NEWOWNER');
         } catch (Exception $e) {
             // After failed transfer, car should still have original owner
-            $carReloaded = new Car($car->data()->id);
+            $carReloaded = new Car((int) $car->data()->id);
             $this->assertEquals($originalUserId, $carReloaded->data()->user_id);
             throw $e;
         }
@@ -267,7 +267,7 @@ final class CarTransferTest extends IntegrationTestCase
 
         // Verify that car now has target user's location data
         $targetUser = getUserWithProfile($this->targetUserId);
-        $updatedCar = new Car($car->data()->id);
+        $updatedCar = new Car((int) $car->data()->id);
 
         $this->assertEquals($targetUser->city ?? '', $updatedCar->data()->city);
         $this->assertEquals($targetUser->state ?? '', $updatedCar->data()->state);

--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -239,7 +239,7 @@ class Car
         ];
         $filteredFields = array_intersect_key($fields, array_flip($validCarFields));
 
-        $carId = $filteredFields['id'];
+        $carId = (int) $filteredFields['id'];
         unset($filteredFields['id']);
 
         $filteredFields = array_filter($filteredFields, function ($value) {
@@ -464,7 +464,7 @@ class Car
         $this->getAdministrationService()->delete(
             $this->_data,
             $reason,
-            $user->data()->id,
+            currentUserId(),
             $this->getRepository()
         );
 
@@ -507,7 +507,7 @@ class Car
             $newUserId,
             $reason,
             $operationType,
-            $user->data()->id,
+            currentUserId(),
             $this->getRepository(),
             function (array $fields) use ($self): bool {
                 return $self->update($fields);
@@ -547,7 +547,7 @@ class Car
             $this->_data,
             $oldCarId,
             $reason,
-            $user->data()->id,
+            currentUserId(),
             $this->getRepository()
         );
 

--- a/usersc/classes/Car/CarAdministrationService.php
+++ b/usersc/classes/Car/CarAdministrationService.php
@@ -48,7 +48,7 @@ class CarAdministrationService
         int $adminUserId,
         CarRepository $repo
     ): bool {
-        $carId = $carData->id;
+        $carId = (int) $carData->id;
         $chassis = $carData->chassis ?? 'Unknown';
 
         try {
@@ -139,7 +139,7 @@ class CarAdministrationService
             throw new CarValidationException(CarErrorMessages::getMessage('user_not_found'));
         }
 
-        $carId = $carData->id;
+        $carId = (int) $carData->id;
 
         try {
             $repo->beginTransaction();
@@ -250,7 +250,7 @@ class CarAdministrationService
         int $adminUserId,
         CarRepository $repo
     ): bool {
-        if ($oldCarId === $targetCarData->id) {
+        if ($oldCarId === (int) $targetCarData->id) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('car_merge_self', ['id' => $oldCarId]);
             logger($adminUserId, LogCategories::LOG_CATEGORY_CAR_MERGE, $technicalMsg);
             throw new CarValidationException(CarErrorMessages::getMessage('car_merge_self'));
@@ -263,7 +263,7 @@ class CarAdministrationService
             throw new CarNotFoundException(CarErrorMessages::getMessage('merge_source_not_found'));
         }
 
-        $newCarId = $targetCarData->id;
+        $newCarId = (int) $targetCarData->id;
         $newChassis = $targetCarData->chassis ?? 'Unknown';
         $oldChassis = $oldCarData->chassis ?? 'Unknown';
 

--- a/usersc/includes/custom_functions.php
+++ b/usersc/includes/custom_functions.php
@@ -122,5 +122,87 @@ function getFeedbackEmail(): string {
 }
 
 
+/**
+ * Extract an integer value from a database result object or scalar
+ *
+ * Handles PDO's inconsistent string/int returns for INTEGER columns
+ * across different PHP versions and configurations.
+ *
+ * @param mixed $value Database result object or scalar value
+ * @param string $property Property name to extract from objects (default: 'id')
+ * @return int The integer value
+ * @throws InvalidArgumentException If the value cannot be converted to int
+ */
+function dbInt(mixed $value, string $property = 'id'): int
+{
+    if (is_object($value)) {
+        if (!isset($value->$property)) {
+            throw new InvalidArgumentException("Property '$property' does not exist on object");
+        }
+        $value = $value->$property;
+    }
+
+    if ($value === null || $value === '') {
+        throw new InvalidArgumentException("Cannot convert empty value to int (property: $property)");
+    }
+
+    if (!is_numeric($value)) {
+        throw new InvalidArgumentException("Cannot convert non-numeric value to int (property: $property): $value");
+    }
+
+    return (int) $value;
+}
+
+/**
+ * Extract a nullable integer value from a database result object or scalar
+ *
+ * Same as dbInt() but returns null for null/empty values instead of throwing.
+ *
+ * @param mixed $value Database result object or scalar value
+ * @param string $property Property name to extract from objects (default: 'id')
+ * @return int|null The integer value, or null if empty/null
+ * @throws InvalidArgumentException If the value is non-null and non-numeric
+ */
+function dbIntOrNull(mixed $value, string $property = 'id'): ?int
+{
+    if (is_object($value)) {
+        if (!isset($value->$property)) {
+            return null;
+        }
+        $value = $value->$property;
+    }
+
+    if ($value === null || $value === '') {
+        return null;
+    }
+
+    if (!is_numeric($value)) {
+        throw new InvalidArgumentException("Cannot convert non-numeric value to int (property: $property): $value");
+    }
+
+    return (int) $value;
+}
+
+/**
+ * Get the current logged-in user's ID as an integer
+ *
+ * Provides a type-safe shorthand for (int) $user->data()->id with
+ * a login check to avoid errors when no user is authenticated.
+ *
+ * @return int The current user's ID
+ * @throws RuntimeException If no user is logged in
+ */
+function currentUserId(): int
+{
+    global $user;
+
+    if (!isset($user) || !$user->isLoggedIn()) {
+        throw new RuntimeException('No user is currently logged in');
+    }
+
+    return (int) $user->data()->id;
+}
+
+
 // We need server globals in custom functions as it's used early in the load process.
 require_once $abs_us_root . $us_url_root . 'usersc/includes/server_globals.php';


### PR DESCRIPTION
## Summary

- Extract `displayValidationErrors()` function in `edit.php` to share error display logic between `successmultiple` and `error` Dropzone handlers
- Parse JSON response body in Dropzone `error` handler to display validation errors from HTTP 422 responses instead of a generic alert
- Add `->withData('cardetails', $cardetails)` to both `validationError` API responses so form fields repopulate on validation failure
- Add `dbInt()`, `dbIntOrNull()`, and `currentUserId()` type-safe helpers to `custom_functions.php` for PDO string-to-int handling
- Replace `(int) $user->data()->id` with `currentUserId()` in `Car.php` delete/transfer/merge methods
- Cast `$carData->id` to `(int)` in `CarAdministrationService` methods
- Fix PDO string-to-int type errors in integration tests for `Car` constructor calls

## Test plan

- [x] All 614 unit tests pass (`composer test:quick`)
- [x] All 18 integration tests pass (`composer test:medium`)
- [x] Pre-commit hooks pass (coding standards, unit tests)
- [ ] Submit car form with invalid data — confirm validation errors display in results fieldset with error table
- [ ] Confirm form fields repopulate with submitted values after validation error
- [ ] Simulate network error — confirm generic alert still displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)