### PR TITLE
fix: replace raw $_GET access in statistics API endpoint (#604)

### DIFF
--- a/app/reports/api/statistics-data.php
+++ b/app/reports/api/statistics-data.php
@@ -24,7 +24,7 @@ if (!securePage($php_self)) {
 }
 
 // Get requested tab
-$tab = $_GET['tab'] ?? '';
+$tab = Input::get('tab') ?? '';
 
 if (empty($tab)) {
     ApiResponse::error('Tab parameter required', 400)
@@ -78,7 +78,6 @@ try {
 
         default:
             ApiResponse::error('Invalid tab parameter', 400)
-                ->withData('tab', $tab)
                 ->withData('valid_tabs', ['geographic', 'production', 'colors', 'quality'])
                 ->withLogging($user->data()->id ?? 0, 'ValidationError', "Statistics API: Invalid tab '{$tab}'")
                 ->send();

--- a/app/reports/api/statistics-data.php
+++ b/app/reports/api/statistics-data.php
@@ -19,7 +19,7 @@ require_once $abs_us_root . $us_url_root . 'usersc/classes/StatisticsDataService
 // Security check
 if (!securePage($php_self)) {
     ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, 'SecurityError', 'Unauthorized statistics-data.php access attempt')
+        ->withLogging(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized statistics-data.php access attempt')
         ->send();
 }
 
@@ -28,7 +28,7 @@ $tab = Input::get('tab');
 
 if (empty($tab)) {
     ApiResponse::error('Tab parameter required', 400)
-        ->withLogging($user->data()->id ?? 0, 'ValidationError', 'Statistics API called without tab parameter')
+        ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'Statistics API called without tab parameter')
         ->send();
 }
 
@@ -36,7 +36,7 @@ if (empty($tab)) {
 try {
     if (!isset($db)) {
         ApiResponse::serverError('Database connection not available')
-            ->withLogging($user->data()->id ?? 0, 'DatabaseError', 'Statistics API: Database connection not available')
+            ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Statistics API: Database connection not available')
             ->send();
     }
     $dataService = new StatisticsDataService($db);
@@ -79,7 +79,7 @@ try {
         default:
             ApiResponse::error('Invalid tab parameter', 400)
                 ->withData('valid_tabs', ['geographic', 'production', 'colors', 'quality'])
-                ->withLogging($user->data()->id ?? 0, 'ValidationError', "Statistics API: Invalid tab '{$tab}'")
+                ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, "Statistics API: Invalid tab '{$tab}'")
                 ->send();
     }
 
@@ -90,9 +90,10 @@ try {
 
 } catch (Throwable $e) {
     ApiResponse::serverError('Data retrieval failed')
+        ->withData('tab', $tab)
         ->withLogging(
             $user->data()->id ?? 0,
-            'DatabaseError',
+            LogCategories::LOG_CATEGORY_DATABASE_ERROR,
             "Statistics API error for tab '{$tab}': " . $e->getMessage()
         )
         ->send();

--- a/app/reports/api/statistics-data.php
+++ b/app/reports/api/statistics-data.php
@@ -24,7 +24,7 @@ if (!securePage($php_self)) {
 }
 
 // Get requested tab
-$tab = Input::get('tab') ?? '';
+$tab = Input::get('tab');
 
 if (empty($tab)) {
     ApiResponse::error('Tab parameter required', 400)
@@ -90,7 +90,6 @@ try {
 
 } catch (Throwable $e) {
     ApiResponse::serverError('Data retrieval failed')
-        ->withData('tab', $tab ?? 'unknown')
         ->withLogging(
             $user->data()->id ?? 0,
             'DatabaseError',


### PR DESCRIPTION
## Summary
- Replace `$_GET['tab']` with `Input::get('tab')` to comply with server globals policy (v2.13.0+)
- Remove `->withData('tab', $tab)` from invalid tab error response to prevent echoing unsanitized user input
- Keep `->withData('tab', $tab)` in catch block (validated value needed for frontend debugging)
- Remove redundant `?? ''` and `?? 'unknown'` fallbacks since `Input::get()` already defaults to empty string
- Replace all hardcoded log category strings with `LogCategories` constants per mandatory coding standard

## Test plan
- [ ] Valid tab requests (`geographic`, `production`, `colors`, `quality`) return data unchanged
- [ ] Invalid tab returns 400 error without echoing the tab value
- [ ] Missing tab parameter returns 400 error
- [ ] Server errors include validated tab value for debugging

Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)