### PR TITLE
fix: location change false detection and email verification bugs (#644)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.17.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.17.0.md
@@ -11,6 +11,13 @@ None.
 
 ### Bug Fixes
 
+- **False location change detection on settings save**
+  ([#644](https://github.com/unibrain1/elanregistry/issues/644)):
+  Changing only email or other non-location fields on the account settings page
+  no longer triggers a spurious geocoding lookup or "Geocoding failed" log entry.
+  The fix preserves existing location data when the LocationPicker JS fails to
+  populate hidden inputs (e.g. if JavaScript is disabled).
+
 - **Email rendering in Outlook and Gmail mobile**
   ([#597](https://github.com/unibrain1/elanregistry/issues/597)):
   All registry emails now render correctly in Outlook for Windows and Gmail on
@@ -84,6 +91,13 @@ None.
   The success confirmation is now shown only when email delivery succeeds. On
   failure, an error message is displayed and the failure is logged under
   `LOG_CATEGORY_EMAIL_ERROR`.
+- **Location change detection hardened** in `usersc/user_settings.php`
+  ([#644](https://github.com/unibrain1/elanregistry/issues/644)):
+  Added server-side fallback: when all location POST fields are empty but the
+  user has existing location data, the DB values are used instead of the empty
+  POST values, preventing false change detection if the LocationPicker JS fails.
+  Added a `$geocodingAttempted` flag so the "Geocoding failed" log only fires
+  when geocoding was actually called, not on every save with no location change.
 - **Open-redirect guard now logs security events** in `_email_template_verify_new.php`:
   Added a `logger()` call under `LOG_CATEGORY_SECURITY` when the scheme-rejection
   guard triggers, making security events visible in the admin log.
@@ -93,9 +107,11 @@ None.
 - [#324](https://github.com/unibrain1/elanregistry/issues/324) — Migrate existing email functionality to centralized EmailTemplate system
 - [#597](https://github.com/unibrain1/elanregistry/issues/597) — fix: improve email template HTML compatibility for Outlook and Gmail mobile
 - [#638](https://github.com/unibrain1/elanregistry/issues/638) — send-feedback.php delivery failure check dead code
+- [#644](https://github.com/unibrain1/elanregistry/issues/644) — user_settings.php: location change falsely detected when only email changes
 
 ## Summary
 
-3 issues resolved, fixing email rendering across major clients, migrating all
-registry emails to a consistent centralized template system, and hardening the
-email send path with correct failure detection and spam score reduction.
+4 issues resolved, fixing email rendering across major clients, migrating all
+registry emails to a consistent centralized template system, hardening the
+email send path with correct failure detection and spam score reduction, and
+fixing false location change detection on the account settings page.

--- a/tests/unit/classes/EmailTemplateTest.php
+++ b/tests/unit/classes/EmailTemplateTest.php
@@ -846,19 +846,20 @@ final class EmailTemplateTest extends TestCase
 
     public function testVerifyNewEmailViewBuildsFullUrlFromBaseUrl(): void
     {
-        $relativeUrl = 'users/verify_new.php?vericode=NEWCODE77';
         $html = $this->renderView('_email_template_verify_new.php', [
             'fname'               => 'Carol',
             'email'               => 'carol@example.com',
             'vericode'            => 'NEWCODE77',
             'user_id'             => 12,
             'join_vericode_expiry' => 24,
-            'url'                 => $relativeUrl,
         ]);
 
-        // The template prepends getBaseUrl() (mocked as 'https://test.elanregistry.org')
-        // to the relative $url value.
-        $this->assertStringContainsString('https://test.elanregistry.org/' . $relativeUrl, $html);
+        // URL is built from trusted components (same as UserSpice original):
+        // users/verify.php?new=1&email=<email>&vericode=<code>&user_id=<id>
+        $this->assertStringContainsString(
+            'https://test.elanregistry.org/users/verify.php?new=1&amp;email=carol@example.com&amp;vericode=NEWCODE77&amp;user_id=12',
+            $html
+        );
     }
 
     public function testVerifyNewEmailViewContainsExpiryHours(): void
@@ -890,8 +891,10 @@ final class EmailTemplateTest extends TestCase
         $this->assertStringContainsString('&lt;script&gt;', $html);
     }
 
-    public function testVerifyNewEmailViewOpenRedirectGuardRejectsScheme(): void
+    public function testVerifyNewEmailViewUrlIgnoresUrlParameter(): void
     {
+        // The $url option is not used — URL is always built from trusted components.
+        // Passing a malicious $url has no effect on the output.
         $html = $this->renderView('_email_template_verify_new.php', [
             'fname'               => 'Carol',
             'email'               => 'carol@example.com',
@@ -901,9 +904,8 @@ final class EmailTemplateTest extends TestCase
             'url'                 => 'javascript:alert(1)',
         ]);
 
-        // Scheme-based open-redirect must be rejected; URL must fall back to safe path.
         $this->assertStringNotContainsString('javascript:', $html);
-        $this->assertStringContainsString('users/verify_new.php', $html);
+        $this->assertStringContainsString('users/verify.php', $html);
     }
 
     // ============================================================

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -362,6 +362,7 @@ if (!empty($_POST)) {
                                     'fname' => $user->data()->fname,
                                     'email' => rawurlencode($user->data()->email),
                                     'vericode' => $vericode,
+                                    'user_id' => $userId,
                                     'join_vericode_expiry' => $settings->join_vericode_expiry
                                 ];
                                 $encoded_email = rawurlencode($email);

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -371,7 +371,7 @@ if (!empty($_POST)) {
                                 if (!$email_sent) {
                                     $errors[] = 'Email NOT sent due to error. Please contact site administrator.';
                                 } else {
-                                    $successes[] = 'Email request received. Please check your email to perform verification. Be sure to check your Spam and Junk folder as the verification link expires in $settings->join_vericode_expiry hours.';
+                                    $successes[] = "Email request received. Please check your email to perform verification. Be sure to check your Spam and Junk folder as the verification link expires in {$settings->join_vericode_expiry} hours.";
                                 }
                                 if ($emailR->email_act == 1) {
                                     logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, "Requested change email from $userdetails->email to $email. Verification email sent.");

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -160,11 +160,22 @@ if (!empty($_POST)) {
         // Extend user_setttings.php with some PROFILE information
         // Update Location (city, state, country, lat, lon)
         $locationChanged = false;
+        $geocodingAttempted = false;
         $newCity = Input::get('city');
         $newState = Input::get('state');
         $newCountry = Input::get('country');
         $newLat = Input::get('lat');
         $newLon = Input::get('lon');
+
+        // If all location fields are empty but the user has existing location data,
+        // JS pre-population likely failed — preserve existing values to prevent false change detection
+        if (empty($newCity) && empty($newCountry) && !empty($profiledetails->city)) {
+            $newCity    = $profiledetails->city;
+            $newState   = $profiledetails->state ?? '';
+            $newCountry = $profiledetails->country;
+            $newLat     = (string)($profiledetails->lat ?? '');
+            $newLon     = (string)($profiledetails->lon ?? '');
+        }
 
         // Check if any location field changed
         if ($profiledetails->city != $newCity ||
@@ -211,6 +222,7 @@ if (!empty($_POST)) {
                 } else {
                     // Fallback to old geocoding method if coordinates not provided
                     /** @deprecated Fallback only - location picker should provide coordinates */
+                    $geocodingAttempted = true;
                     $geoResult = ElanRegistryOwner::geocodeAddress($newCity, $newState, $newCountry);
                     if (!empty($geoResult)) {
                         $locationFields = array_merge($locationFields, $geoResult);
@@ -288,7 +300,7 @@ if (!empty($_POST)) {
                     logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, "Location sync: Updated $carsUpdated cars with new coordinates");
                 }
             }
-        } else {
+        } elseif ($geocodingAttempted) {
             logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, 'Geocoding failed - preserving existing lat/lon coordinates');
         }
 

--- a/usersc/views/_email_template_verify_new.php
+++ b/usersc/views/_email_template_verify_new.php
@@ -17,18 +17,12 @@ require_once $abs_us_root . $us_url_root . 'usersc/classes/EmailTemplate.php';
 
 $emailTemplate = new EmailTemplate();
 
-// Build verification URL. UserSpice pre-builds $url as a server-relative path from trusted
-// server-side data, so direct user control is not expected. Guard against scheme-based or
-// protocol-relative redirects as defense-in-depth against future template reuse in other contexts.
-$baseUrl = getBaseUrl();
-$relPath = ltrim($url ?? '', '/');
-if (preg_match('#^[a-zA-Z][a-zA-Z0-9+\-.]*:|^//#', $relPath)) {
-    logger(0, LogCategories::LOG_CATEGORY_SECURITY,
-        '_email_template_verify_new.php: open-redirect guard triggered on $url: '
-        . preg_replace('/[\r\n\t]/', '', $url ?? ''));
-    $relPath = 'users/verify_new.php';
-}
-$verifyUrl = $baseUrl . '/' . $relPath;
+// Build verification URL from components (same pattern as UserSpice original).
+// $email is already rawurlencode()'d by usersc/user_settings.php; $vericode is alphanumeric.
+$verifyUrl = getBaseUrl() . '/users/verify.php?new=1'
+    . '&email=' . ($email ?? '')
+    . '&vericode=' . rawurlencode($vericode ?? '')
+    . '&user_id=' . (int)($user_id ?? 0);
 
 $content = "
     <p>Hello <strong>" . htmlspecialchars($fname, ENT_QUOTES, 'UTF-8') . "</strong>,</p>


### PR DESCRIPTION
## Summary

- Fixes false location change detection in `user_settings.php` — changing only email or name no longer triggers geocoding or logs a misleading "Geocoding failed" entry
- Fixes email change verification link pointing to base URL instead of the correct verify endpoint
- Fixes `$settings->join_vericode_expiry` displaying as a literal string in the success message

## Changes

**`usersc/user_settings.php`**
- Server-side fallback: when all location POST fields are empty but the user has existing data, DB values are preserved (protects against JS pre-population failure)
- `$geocodingAttempted` flag: "Geocoding failed" log only fires when geocoding was actually called
- Added missing `user_id` to email change options array
- Fixed single-quoted success message so `$settings->join_vericode_expiry` interpolates correctly

**`usersc/views/_email_template_verify_new.php`**
- URL now built from trusted components (`users/verify.php?new=1&email=...&vericode=...&user_id=...`) instead of unused `$url` variable that caused the button to link to just the base URL

**`tests/unit/classes/EmailTemplateTest.php`**
- Updated two tests to match the new component-based URL construction

## Test plan

- [x] Changing only email → no "Geocoding failed" log, email change proceeds correctly
- [x] Email change verification link goes to correct URL with all parameters
- [x] Success message shows actual expiry hours (not literal `$settings->join_vericode_expiry`)
- [x] `composer test:quick` passes (735 tests)
- [x] `composer check:php` clean on modified files

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)