### PR TITLE
fix: use getUserMessage() in AdminContactException catch to prevent info disclosure (#651)

### DIFF
--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -73,7 +73,6 @@ if (Input::exists('post')) {
                 // Get admin user data
                 $adminData = $db->query('SELECT id, email, fname, lname FROM users WHERE id = ?', [$user->data()->id])->first();
                 if (!$adminData) {
-                    $errors[] = 'Admin user data not found';
                     throw new AdminContactException('Admin user not found');
                 }
 
@@ -88,13 +87,11 @@ if (Input::exists('post')) {
                         'lname' => 'Users'
                     ];
                     if (empty($ownerData->email)) {
-                        $errors[] = 'Target email is required for multiple user contact';
                         throw new AdminContactException('Target email not provided for multiple users');
                     }
                 } else {
                     $ownerData = $db->query('SELECT id, email, fname, lname FROM users WHERE id = ?', [$ownerId])->first();
                     if (!$ownerData) {
-                        $errors[] = 'Owner user data not found (Owner ID: ' . $ownerId . ')';
                         throw new AdminContactException('Owner user not found');
                     }
                 }
@@ -167,7 +164,7 @@ if (Input::exists('post')) {
                 }
 
             } catch (AdminContactException $e) {
-                $errors[] = 'An error occurred while sending the message: ' . $e->getMessage();
+                $errors[] = $e->getUserMessage();
                 logger($user->data()->id, $e->getLogCategory(), "Admin contact error: " . $e->getMessage());
             }
         }

--- a/tests/unit/exceptions/AdminExceptionsTest.php
+++ b/tests/unit/exceptions/AdminExceptionsTest.php
@@ -56,6 +56,22 @@ class AdminExceptionsTest extends TestCase
     }
 
     /**
+     * Regression test for issue #651: catch block must use getUserMessage(), not getMessage().
+     * Verifies the two return different strings so the bug would be observable in a code review.
+     */
+    public function testGetMessageAndGetUserMessageAreDistinctForIssue651(): void
+    {
+        $e = new AdminContactException('Admin user not found');
+
+        $this->assertEquals('Admin user not found', $e->getMessage());
+        $this->assertEquals(
+            'An error occurred while sending the message. Please try again.',
+            $e->getUserMessage()
+        );
+        $this->assertNotEquals($e->getMessage(), $e->getUserMessage());
+    }
+
+    /**
      * Test AdminOperationException instantiation and properties
      */
     public function testAdminOperationException(): void


### PR DESCRIPTION
## Summary

- Replace `$e->getMessage()` with `$e->getUserMessage()` in the `AdminContactException` catch block so the admin UI receives a safe, generic message instead of internal system details
- Remove three pre-throw `$errors[]` assignments that caused duplicate error messages and leaked an owner ID to the UI
- Add regression test verifying `getMessage()` and `getUserMessage()` return different strings

## Bug Escape Analysis

**Root cause:** Catch block written using `$e->getMessage()` instead of `$e->getUserMessage()`, violating the established codebase pattern. Pre-throw `$errors[]` assignments also caused duplicate messages and a data leak (owner ID on line 97).

**Testing gap:** No tests existed for `process-admin-contact.php`. No integration test verified error message content from this endpoint.

**Preventive measure:** Regression test added to `AdminExceptionsTest.php` documenting the `getMessage()`/`getUserMessage()` distinction permanently.

## Follow-up Issues Created

- #658 — Same pattern in `edit.php`
- #659 — Same pattern in `manage-consolidated.php`
- #660 — Email header injection via `$qualityIssue` in subject (pre-existing, found during security review)
- #661 — `target_email` unvalidated in multiple-user path (pre-existing, found during security review)

## Test Plan

- [x] `composer test:quick` — 736 tests pass
- [x] IDE diagnostics — no errors in modified files
- [x] Security review — fix is clean; pre-existing findings filed as follow-up issues
- [x] Architect review — fix is correct and complete

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)