### PR TITLE
Issue #603: Remove internal error details from admin API responses

### DIFF
--- a/app/admin/includes/system/backup-operations.php
+++ b/app/admin/includes/system/backup-operations.php
@@ -34,8 +34,8 @@ if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
         ->send();
 }
 
-// Get action
-$action = $_POST['action'] ?? '';
+// Get action — sanitize to prevent log injection from user-controlled input
+$action = preg_replace('/[^\w\-]/', '', $_POST['action'] ?? '') ?? '';
 
 try {
     // Initialize BackupManager with global configuration constant
@@ -293,12 +293,11 @@ try {
     }
 
 } catch (Exception $e) {
-    // Log detailed error with stack trace — sanitize $action to prevent log injection
-    $safeAction = preg_replace('/[^\w\-]/', '', $action ?? '');
-    $errorDetails = "Backup operation '{$safeAction}' failed for user {$user->data()->username}\n";
+    // Log detailed error with stack trace
+    $errorDetails = "Backup operation '{$action}' failed for user {$user->data()->username}\n";
     $errorDetails .= "Error: " . $e->getMessage() . "\n";
     $errorDetails .= "File: " . $e->getFile() . " (Line " . $e->getLine() . ")\n";
-    $errorDetails .= "Request action: " . ($safeAction ?: 'none') . "\n";
+    $errorDetails .= "Request action: " . ($action ?: 'none') . "\n";
     $errorDetails .= "Stack trace:\n" . $e->getTraceAsString();
 
     logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_ERROR, $errorDetails);

--- a/app/admin/includes/system/backup-operations.php
+++ b/app/admin/includes/system/backup-operations.php
@@ -48,8 +48,8 @@ try {
             // Log backup initiation with details
             logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_MANAGER, "Manual backup initiated by {$user->data()->username}");
 
-            // Get reason (default to Admin Panel Manual Backup)
-            $reason = $_POST['reason'] ?? 'Admin Panel Manual Backup';
+            // Get reason — strip control characters to prevent log injection
+            $reason = preg_replace('/[\x00-\x1f\x7f]/', '', $_POST['reason'] ?? '') ?: 'Admin Panel Manual Backup';
 
             // Log the reason for debugging
             logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_DEBUG, "Backup reason: '{$reason}'");
@@ -239,8 +239,8 @@ try {
             break;
 
         case 'delete_backup':
-            // Log delete request
-            $filename = $_POST['filename'] ?? '';
+            // Sanitize filename at assignment — basename() prevents path traversal and log injection
+            $filename = basename($_POST['filename'] ?? '');
             logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_MANAGER, "Delete backup requested: {$filename}");
 
             if (empty($filename)) {
@@ -254,7 +254,7 @@ try {
             $types = ['automated', 'manual', 'rollback'];
 
             foreach ($types as $type) {
-                $filepath = $backupDir . $type . '/' . basename($filename);
+                $filepath = $backupDir . $type . '/' . $filename;
 
                 if (file_exists($filepath)) {
                     if (unlink($filepath)) {

--- a/app/admin/includes/system/backup-operations.php
+++ b/app/admin/includes/system/backup-operations.php
@@ -293,23 +293,17 @@ try {
     }
 
 } catch (Exception $e) {
-    // Log detailed error with stack trace
-    $errorDetails = "Backup operation '{$action}' failed for user {$user->data()->username}\n";
+    // Log detailed error with stack trace — sanitize $action to prevent log injection
+    $safeAction = preg_replace('/[^\w\-]/', '', $action ?? '');
+    $errorDetails = "Backup operation '{$safeAction}' failed for user {$user->data()->username}\n";
     $errorDetails .= "Error: " . $e->getMessage() . "\n";
     $errorDetails .= "File: " . $e->getFile() . " (Line " . $e->getLine() . ")\n";
-    $errorDetails .= "Request params: " . json_encode($_POST) . "\n";
+    $errorDetails .= "Request action: " . ($safeAction ?: 'none') . "\n";
     $errorDetails .= "Stack trace:\n" . $e->getTraceAsString();
 
     logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_ERROR, $errorDetails);
 
-    ApiResponse::serverError($e->getMessage())
-        ->withDataArray([
-            'error_details' => [
-                'file' => basename($e->getFile()),
-                'line' => $e->getLine(),
-                'action' => $action
-            ]
-        ])
+    ApiResponse::serverError('Backup operation failed')
         ->send();
 }
 

--- a/app/admin/includes/system/backup-operations.php
+++ b/app/admin/includes/system/backup-operations.php
@@ -34,7 +34,7 @@ if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
         ->send();
 }
 
-// Get action — sanitize to prevent log injection from user-controlled input
+// Get action — allow only word characters and hyphens (safe for routing, logging, and display)
 $action = preg_replace('/[^\w\-]/', '', $_POST['action'] ?? '') ?? '';
 
 try {
@@ -48,7 +48,7 @@ try {
             // Log backup initiation with details
             logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_MANAGER, "Manual backup initiated by {$user->data()->username}");
 
-            // Get reason — strip control characters to prevent log injection
+            // Get reason — strip control characters to prevent log injection; default to standard reason if empty
             $reason = preg_replace('/[\x00-\x1f\x7f]/', '', $_POST['reason'] ?? '') ?: 'Admin Panel Manual Backup';
 
             // Log the reason for debugging
@@ -239,7 +239,7 @@ try {
             break;
 
         case 'delete_backup':
-            // Sanitize filename at assignment — basename() prevents path traversal and log injection
+            // Sanitize filename at assignment — basename() strips directory components to prevent path traversal
             $filename = basename($_POST['filename'] ?? '');
             logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_MANAGER, "Delete backup requested: {$filename}");
 

--- a/app/admin/includes/system/schema-operations.php
+++ b/app/admin/includes/system/schema-operations.php
@@ -119,7 +119,8 @@ try {
             break;
 
         default:
-            throw new SchemaException('Unknown action: ' . $action);
+            $safeAction = preg_replace('/[^\w\-]/', '', $action ?? '');
+            throw new SchemaException('Unknown action: ' . $safeAction);
     }
 
 } catch (Exception $e) {
@@ -127,6 +128,6 @@ try {
     logger($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_SCHEMA_OPERATION_ERROR,
         'Schema operation failed: ' . $e->getMessage());
 
-    ApiResponse::serverError('Schema operation failed: ' . $e->getMessage())
+    ApiResponse::serverError('Schema operation failed')
         ->send();
 }

--- a/app/admin/includes/system/schema-operations.php
+++ b/app/admin/includes/system/schema-operations.php
@@ -28,7 +28,8 @@ if ($method === 'POST' && (!isset($_POST['csrf']) || !Token::check($_POST['csrf'
 header('Content-Type: application/json');
 
 try {
-    $action = $_POST['action'] ?? $_GET['action'] ?? null;
+    $action = preg_replace('/[^\w\-]/', '', $_POST['action'] ?? $_GET['action'] ?? '') ?? '';
+    $action = $action ?: null;
 
     if (!$action) {
         throw new SchemaException('No action specified');
@@ -119,12 +120,11 @@ try {
             break;
 
         default:
-            $safeAction = preg_replace('/[^\w\-]/', '', $action ?? '');
-            throw new SchemaException('Unknown action: ' . $safeAction);
+            throw new SchemaException('Unknown action: ' . $action);
     }
 
 } catch (Exception $e) {
-    // Keep existing logger() call for detailed error logging
+    // Log error details server-side for diagnosis; generic message returned to client
     logger($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_SCHEMA_OPERATION_ERROR,
         'Schema operation failed: ' . $e->getMessage());
 


### PR DESCRIPTION
## Summary
- Replace exception messages, filenames, and line numbers in `backup-operations.php` and `schema-operations.php` API error responses with generic messages
- Sanitize user-supplied `$action` parameter before logging to prevent log injection
- Replace full `$_POST` dump with safe action name in backup error logs
- Add trailing newline to `schema-operations.php`

## Test plan
- [x] PHP syntax check passes
- [x] PHPStan static analysis passes
- [x] All 669 unit tests pass
- [x] IDE diagnostics clean
- [x] Security review passed — no new vulnerabilities introduced
- [ ] Manual verification: trigger backup/schema errors and confirm generic messages in response
- [ ] Manual verification: confirm full error details still appear in server-side logs

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)