### PR TITLE
Fix: Return JSON instead of HTML on CSRF token failures (#582)

### DIFF
--- a/app/action/getDataTables.php
+++ b/app/action/getDataTables.php
@@ -24,9 +24,9 @@ if ($method !== 'POST') {
 if (Input::exists('post')) {
     $token = Input::get('csrf');
     if (!Token::check($token)) {
-        http_response_code(403);
-        include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
-        exit();
+        ApiResponse::forbidden('Invalid CSRF token')
+            ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_SECURITY, 'CSRF token validation failed in DataTables endpoint')
+            ->send();
     }
     
     try {

--- a/app/cars/actions/history.php
+++ b/app/cars/actions/history.php
@@ -10,58 +10,60 @@ require_once '../../../users/init.php';
 if (!empty($_POST)) {
     $token = Input::get('csrf');
     if (!Token::check($token)) {
-        include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
-    } else {
-        $draw = (int)Input::get('draw');
-        $carID = (int)Input::get('car_id');
+        ApiResponse::forbidden('Invalid CSRF token')
+            ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_SECURITY, 'CSRF token validation failed in car history endpoint')
+            ->send();
+    }
 
-        if (empty($carID)) {
-            ApiResponse::error('Car ID not provided', 400)
+    $draw = (int)Input::get('draw');
+    $carID = (int)Input::get('car_id');
+
+    if (empty($carID)) {
+        ApiResponse::error('Car ID not provided', 400)
+            ->withDataArray([
+                'draw' => $draw,
+                'recordsTotal' => 0,
+                'recordsFiltered' => 0,
+                'history' => []
+            ])
+            ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'Car history requested without car ID')
+            ->send();
+    }
+
+    try {
+        $car = new Car($carID);
+        if (!$car->exists()) {
+            ApiResponse::notFound('Car not found')
                 ->withDataArray([
                     'draw' => $draw,
                     'recordsTotal' => 0,
                     'recordsFiltered' => 0,
                     'history' => []
                 ])
-                ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'Car history requested without car ID')
+                ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, "Car history requested for non-existent car ID: $carID")
                 ->send();
         }
 
-        try {
-            $car = new Car($carID);
-            if (!$car->exists()) {
-                ApiResponse::notFound('Car not found')
-                    ->withDataArray([
-                        'draw' => $draw,
-                        'recordsTotal' => 0,
-                        'recordsFiltered' => 0,
-                        'history' => []
-                    ])
-                    ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, "Car history requested for non-existent car ID: $carID")
-                    ->send();
-            }
+        $carHist = $car->history();
+        $count   = count($carHist);
 
-            $carHist = $car->history();
-            $count   = count($carHist);
-
-            ApiResponse::success('Car history retrieved')
-                ->withDataArray([
-                    'draw' => $draw,
-                    'recordsTotal' => $count,
-                    'recordsFiltered' => $count,
-                    'history' => $carHist
-                ])
-                ->send();
-        } catch (ElanRegistryException $e) {
-            ApiResponse::serverError('Failed to load car history')
-                ->withDataArray([
-                    'draw' => $draw,
-                    'recordsTotal' => 0,
-                    'recordsFiltered' => 0,
-                    'history' => []
-                ])
-                ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, "Failed to load car history for car ID $carID: " . $e->getMessage())
-                ->send();
-        }
+        ApiResponse::success('Car history retrieved')
+            ->withDataArray([
+                'draw' => $draw,
+                'recordsTotal' => $count,
+                'recordsFiltered' => $count,
+                'history' => $carHist
+            ])
+            ->send();
+    } catch (ElanRegistryException $e) {
+        ApiResponse::serverError('Failed to load car history')
+            ->withDataArray([
+                'draw' => $draw,
+                'recordsTotal' => 0,
+                'recordsFiltered' => 0,
+                'history' => []
+            ])
+            ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, "Failed to load car history for car ID $carID: " . $e->getMessage())
+            ->send();
     }
 }


### PR DESCRIPTION
## Summary

Fixes issue #582 where two AJAX endpoints returned HTML error pages instead of JSON when CSRF token validation failed. This broke AJAX clients (like DataTables) that expect JSON responses.

**Before:** Endpoints called `include(token_error.php)` which rendered an HTML page with a "go back" link
**After:** Endpoints now return JSON with proper 403 status code

## Changes

### Modified Files
- `app/action/getDataTables.php` - DataTables endpoint CSRF handling
- `app/cars/actions/history.php` - Car history endpoint CSRF handling

### What Changed
Both endpoints now use `ApiResponse::forbidden()` to return:
- Consistent JSON response format: `{success: false, message: "Invalid CSRF token"}`
- Proper HTTP 403 (Forbidden) status code
- Security logging for audit trail (logs user ID and endpoint info)

### Pattern Match
This fix standardizes the error handling to match the established ApiResponse pattern already used in 20+ other endpoints (e.g., location-search.php, check-chassis.php).

## Verification

✅ All checks passed:
- PHP coding standards validation
- 652 unit tests passed
- PHPStan static analysis
- No PHP syntax errors
- Pre-commit hooks validation

## Testing

**Manual testing required:**
1. Load `/app/cars/index.php` (car listing)
2. Open browser dev tools → Network tab
3. Modify CSRF token before triggering DataTables request
4. Verify response is JSON with 403 status (not HTML)
5. Repeat for car history endpoint

**Regression testing:**
- Verify DataTables loads normally with valid CSRF token
- Verify car history tab loads normally with valid CSRF token

## Related Issues
- Closes #582
- Related to #585 (standardize CSRF status codes)
- Related to #586 (create CSRF validation utility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)