### PR TITLE
Fix #553: Clean up CSP: remove unused Google Analytics domains and add Gravatar

### DIFF
--- a/usersc/includes/security_headers.php
+++ b/usersc/includes/security_headers.php
@@ -18,10 +18,6 @@ header("Content-Security-Policy: " .
     "script-src 'self' 'unsafe-inline' 'unsafe-eval' " .
         // Google Services
         "https://maps.googleapis.com " .
-        "https://www.google-analytics.com " .
-        "https://analytics.google.com " .
-        "https://www.googletagmanager.com " .
-        "https://region1.google-analytics.com " .
         "https://www.gstatic.com " .
         "https://ssl.gstatic.com " .
         // Google reCAPTCHA
@@ -57,10 +53,7 @@ header("Content-Security-Policy: " .
         // Image sources
         "https://maps.googleapis.com " .
         "https://maps.gstatic.com " .
-        "https://www.google-analytics.com " .
-        "https://analytics.google.com " .
-        "https://www.googletagmanager.com " .
-        "https://region1.google-analytics.com " .
+        "https://www.gravatar.com " .
         "https://ssl.gstatic.com; " .
     "font-src 'self' " .
         // Font sources
@@ -71,11 +64,6 @@ header("Content-Security-Policy: " .
     "connect-src 'self' " .
         // API and AJAX endpoints
         "https://maps.googleapis.com " .
-        "https://www.google-analytics.com " .
-        "https://www.google-analytics.com/* " .
-        "https://analytics.google.com " .
-        "https://www.googletagmanager.com " .
-        "https://region1.google-analytics.com " .
         "https://www.gstatic.com " .
         "https://ssl.gstatic.com " .
         // Google reCAPTCHA API


### PR DESCRIPTION
## Summary

- Remove unused Google Analytics/GTM domains (`google-analytics.com`, `analytics.google.com`, `googletagmanager.com`, `region1.google-analytics.com`) from `script-src`, `img-src`, and `connect-src` CSP directives
- Add `https://www.gravatar.com` to `img-src` to fix CSP violations on pages displaying Gravatar images

## Test plan

- [ ] Verify Gravatar images load on `account.php` without CSP violations
- [ ] Verify no CSP errors in browser console on key pages (home, car details, account)
- [ ] Scan with https://securityheaders.io/ to confirm CSP header is well-formed

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)