### PR TITLE
fix: correct email delivery check in process-admin-contact.php

### DIFF
--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -1,0 +1,8 @@
+# Simplify
+
+Review the recently modified code for opportunities to simplify, improve clarity, reduce redundancy,
+and align with project coding standards — without changing any behavior. Focus only on files changed
+in the current session unless instructed otherwise.
+
+Use the Agent tool with `subagent_type: "code-simplifier:code-simplifier"` to perform the review
+and apply refinements.

--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -151,7 +151,7 @@ if (Input::exists('post')) {
                 $result      = email($toEmail, $subject, $body);
                 $safeFromLog = preg_replace('/[\r\n\t]/', '', $fromEmail);
                 $safeToLog   = preg_replace('/[\r\n\t]/', '', $toEmail);
-                $safeIssue   = preg_replace('/[\r\n\t]/', '', $qualityIssue);
+                $safeIssue   = preg_replace('/[\r\n\t]/', '', (string)($qualityIssue ?? ''));
 
                 if ($result !== true) {
                     $resultStr = is_string($result) ? $result : 'unknown delivery error';

--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -148,21 +148,22 @@ if (Input::exists('post')) {
                 $body = email_body('_email_admin_contact_owner.php', $template);
 
                 // Send email
-                $result = email($toEmail, $subject, $body);
+                $result      = email($toEmail, $subject, $body);
+                $safeFromLog = preg_replace('/[\r\n\t]/', '', $fromEmail);
+                $safeToLog   = preg_replace('/[\r\n\t]/', '', $toEmail);
+                $safeIssue   = preg_replace('/[\r\n\t]/', '', $qualityIssue);
 
-                if ($result) {
-                    // For duplicate accounts, show the email address instead of "Multiple Users"
+                if ($result !== true) {
+                    $resultStr = is_string($result) ? $result : 'unknown delivery error';
+                    $errors[] = 'Failed to send email. Please try again.';
+                    logger($user->data()->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Admin contact SEND FAILED to {$safeToLog}: {$resultStr}");
+                } else {
                     if ($ownerId === 'Multiple') {
                         $successes[] = 'Administrator message sent successfully to duplicate accounts at ' . $toEmail;
                     } else {
                         $successes[] = 'Administrator message sent successfully to ' . $toName;
                     }
-
-                    // Log the admin contact for audit trail
-                    logger($user->data()->id, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Admin contact sent - Admin: {$fromEmail}, Owner: {$toEmail}, Car: {$carId}, Issue: {$qualityIssue}");
-                } else {
-                    $errors[] = 'Failed to send email. Please try again.';
-                    logger($user->data()->id, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Failed admin contact email - Admin: {$fromEmail}, Owner: {$toEmail}");
+                    logger($user->data()->id, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Admin contact sent - Admin: {$safeFromLog}, Owner: {$safeToLog}, Car: {$carId}, Issue: {$safeIssue}");
                 }
 
             } catch (AdminContactException $e) {


### PR DESCRIPTION
## Summary

- Replaced loose `if ($result)` with `if ($result !== true)` to correctly detect email delivery failures (Brevo v1.5 returns `false` on failure, not an error string)
- Hoisted log sanitization (`preg_replace('/[\r\n\t]/', '', ...)`) before the conditional — computed once, used in both branches
- Added `$qualityIssue` sanitization to prevent log injection
- Switched failure log category to `LOG_CATEGORY_EMAIL_ERROR` for consistency with `send-owner-email.php` and `send-feedback.php`
- Removed narration comments that restated what the code already expressed

## Bug Escape Analysis

**Root cause:** Loose truthiness check from the PHPMailer-only era was never updated when the Brevo plugin was introduced. A Brevo error string (older versions) or `false` (v1.5) would have caused the failure branch to be silently skipped.

**Testing gap:** No tests exist for `process-admin-contact.php` email delivery logic. The same gap exists in `send-owner-email.php` and `send-feedback.php` — tracked as broader tech debt.

## Test plan

- [ ] Trigger an admin contact email on test — confirm delivery success is logged correctly
- [ ] Simulate a Brevo failure (invalid API key) — confirm error branch executes and `LOG_CATEGORY_EMAIL_ERROR` entry appears in `elan_log`
- [ ] `composer test:quick` passes (735 tests)

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)