### PR TITLE
Fix #546: Cast user ID to int in Car constructor

### DIFF
--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -73,7 +73,7 @@ class Car
         }
 
         if (isset($user) && $user->isLoggedIn()) {
-            $this->_owner = getUserWithProfile($user->data()->id);
+            $this->_owner = getUserWithProfile((int) $user->data()->id);
         }
 
         if ($id && $settings) {

--- a/usersc/includes/custom_functions.php
+++ b/usersc/includes/custom_functions.php
@@ -33,10 +33,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * including location data from the profiles table for car ownership transfers,
  * reassignments, and display purposes.
  *
- * @param int|string $user_id The user ID to fetch
+ * @param int $user_id The user ID to fetch
  * @return object|null User object with profile data, or null if not found
  */
-function getUserWithProfile(int|string $user_id): ?object {
+function getUserWithProfile(int $user_id): ?object {
     $db = DB::getInstance();
 
     $userQ = $db->query(
@@ -44,7 +44,7 @@ function getUserWithProfile(int|string $user_id): ?object {
          FROM users u
          LEFT JOIN profiles p ON u.id = p.user_id
          WHERE u.id = ?",
-        [(int)$user_id]
+        [$user_id]
     );
 
     if ($userQ->count() > 0) {


### PR DESCRIPTION
## Summary
- Cast `$user->data()->id` to `(int)` in `Car.php:76` to fix TypeError under `strict_types`
- Tightened `getUserWithProfile()` signature from `int|string` to `int` and removed redundant internal cast
- Audited all call sites — this was the only one passing an uncast string

## Test plan
- [x] All 650 unit tests pass
- [x] Pre-commit hooks pass
- [ ] Verify `account.php` loads without TypeError

Fixes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)