### PR TITLE
fix: detect and log registration verification email delivery failure (#639)

### DIFF
--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -147,6 +147,30 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #639: join.php must capture email() return value and log failures.
+     */
+    public function testJoinPhpCapturesEmailReturnValue(): void
+    {
+        $filePath = $this->rootDir . '/usersc/join.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('join.php not found');
+        }
+
+        $content = file_get_contents($filePath);
+
+        $this->assertMatchesRegularExpression(
+            '/\$\w+\s*=\s*email\s*\(/',
+            $content,
+            'join.php must capture the return value of email() (Issue #639)'
+        );
+        $this->assertStringContainsString(
+            'LogCategories::LOG_CATEGORY_EMAIL_ERROR',
+            $content,
+            'join.php must log email failures using LogCategories::LOG_CATEGORY_EMAIL_ERROR (Issue #639)'
+        );
+    }
+
+    /**
      * Data provider for car endpoint files
      */
     public static function carEndpointFilesProvider(): array

--- a/usersc/join.php
+++ b/usersc/join.php
@@ -217,8 +217,12 @@ if (Input::exists()) {
                     $to = rawurlencode($email);
                     $subject = html_entity_decode($settings->site_name, ENT_QUOTES);
                     $body = email_body('_email_template_verify.php', $params);
-                    email($to, $subject, $body);
-                    
+                    $email_result = email($to, $subject, $body);
+                    if ($email_result !== true) {
+                        $safeToLog = preg_replace('/[\r\n\t]/', '', $email);
+                        logger($theNewId, LogCategories::LOG_CATEGORY_EMAIL_ERROR,
+                            'join.php: Registration verification email SEND FAILED to ' . $safeToLog);
+                    }
                 }
             } catch (Exception $e) {
                 // Record failed registration attempt

--- a/usersc/join.php
+++ b/usersc/join.php
@@ -243,7 +243,10 @@ if (Input::exists()) {
                 include $abs_us_root.$us_url_root.'usersc/scripts/during_user_creation.php';
 
                 if ($act == 1 || $settings->no_passwords == 1) {
-                    logger($theNewId, LogCategories::LOG_CATEGORY_USER, 'Registration completed and verification email sent.');
+                    $logMsg = ($email_result === true)
+                        ? 'Registration completed and verification email sent.'
+                        : 'Registration completed. Verification email delivery failed — see EmailError log.';
+                    logger($theNewId, LogCategories::LOG_CATEGORY_USER, $logMsg);
 
                     Redirect::to($us_url_root . "users/complete.php?action=thank_you_verify");
 


### PR DESCRIPTION
## Summary

- Capture `email()` return value in `usersc/join.php` (was called as void, silently discarding failures)
- Log `SEND FAILED` to `LogCategories::LOG_CATEGORY_EMAIL_ERROR` on failure, matching the pattern used by all other email callers in the codebase
- Add regression test to `LogCategoriesUsageTest` that verifies join.php captures the return value and uses the error log category

## Bug Escape Analysis

**Root cause:** `email()` called as a void statement before the project established the return-value-check convention. Every other email caller captures and checks the result; join.php was missed.

**Testing gap:** No tests existed for join.php's email-sending path. A bare void call is invisible to static analysis.

**Preventive measure:** `testJoinPhpCapturesEmailReturnValue()` added to `LogCategoriesUsageTest` — a static content scan that catches any future reversion to an unchecked `email()` call, consistent with the existing pattern in that test class.

## Test Plan

- [x] `composer test:quick` — 737 tests pass
- [x] IDE diagnostics — no errors in modified files
- [x] Pattern matches established codebase convention (`process-admin-contact.php`, `send-owner-email.php`, `transfer_email_notifications.php`)

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)