### PR TITLE
Fix ownership queries to use car_user junction table

### DIFF
--- a/tests/integration/CarDataTablesTest.php
+++ b/tests/integration/CarDataTablesTest.php
@@ -26,7 +26,7 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Clean up any test data if needed
+        parent::tearDown();
     }
 
     /**

--- a/tests/integration/CarDeletionTest.php
+++ b/tests/integration/CarDeletionTest.php
@@ -57,7 +57,7 @@ final class CarDeletionTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Clean up any test data if needed
+        parent::tearDown();
     }
 
     /**

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -64,7 +64,7 @@ final class CarMergeTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Clean up any test data if needed
+        parent::tearDown();
     }
 
     /**

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -59,7 +59,7 @@ final class CarTransferTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Clean up any test data if needed
+        parent::tearDown();
     }
 
     /**

--- a/tests/integration/CarVerificationTest.php
+++ b/tests/integration/CarVerificationTest.php
@@ -36,7 +36,7 @@ final class CarVerificationTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Clean up any test data if needed
+        parent::tearDown();
     }
 
     /**

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -36,6 +36,12 @@ abstract class IntegrationTestCase extends TestCase
     protected $db;
     protected $databaseConnected = false;
 
+    /** @var int[] Car IDs created during this test, cleaned up in tearDown */
+    private array $createdCarIds = [];
+
+    /** @var int[] User IDs created during this test, cleaned up in tearDown */
+    private array $createdUserIds = [];
+
     /**
      * Set up test environment
      * Initializes database connection
@@ -43,6 +49,9 @@ abstract class IntegrationTestCase extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->createdCarIds = [];
+        $this->createdUserIds = [];
 
         // Get real DB instance (loaded by bootstrap-integration.php)
         try {
@@ -57,6 +66,36 @@ abstract class IntegrationTestCase extends TestCase
             $this->databaseConnected = false;
             // Don't fail yet - let requireDatabase() handle it
         }
+    }
+
+    /**
+     * Clean up all test-created cars and users
+     */
+    protected function tearDown(): void
+    {
+        if ($this->databaseConnected) {
+            // Delete cars first (depend on users via car_user)
+            foreach ($this->createdCarIds as $carId) {
+                try {
+                    $this->db->query("DELETE FROM car_user WHERE car_id = ?", [$carId]);
+                    $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
+                    $this->db->delete('cars', ['id', '=', $carId]);
+                } catch (RuntimeException $e) {
+                    // Ignore cleanup errors
+                }
+            }
+
+            // Then delete users
+            foreach ($this->createdUserIds as $userId) {
+                try {
+                    $this->db->delete('users', ['id', '=', $userId]);
+                } catch (RuntimeException $e) {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+
+        parent::tearDown();
     }
 
     /**
@@ -104,12 +143,14 @@ abstract class IntegrationTestCase extends TestCase
             throw new RuntimeException("Failed to create test user: {$this->db->errorString()}");
         }
 
-        $userId = $this->db->lastId();
+        $userId = (int) $this->db->lastId();
         if (!$userId) {
             throw new RuntimeException("Failed to get inserted user ID");
         }
 
-        return (int)$userId;
+        $this->createdUserIds[] = $userId;
+
+        return $userId;
     }
 
     /**
@@ -153,12 +194,20 @@ abstract class IntegrationTestCase extends TestCase
             throw new RuntimeException("Failed to create test car: {$this->db->errorString()}");
         }
 
-        $carId = $this->db->lastId();
+        $carId = (int) $this->db->lastId();
         if (!$carId) {
             throw new RuntimeException("Failed to get inserted car ID");
         }
 
-        return (int)$carId;
+        // Insert into car_user junction table
+        $junctionResult = $this->db->insert('car_user', ['userid' => $userId, 'car_id' => $carId]);
+        if (!$junctionResult) {
+            throw new RuntimeException("Failed to create car_user record: {$this->db->errorString()}");
+        }
+
+        $this->createdCarIds[] = $carId;
+
+        return $carId;
     }
 
     /**
@@ -175,6 +224,8 @@ abstract class IntegrationTestCase extends TestCase
 
         try {
             $this->db->delete('users', ['id', '=', $userId]);
+            // Remove from tracking so tearDown doesn't double-delete
+            $this->createdUserIds = array_values(array_diff($this->createdUserIds, [$userId]));
             return true;
         } catch (RuntimeException $e) {
             return false;
@@ -194,7 +245,11 @@ abstract class IntegrationTestCase extends TestCase
         }
 
         try {
+            $this->db->query("DELETE FROM car_user WHERE car_id = ?", [$carId]);
+            $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
             $this->db->delete('cars', ['id', '=', $carId]);
+            // Remove from tracking so tearDown doesn't double-delete
+            $this->createdCarIds = array_values(array_diff($this->createdCarIds, [$carId]));
             return true;
         } catch (RuntimeException $e) {
             return false;

--- a/tests/integration/database/CarDatabaseOperationsTest.php
+++ b/tests/integration/database/CarDatabaseOperationsTest.php
@@ -58,8 +58,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Clean up any test-specific data if needed
-        // Keep main test fixtures intact for other tests
+        parent::tearDown();
     }
 
     /**

--- a/tests/integration/transfer/CarTransferWorkflowTest.php
+++ b/tests/integration/transfer/CarTransferWorkflowTest.php
@@ -42,7 +42,7 @@ class CarTransferWorkflowTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        $this->db = null;
+        parent::tearDown();
     }
 
     // =========================================================================

--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -73,7 +73,14 @@ class Car
         }
 
         if (isset($user) && $user->isLoggedIn()) {
-            $this->_owner = getUserWithProfile((int) $user->data()->id);
+            static $cachedOwner = null;
+            static $cachedOwnerId = null;
+            $currentUserId = (int) $user->data()->id;
+            if ($cachedOwnerId !== $currentUserId) {
+                $cachedOwner = getUserWithProfile($currentUserId);
+                $cachedOwnerId = $currentUserId;
+            }
+            $this->_owner = $cachedOwner;
         }
 
         if ($id && $settings) {

--- a/usersc/classes/Car/CarRepository.php
+++ b/usersc/classes/Car/CarRepository.php
@@ -147,7 +147,7 @@ class CarRepository
      */
     public function findByOwner(int $ownerId): array
     {
-        return $this->db->query("SELECT id FROM cars WHERE user_id = ?", [$ownerId])->results();
+        return $this->db->query("SELECT car_id AS id FROM car_user WHERE userid = ?", [$ownerId])->results();
     }
 
     /**

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -316,7 +316,10 @@ class ElanRegistryOwner
         }
 
         $carsQuery = $this->_db->query(
-            "SELECT * FROM cars WHERE user_id = ? ORDER BY model, year",
+            "SELECT c.* FROM cars c
+             INNER JOIN car_user cu ON c.id = cu.car_id
+             WHERE cu.userid = ?
+             ORDER BY c.model, c.year",
             [$this->_data->id]
         );
 

--- a/usersc/plugins/hooker/hooks/user_form_hook.php
+++ b/usersc/plugins/hooker/hooks/user_form_hook.php
@@ -17,7 +17,7 @@ if ($userQ->count() > 0) {
 	$thatUser = $userQ->results();
 }
 
-$carQ = $db->query("SELECT * FROM cars WHERE user_id = ?", array($user_id));
+$carQ = $db->query("SELECT c.* FROM cars c INNER JOIN car_user cu ON c.id = cu.car_id WHERE cu.userid = ?", array($user_id));
 if ($carQ->count() > 0) {
 	$thatCar = $carQ->results();
 }

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -255,7 +255,7 @@ if (!empty($_POST)) {
             logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, 'Successfully updated lat/lon: ' . json_encode($geoResult));
             
             // BUGFIX #193: Sync location to all cars owned by this user
-            $userCarsQuery = $db->query("SELECT id FROM cars WHERE user_id = ?", [$userId]);
+            $userCarsQuery = $db->query("SELECT car_id AS id FROM car_user WHERE userid = ?", [$userId]);
             if ($userCarsQuery->count() > 0) {
                 $userCars = $userCarsQuery->results();
                 $carFields = [


### PR DESCRIPTION
## Summary
- All ownership lookups (`findByOwner`, `getCarsOwned`, user_settings location sync, `user_form_hook`) now query the `car_user` junction table instead of the denormalized `cars.user_id` column
- Cache `getUserWithProfile()` in `Car` constructor to eliminate N redundant identical queries when instantiating multiple cars
- Integration test `createTestCar()` now inserts into `car_user` junction table, and `tearDown()` automatically cleans up all test-created cars and users

## Test plan
- [x] Unit tests pass (650 tests)
- [x] Integration tests pass (188 tests)
- [ ] Verify account page loads correctly for users with cars
- [ ] Verify user settings location sync updates all owned cars
- [ ] Verify admin user form hook displays correct cars

🤖 Generated with [Claude Code](https://claude.com/claude-code)