### PR TITLE
fix: log verify-email delivery failure in user_settings.php (#657)

### DIFF
--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -171,6 +171,25 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #657: user_settings.php must log verify-email delivery failures.
+     */
+    public function testUserSettingsPhpLogsEmailFailure(): void
+    {
+        $filePath = $this->rootDir . '/usersc/user_settings.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('user_settings.php not found');
+        }
+
+        $content = file_get_contents($filePath);
+
+        $this->assertStringContainsString(
+            'LogCategories::LOG_CATEGORY_EMAIL_ERROR',
+            $content,
+            'user_settings.php must log verify-email failures using LogCategories::LOG_CATEGORY_EMAIL_ERROR (Issue #657)'
+        );
+    }
+
+    /**
      * Data provider for car endpoint files
      */
     public static function carEndpointFilesProvider(): array

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -369,6 +369,9 @@ if (!empty($_POST)) {
                                 $body =  email_body('_email_template_verify_new.php', $options);
                                 $email_sent = email($email, $subject, $body);
                                 if ($email_sent !== true) {
+                                    $safeToLog = preg_replace('/[\r\n\t]/', '', $email);
+                                    logger($userId, LogCategories::LOG_CATEGORY_EMAIL_ERROR,
+                                        'user_settings.php: verify-email SEND FAILED for user ' . $userId . ' to ' . $safeToLog);
                                     $errors[] = 'Email NOT sent due to error. Please contact site administrator.';
                                 } else {
                                     $successes[] = "Email request received. Please check your email to perform verification. Be sure to check your Spam and Junk folder as the verification link expires in {$settings->join_vericode_expiry} hours.";


### PR DESCRIPTION
## Summary

- Adds `logger()` call under `LOG_CATEGORY_EMAIL_ERROR` when `email()` returns non-true in the verify-email flow of `user_settings.php`
- Sanitizes the email address with `preg_replace('/[\r\n\t]/', '', $email)` before logging to prevent log injection
- Adds regression test in `LogCategoriesUsageTest` to prevent future silent failures

## Bug Escape Analysis

**Root cause:** The `email()` return value was already captured and checked (`$email_sent !== true`), but the failure branch only set a user-facing error message — no log entry was written. Silent failure was invisible to admins.

**Testing gap:** No static content scan existed for `user_settings.php`'s email failure path. The new test in `LogCategoriesUsageTest::testUserSettingsPhpLogsEmailFailure()` guards against future regression.

## Test plan

- [x] `composer test:quick` — 739 tests pass, including new regression test
- [x] `mcp__ide__getDiagnostics` — no diagnostics on modified files
- [x] Architect review: "Ship it. Fix correct, complete, consistent with project standards."

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)