### PR TITLE
Fix toast overlap and unify notification system (#536)

### DIFF
--- a/app/assets/js/api-client.js
+++ b/app/assets/js/api-client.js
@@ -85,55 +85,20 @@ class NotificationHelper {
      * @param {number} duration - Display duration in milliseconds (0 = persistent)
      */
     static show(message, type = 'info', duration = 5000) {
-        // Escape HTML to prevent XSS
-        const escapedMessage = this.escapeHtml(message);
+        // Delegate to UserSpice toast functions for unified notification system
+        const usFunction = {
+            'success': 'usSuccess',
+            'error': 'usError',
+            'warning': 'usInfo',
+            'info': 'usInfo'
+        }[type] || 'usInfo';
 
-        // Create toast container if it doesn't exist
-        let toastContainer = document.getElementById('elan-toast-container');
-        if (!toastContainer) {
-            toastContainer = document.createElement('div');
-            toastContainer.id = 'elan-toast-container';
-            toastContainer.setAttribute('style', `
-                position: fixed;
-                top: 20px;
-                right: 20px;
-                z-index: 9999;
-                max-width: 400px;
-            `);
-            document.body.appendChild(toastContainer);
-        }
-
-        // Determine Bootstrap alert class
-        const alertClass = {
-            'success': 'alert-success',
-            'error': 'alert-danger',
-            'warning': 'alert-warning',
-            'info': 'alert-info'
-        }[type] || 'alert-info';
-
-        // Create toast element
-        const toastDiv = document.createElement('div');
-        toastDiv.setAttribute('role', 'alert');
-        toastDiv.setAttribute('aria-live', 'assertive');
-        toastDiv.setAttribute('aria-atomic', 'true');
-        toastDiv.className = `alert ${alertClass} alert-dismissible fade show`;
-        toastDiv.setAttribute('style', `
-            margin-bottom: 10px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-        `);
-
-        toastDiv.innerHTML = `
-            ${escapedMessage}
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        `;
-
-        toastContainer.appendChild(toastDiv);
-
-        // Auto-hide if duration specified
-        if (duration > 0) {
-            setTimeout(() => {
-                toastDiv.remove();
-            }, duration);
+        if (typeof window[usFunction] === 'function') {
+            window[usFunction](message);
+        } else {
+            // Fallback if UserSpice toast functions not available
+            console.warn('UserSpice toast function not available:', usFunction);
+            console.log(`[${type}] ${message}`);
         }
     }
 

--- a/docs/development/ERROR_HANDLING.md
+++ b/docs/development/ERROR_HANDLING.md
@@ -347,9 +347,15 @@ async function search(query) {
 The NotificationHelper utility displays user feedback consistently across the
 application with XSS protection.
 
+> **Note (v2.14.0+):** `NotificationHelper.show()` now delegates to UserSpice
+> toast functions (`usSuccess()`, `usError()`, `usInfo()`) instead of creating
+> its own container. This ensures a single, consistent toast system with
+> proper z-index and positioning. The `showValidationErrors()` and
+> `escapeHtml()` methods are unchanged.
+
 **Methods**:
 
-- `show(message, type)` - Display general notification
+- `show(message, type)` - Display general notification (delegates to UserSpice toasts)
   - type: 'success', 'error', 'warning', 'info'
 - `showValidationErrors(errors)` - Display field-level validation errors
   - errors: { field_name: 'Error message' }

--- a/docs/development/PAGE_LOADING_FLOW.md
+++ b/docs/development/PAGE_LOADING_FLOW.md
@@ -1,7 +1,7 @@
 # Page Loading Flow Reference
 
-**Last Updated:** 2026-01-28
-**Version:** 2.13.0
+**Last Updated:** 2026-01-31
+**Version:** 2.14.0
 
 ## Purpose
 
@@ -343,16 +343,9 @@ users/includes/template/prep.php
 │       ├─ User menu (login/logout, account)
 │       └─ Mobile responsive menu toggle
 │
-├─ 2.4. usersc/templates/{template}/container_open.php
-│   └─ Main content container:
-│       └─ <div class="container"> or page wrapper divs
-│
-└─ 2.5. System Messages
-    └─ usersc/includes/system_messages_header.php (or users/ fallback)
-        └─ Display error and success messages:
-            ├─ Session-based messages (usError, usSuccess)
-            ├─ Bootstrap alert styling
-            └─ Auto-dismiss after configured time
+└─ 2.4. usersc/templates/{template}/container_open.php
+    └─ Main content container:
+        └─ <div class="container"> or page wrapper divs
 ```
 
 **Template-Specific Files:**
@@ -418,22 +411,48 @@ if (!hasPerm([2], $userId)) {
 
 ### Phase 4: Footer & Cleanup (`users/includes/html_footer.php`)
 
-**Purpose:** Close HTML structure, load footer scripts, execute plugin hooks
+**Purpose:** Close HTML structure, load toast system, footer scripts, plugin hooks
 
 ```text
 users/includes/html_footer.php
 │
 ├─ 4.1. usersc/templates/{template}/footer.php
-│   └─ Footer content:
-│       ├─ Footer HTML (copyright, links, etc.)
-│       ├─ Closing main container divs
-│       ├─ JavaScript includes (footer):
-│       │   ├─ DataTables JS
-│       │   ├─ Chart.js
-│       │   ├─ Google Maps API
-│       │   ├─ Page-specific JavaScript
-│       │   └─ Custom application scripts
-│       └─ </body> and </html> closing tags
+│   │   (e.g., usersc/templates/ElanRegistry/footer.php)
+│   │
+│   ├─ 4.1.1. usersc/templates/{template}/container_close.php
+│   │   └─ Close main content container divs
+│   │
+│   ├─ 4.1.2. users/includes/page_footer.php
+│   │   │   *** Toast notification system loaded here ***
+│   │   │
+│   │   ├─ 4.1.2a. usersc/includes/pre_footer.php (if exists)
+│   │   │   └─ Pre-footer hook (v2.14.0+):
+│   │   │       └─ Includes toast container HTML + CSS:
+│   │   │           └─ usersc/includes/system_messages_header.php
+│   │   │               (or users/ fallback)
+│   │   │               ├─ #us-toast-container div (position-fixed)
+│   │   │               ├─ Toast positioning (default: top-right)
+│   │   │               ├─ z-index: 1090 (Bootstrap 5 toast layer)
+│   │   │               └─ Toast CSS (color bars, close button, layout)
+│   │   │
+│   │   └─ 4.1.2b. usersc/includes/system_messages_footer.php
+│   │       (or users/ fallback)
+│   │       └─ Toast notification JavaScript:
+│   │           ├─ userSpiceMessage() - Core toast creation function
+│   │           ├─ Window globals: usSuccess(), usError(), usInfo(),
+│   │           │   usPrimary(), usDark()
+│   │           ├─ HTML sanitization (allowlisted tags only)
+│   │           ├─ Bootstrap Toast API integration (6s auto-hide)
+│   │           └─ Emit PHP session messages as toasts on page load
+│   │
+│   ├─ 4.1.3. Footer HTML (copyright, version, links)
+│   │
+│   └─ 4.1.4. JavaScript includes (footer):
+│       ├─ DataTables JS
+│       ├─ Chart.js
+│       ├─ Google Maps API
+│       ├─ Page-specific JavaScript
+│       └─ Custom application scripts
 │
 ├─ 4.2. Plugin Footer Hooks (for each enabled plugin)
 │   └─ usersc/plugins/{plugin_name}/footer.php
@@ -442,7 +461,8 @@ users/includes/html_footer.php
 ├─ 4.3. Custom Footer (if exists)
 │   └─ usersc/includes/footer.php
 │       ├─ ElanRegistryAPI client (app/assets/js/api-client.js)
-│       │   └─ Global window.ElanRegistryAPI instance with auto CSRF injection
+│       │   ├─ Global window.ElanRegistryAPI instance with auto CSRF injection
+│       │   └─ NotificationHelper (delegates to usSuccess/usError/usInfo)
 │       └─ Custom footer code, analytics, tracking
 │
 └─ 4.4. UserSpice Footer Scripts
@@ -451,6 +471,26 @@ users/includes/html_footer.php
         ├─ Bootstrap popover initialization
         └─ Bootstrap tooltip initialization
 ```
+
+**Toast System Architecture (v2.14.0+):**
+
+The toast notification system has two components loaded in sequence during
+Phase 4.1.2:
+
+1. **Container (system_messages_header.php)** — outputs the `#us-toast-container`
+   div with positioning CSS. Loaded via `pre_footer.php` hook. Without this,
+   toast JS falls back to `document.body` and toasts render unstyled/unpositioned.
+
+2. **JavaScript (system_messages_footer.php)** — defines `usSuccess()`,
+   `usError()`, etc. Looks for `#us-toast-container`; uses `document.body` as
+   fallback if container is missing.
+
+Both files support UserSpice's custom override pattern: if the file exists in
+`usersc/includes/`, it is used instead of the `users/includes/` version.
+
+**Important:** `NotificationHelper.show()` in `api-client.js` delegates to the
+UserSpice toast functions (`usSuccess`, `usError`, `usInfo`). There is a single
+unified toast system — do not create separate notification containers.
 
 ## Critical Global Variables
 
@@ -687,8 +727,9 @@ Debug mode shows:
 |---------|------------|--------------------------------------------------|
 | 1.0.0   | 2026-01-09 | Initial documentation of page loading flow       |
 | 1.1.0   | 2026-01-28 | Add server globals to critical variables table   |
+| 1.2.0   | 2026-01-31 | Fix Phase 2.5/4 toast system documentation; document pre_footer.php hook, system_messages_header/footer loading sequence, and unified toast architecture (Issue #536) |
 
 ---
 
 **Note:** This document reflects the loading sequence for UserSpice 5.x and Elan
-Registry v2.13.0. File paths and loading order may vary in different versions.
+Registry v2.14.0. File paths and loading order may vary in different versions.

--- a/docs/releases/RELEASE_NOTES_v2.14.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.14.0.md
@@ -16,6 +16,10 @@ None required for changes included so far.
   server-side processing. Changed fields are now highlighted for easier visual
   comparison between history records.
 
+### Bug Fixes
+
+- **Toast Notification Fix** ([#536](https://github.com/unibrain1/elanregistry/issues/536)): Toasts repositioned to top-right with unified styling and proper z-index
+
 ## 🔧 Technical Changes
 
 ### Code Quality
@@ -29,6 +33,7 @@ None required for changes included so far.
 
 - **Class Consolidation** ([#529](https://github.com/unibrain1/elanregistry/issues/529)): Namespaced exception classes, consolidated
   class file locations, and removed duplicates.
+- **Unified Toast System** ([#536](https://github.com/unibrain1/elanregistry/issues/536)): BS4-compatible toast overrides with `pre_footer.php` hook; `NotificationHelper` delegates to UserSpice toasts. Tagged `@todo #234` for BS5 removal.
 
 ## 📋 Milestone Issues
 
@@ -37,6 +42,7 @@ None required for changes included so far.
 - [#322](https://github.com/unibrain1/elanregistry/issues/322) — ENHANCEMENT: Fix car history table date ordering and highlight changed fields
 - [#369](https://github.com/unibrain1/elanregistry/issues/369) — FIX: Add strict types and specific exceptions to edit.php (already resolved)
 - [#529](https://github.com/unibrain1/elanregistry/issues/529) — Consolidate class file locations and remove duplicates
+- [#536](https://github.com/unibrain1/elanregistry/issues/536) — Toast notifications overlap page heading and UI elements
 
 ### Open
 
@@ -50,5 +56,4 @@ None required for changes included so far.
 - [#390](https://github.com/unibrain1/elanregistry/issues/390) — Implement custom reply-to email addresses in SendInBlue plugin
 - [#467](https://github.com/unibrain1/elanregistry/issues/467) — Improve location terminology for international inclusivity
 - [#514](https://github.com/unibrain1/elanregistry/issues/514) — Remove deprecated imagedestroy() call in Resize.php
-- [#536](https://github.com/unibrain1/elanregistry/issues/536) — Toast notifications overlap page heading and UI elements
 - [#543](https://github.com/unibrain1/elanregistry/issues/543) — Create apple-touch-icon assets

--- a/usersc/includes/pre_footer.php
+++ b/usersc/includes/pre_footer.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Pre-footer hook - loaded by users/includes/page_footer.php before
+ * system_messages_footer.php.
+ *
+ * Includes the toast container so UserSpice toast JS can find it.
+ *
+ * @todo Issue #234 (BS5 migration): This file is still needed after BS5
+ *       migration — it wires the toast container into the page. Only the
+ *       system_messages_header.php override can be removed; this hook
+ *       will then load the upstream users/ version instead.
+ */
+
+// Load toast container (must come before system_messages_footer.php JS)
+if (file_exists($abs_us_root . $us_url_root . 'usersc/includes/system_messages_header.php')) {
+    require_once $abs_us_root . $us_url_root . 'usersc/includes/system_messages_header.php';
+} elseif (file_exists($abs_us_root . $us_url_root . 'users/includes/system_messages_header.php')) {
+    require_once $abs_us_root . $us_url_root . 'users/includes/system_messages_header.php';
+}

--- a/usersc/includes/system_messages_footer.php
+++ b/usersc/includes/system_messages_footer.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Custom override of users/includes/system_messages_footer.php
+ *
+ * Changes from upstream:
+ * - Bootstrap 4 compatible (no BS5 CSS variables, no Toast component)
+ * - Hardcoded color values instead of var(--bs-*) references
+ * - Manual show/hide instead of bootstrap.Toast API
+ * - BS4 class names (close, ml-2, mr-2 instead of btn-close, ms-2, me-2)
+ *
+ * Issue #536: Toast notifications overlap page heading
+ *
+ * @todo Issue #234 (BS5 migration): Remove this override. The upstream
+ *       users/includes/system_messages_footer.php uses BS5 features:
+ *       - CSS: var(--bs-success), var(--bs-primary-rgb), etc.
+ *       - JS: bootstrap.Toast API, btn-close class, data-bs-dismiss,
+ *             ms-2/me-2 utility classes
+ *       All of these work natively with Bootstrap 5. After migration:
+ *       1. Delete this file (upstream will be used automatically)
+ *       2. Verify toast colors render (var(--bs-*) CSS variables resolve)
+ *       3. Verify close button works (data-bs-dismiss="toast")
+ *       4. Verify auto-hide works (bootstrap.Toast API available)
+ */
+
+// Collect messages
+$usSessionMessages = function_exists('parseSessionMessages') ? parseSessionMessages() : [];
+
+$usSessionMessageClasses = [
+  'err'    => 'primary',
+  'msg'    => 'info',
+  'genMsg' => 'dark',
+  'valSuc' => 'success',
+  'valErr' => 'danger',
+];
+?>
+<style>
+/* Toast notification bar styles (BS4 compatible - no CSS variables) */
+.us-toast-bar {
+  height: 4px;
+  width: 100%;
+  border-radius: 0.25rem 0.25rem 0 0;
+}
+
+.us-bar-primary {
+  background: linear-gradient(90deg, #007bff, #6610f2);
+}
+
+.us-bar-info {
+  background: linear-gradient(90deg, #17a2b8, #6f42c1);
+}
+
+.us-bar-dark {
+  background: linear-gradient(90deg, #343a40, #6c757d);
+}
+
+.us-bar-success {
+  background: linear-gradient(90deg, #28a745, #20c997);
+}
+
+.us-bar-danger {
+  background: linear-gradient(90deg, #dc3545, #fd7e14);
+}
+
+/* Toast element styles */
+.us-toast {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.25rem;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  margin-bottom: 0.5rem;
+  min-width: 250px;
+  max-width: 400px;
+  overflow: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.us-toast.us-toast-show {
+  opacity: 1;
+}
+
+.us-toast .toast-body {
+  padding: 0.75rem 1rem;
+  color: #495057;
+  font-weight: 500;
+}
+
+.us-toast .us-toast-close {
+  background: transparent;
+  border: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #000;
+  opacity: 0.5;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+.us-toast .us-toast-close:hover {
+  opacity: 1;
+}
+</style>
+<script nonce="<?=htmlspecialchars($userspice_nonce ?? '')?>">
+(function(){
+  var container = document.getElementById('us-toast-container');
+  var justify = container ? (container.getAttribute('data-justify') || 'left') : 'left';
+  var LEFT = justify === 'left';
+
+  // A randomized break token to prevent attackers from forcing breaks.
+  var USERSPICE_BREAK = '---USERSPICE_BREAK-' + Math.random().toString(36).substring(7) + '---';
+  var MAX_MESSAGE_LENGTH = 500;
+
+  function userSpiceMessage(message, bootstrapType) {
+    var wrap = container || document.body;
+
+    var toast = document.createElement('div');
+    toast.className = 'us-toast' + (LEFT ? ' us-toast-left' : '');
+    toast.setAttribute('role', 'alert');
+    toast.setAttribute('aria-live', 'assertive');
+    toast.setAttribute('aria-atomic', 'true');
+
+    var bar = document.createElement('div');
+    bar.className = 'us-toast-bar ' + mapTypeToBar(bootstrapType);
+    toast.appendChild(bar);
+
+    var row = document.createElement('div');
+    row.className = 'd-flex' + (LEFT ? ' flex-row-reverse' : ' flex-row') + ' align-items-start';
+
+    var body = document.createElement('div');
+    body.className = 'toast-body flex-grow-1';
+    buildToastBodyContent(body, String(message == null ? '' : message));
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'us-toast-close';
+    btn.setAttribute('aria-label', 'Close');
+    btn.innerHTML = '&times;';
+    btn.onclick = function() { dismissToast(toast); };
+
+    row.appendChild(body);
+    row.appendChild(btn);
+    toast.appendChild(row);
+    wrap.appendChild(toast);
+
+    // Trigger show after append (allows CSS transition)
+    requestAnimationFrame(function() {
+      toast.classList.add('us-toast-show');
+    });
+
+    // Auto-hide after 6 seconds
+    setTimeout(function() {
+      dismissToast(toast);
+    }, 6000);
+  }
+
+  function dismissToast(toast) {
+    toast.classList.remove('us-toast-show');
+    setTimeout(function() {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 300);
+  }
+
+  function mapTypeToBar(t){
+    switch(t){
+      case 'primary': return 'us-bar-primary';
+      case 'info': return 'us-bar-info';
+      case 'dark': return 'us-bar-dark';
+      case 'success': return 'us-bar-success';
+      case 'danger': return 'us-bar-danger';
+      default: return 'us-bar-info';
+    }
+  }
+
+  /**
+   * Sanitizes HTML using a safe token-replacement approach.
+   */
+  function sanitizeAndFormat(html) {
+    var temp = String(html).substring(0, MAX_MESSAGE_LENGTH);
+
+    var tokens = [];
+    var TOKEN_PREFIX = USERSPICE_BREAK;
+
+    var allowedPatterns = [
+      { regex: /<\s*br\s*\/?>/gi, tag: '<br>' },
+      { regex: /<\s*\/?\s*strong\s*>/gi, restore: true },
+      { regex: /<\s*\/?\s*b\s*>/gi, restore: true },
+      { regex: /<\s*\/?\s*em\s*>/gi, restore: true },
+      { regex: /<\s*\/?\s*i\s*>/gi, restore: true },
+      { regex: /<\s*\/?\s*u\s*>/gi, restore: true },
+      { regex: /<\s*\/?\s*ul\s*>/gi, restore: true },
+      { regex: /<\s*\/?\s*li\s*>/gi, restore: true }
+    ];
+
+    allowedPatterns.forEach(function(pattern) {
+      temp = temp.replace(pattern.regex, function(match) {
+        var tokenIndex = tokens.length;
+        var normalized = pattern.tag || match.toLowerCase().replace(/\s+/g, '');
+        tokens.push(normalized);
+        return TOKEN_PREFIX + tokenIndex + TOKEN_PREFIX;
+      });
+    });
+
+    var doc = new DOMParser().parseFromString(temp, 'text/html');
+    var safeText = doc.body.textContent || "";
+
+    tokens.forEach(function(tag, index) {
+      var escaped = TOKEN_PREFIX.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+      var tokenPattern = new RegExp(escaped + index + escaped, 'g');
+      safeText = safeText.replace(tokenPattern, tag);
+    });
+
+    return safeText;
+  }
+
+  function buildToastBodyContent(bodyElement, message) {
+    var safeText = sanitizeAndFormat(String(message == null ? '' : message));
+    bodyElement.innerHTML = safeText;
+  }
+
+  // Shorthand helpers
+  window.usSuccess = function(msg){ userSpiceMessage(msg,'success'); };
+  window.usError   = function(msg){ userSpiceMessage(msg,'danger'); };
+  window.usInfo    = function(msg){ userSpiceMessage(msg,'info'); };
+  window.usPrimary = function(msg){ userSpiceMessage(msg,'primary'); };
+  window.usDark    = function(msg){ userSpiceMessage(msg,'dark'); };
+
+  // Emit from PHP
+  <?php if (!empty($_GET['err'])): ?>
+    userSpiceMessage(<?php echo json_encode((string)$_GET['err'], JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP); ?>,'<?php echo $usSessionMessageClasses['err']; ?>');
+  <?php endif; ?>
+  <?php if (!empty($_GET['msg'])): ?>
+    userSpiceMessage(<?php echo json_encode((string)$_GET['msg'], JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP); ?>,'<?php echo $usSessionMessageClasses['msg']; ?>');
+  <?php endif; ?>
+  <?php foreach (['genMsg','valSuc','valErr'] as $k): if (!empty($usSessionMessages[$k])): ?>
+    userSpiceMessage(<?php echo json_encode((string)$usSessionMessages[$k], JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP); ?>,'<?php echo $usSessionMessageClasses[$k]; ?>');
+  <?php endif; endforeach; ?>
+})();
+</script>

--- a/usersc/includes/system_messages_header.php
+++ b/usersc/includes/system_messages_header.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Custom override of users/includes/system_messages_header.php
+ *
+ * Changes from upstream:
+ * - Default justify changed from 'left' to 'right' (Issue #536)
+ * - Added z-index: 1090 to ensure toasts render above all content
+ * - Uses inline styles for positioning (Bootstrap 4 compatible)
+ *
+ * Toast CSS (color bars, body styles) is in system_messages_footer.php.
+ * Only positioning/z-index overrides belong here.
+ *
+ * @todo Issue #234 (BS5 migration): Remove this override. The upstream
+ *       users/includes/system_messages_header.php uses BS5 utility classes
+ *       (position-fixed, top-0, end-0) which will work once the template
+ *       loads Bootstrap 5. After migration:
+ *       1. Delete this file
+ *       2. Set $system_messages_justify = 'right' in usersc/includes/loader.php
+ *          (or upstream default if changed to 'right')
+ *       3. Add z-index: 1090 to upstream CSS or via custom stylesheet
+ */
+
+// Set default justify if not already set
+if (!isset($system_messages_justify)) { $system_messages_justify = 'right'; } // left|center|right
+
+$justify = in_array($system_messages_justify, ['left','center','right'], true) ? $system_messages_justify : 'right';
+
+// Map justify to CSS positioning (BS4-compatible inline styles)
+$positionStyle = [
+    'left'   => 'top: 0; left: 0;',
+    'center' => 'top: 0; left: 50%; transform: translateX(-50%);',
+    'right'  => 'top: 0; right: 0;',
+][$justify];
+?>
+
+<style>
+#us-toast-container {
+    position: fixed;
+    <?php echo $positionStyle; ?>
+    z-index: 1090;
+    padding-top: 4.6rem;
+    padding-left: .5rem;
+    padding-right: 1rem;
+    max-width: 90vw;
+}
+</style>
+
+<!-- Toast Container for UserSpice Messages -->
+<div id="us-toast-container"
+     data-justify="<?php echo htmlspecialchars($justify, ENT_QUOTES, 'UTF-8'); ?>">
+</div>


### PR DESCRIPTION
Closes #536

## Summary
- Toast notifications repositioned to top-right with z-index 1090
- Consolidated dual toast systems (UserSpice + NotificationHelper) into single unified system
- BS4-compatible overrides for upstream BS5-dependent toast files (tagged @todo #234)

## Test plan
- [ ] Trigger toast on admin consolidated page — appears top-right, not over heading
- [ ] Trigger toasts on 2-3 other pages (edit car, send email) — consistent positioning
- [ ] Check mobile viewport (375px) — toast doesn't overflow
- [ ] Toast auto-hides after ~6 seconds
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)