### PR TITLE
fix: prevent false location change detection when only email changes (#644)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.17.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.17.0.md
@@ -11,6 +11,13 @@ None.
 
 ### Bug Fixes
 
+- **False location change detection on settings save**
+  ([#644](https://github.com/unibrain1/elanregistry/issues/644)):
+  Changing only email or other non-location fields on the account settings page
+  no longer triggers a spurious geocoding lookup or "Geocoding failed" log entry.
+  The fix preserves existing location data when the LocationPicker JS fails to
+  populate hidden inputs (e.g. if JavaScript is disabled).
+
 - **Email rendering in Outlook and Gmail mobile**
   ([#597](https://github.com/unibrain1/elanregistry/issues/597)):
   All registry emails now render correctly in Outlook for Windows and Gmail on
@@ -84,6 +91,13 @@ None.
   The success confirmation is now shown only when email delivery succeeds. On
   failure, an error message is displayed and the failure is logged under
   `LOG_CATEGORY_EMAIL_ERROR`.
+- **Location change detection hardened** in `usersc/user_settings.php`
+  ([#644](https://github.com/unibrain1/elanregistry/issues/644)):
+  Added server-side fallback: when all location POST fields are empty but the
+  user has existing location data, the DB values are used instead of the empty
+  POST values, preventing false change detection if the LocationPicker JS fails.
+  Added a `$geocodingAttempted` flag so the "Geocoding failed" log only fires
+  when geocoding was actually called, not on every save with no location change.
 - **Open-redirect guard now logs security events** in `_email_template_verify_new.php`:
   Added a `logger()` call under `LOG_CATEGORY_SECURITY` when the scheme-rejection
   guard triggers, making security events visible in the admin log.
@@ -93,9 +107,11 @@ None.
 - [#324](https://github.com/unibrain1/elanregistry/issues/324) — Migrate existing email functionality to centralized EmailTemplate system
 - [#597](https://github.com/unibrain1/elanregistry/issues/597) — fix: improve email template HTML compatibility for Outlook and Gmail mobile
 - [#638](https://github.com/unibrain1/elanregistry/issues/638) — send-feedback.php delivery failure check dead code
+- [#644](https://github.com/unibrain1/elanregistry/issues/644) — user_settings.php: location change falsely detected when only email changes
 
 ## Summary
 
-3 issues resolved, fixing email rendering across major clients, migrating all
-registry emails to a consistent centralized template system, and hardening the
-email send path with correct failure detection and spam score reduction.
+4 issues resolved, fixing email rendering across major clients, migrating all
+registry emails to a consistent centralized template system, hardening the
+email send path with correct failure detection and spam score reduction, and
+fixing false location change detection on the account settings page.

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -371,7 +371,7 @@ if (!empty($_POST)) {
                                 if (!$email_sent) {
                                     $errors[] = 'Email NOT sent due to error. Please contact site administrator.';
                                 } else {
-                                    $successes[] = 'Email request received. Please check your email to perform verification. Be sure to check your Spam and Junk folder as the verification link expires in $settings->join_vericode_expiry hours.';
+                                    $successes[] = "Email request received. Please check your email to perform verification. Be sure to check your Spam and Junk folder as the verification link expires in {$settings->join_vericode_expiry} hours.";
                                 }
                                 if ($emailR->email_act == 1) {
                                     logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, "Requested change email from $userdetails->email to $email. Verification email sent.");

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -160,11 +160,22 @@ if (!empty($_POST)) {
         // Extend user_setttings.php with some PROFILE information
         // Update Location (city, state, country, lat, lon)
         $locationChanged = false;
+        $geocodingAttempted = false;
         $newCity = Input::get('city');
         $newState = Input::get('state');
         $newCountry = Input::get('country');
         $newLat = Input::get('lat');
         $newLon = Input::get('lon');
+
+        // If all location fields are empty but the user has existing location data,
+        // JS pre-population likely failed — preserve existing values to prevent false change detection
+        if (empty($newCity) && empty($newCountry) && !empty($profiledetails->city)) {
+            $newCity    = $profiledetails->city;
+            $newState   = $profiledetails->state ?? '';
+            $newCountry = $profiledetails->country;
+            $newLat     = (string)($profiledetails->lat ?? '');
+            $newLon     = (string)($profiledetails->lon ?? '');
+        }
 
         // Check if any location field changed
         if ($profiledetails->city != $newCity ||
@@ -211,6 +222,7 @@ if (!empty($_POST)) {
                 } else {
                     // Fallback to old geocoding method if coordinates not provided
                     /** @deprecated Fallback only - location picker should provide coordinates */
+                    $geocodingAttempted = true;
                     $geoResult = ElanRegistryOwner::geocodeAddress($newCity, $newState, $newCountry);
                     if (!empty($geoResult)) {
                         $locationFields = array_merge($locationFields, $geoResult);
@@ -288,7 +300,7 @@ if (!empty($_POST)) {
                     logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, "Location sync: Updated $carsUpdated cars with new coordinates");
                 }
             }
-        } else {
+        } elseif ($geocodingAttempted) {
             logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, 'Geocoding failed - preserving existing lat/lon coordinates');
         }
 


### PR DESCRIPTION
## Summary

- Adds server-side fallback in `user_settings.php`: when all location POST fields are empty but the user has existing location data, DB values are used instead, preventing false change detection if the LocationPicker JS pre-population fails
- Adds `$geocodingAttempted` flag so the "Geocoding failed" log only fires when geocoding was actually called — not on every save where location didn't change

## Escape Analysis

**Root cause:** The `$geoResult = []` path was shared by both "no location change" and "geocoding attempted and failed". The `else` log at line 292 fired on every normal form save, creating a misleading log entry. Additionally, if LocationPicker's JS pre-population didn't run (JS disabled, element missing, etc.), empty strings were submitted for location fields, causing a false positive in the change detection comparison.

**Testing gap:** The user settings page POST processing is not covered by unit tests — the false log and defensive fallback couldn't be caught automatically. Future protection comes from the fallback itself making the behavior correct even under failure conditions.

## Test plan

- [ ] Submit settings form changing only email — no "Geocoding failed" log appears
- [ ] Submit settings form changing only name — location unchanged, no log
- [ ] Submit settings form changing location — location updated correctly, lat/lon synced to cars
- [ ] `composer test:quick` passes
- [ ] `composer check:php` clean on modified files

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)