### PR TITLE
Fix #377: Configure ImgBot to exclude user content and test artifacts

### DIFF
--- a/.imgbotconfig
+++ b/.imgbotconfig
@@ -1,0 +1,11 @@
+{
+  "schedule": "weekly",
+  "ignoredFiles": [
+    "userimages/**",
+    ".playwright-mcp/**",
+    "test-results/**",
+    "playwright-report/**"
+  ],
+  "aggressiveCompression": false,
+  "compressWiki": false
+}


### PR DESCRIPTION
## Summary
- Adds `.imgbotconfig` to exclude user-uploaded content and test artifact directories from ImgBot optimization
- Sets weekly schedule with standard (non-aggressive) compression

## Test plan
- [ ] Verify ImgBot respects the configuration on next run
- [ ] Trigger ImgBot manually or add an image to `docs/` to confirm only legitimate assets are optimized

🤖 Generated with [Claude Code](https://claude.com/claude-code)