### PR TITLE
fix: log partial admin alert failure under EMAIL_ERROR category (#656)

### DIFF
--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -25,6 +25,7 @@ class LogCategoriesUsageTest extends TestCase
         'app/admin/includes/process-transfer-approve.php',
         'app/admin/includes/process-transfer-deny.php',
         'app/admin/includes/process-car-details.php',
+        'usersc/includes/transfer_email_notifications.php',
     ];
 
     private string $rootDir;
@@ -191,6 +192,16 @@ class LogCategoriesUsageTest extends TestCase
             '/logger\s*\([^,]+,\s*LogCategories::LOG_CATEGORY_EMAIL_ERROR[^)]*\$failCount/',
             $content,
             'Partial admin alert failure must log under LOG_CATEGORY_EMAIL_ERROR with $failCount (Issue #656)'
+        );
+        $this->assertMatchesRegularExpression(
+            '/if\s*\(\s*\$failCount\s*>\s*0\s*\)/',
+            $content,
+            'Error log must be gated on $failCount > 0 (Issue #656)'
+        );
+        $this->assertMatchesRegularExpression(
+            '/if\s*\(\s*\$successCount\s*>\s*0\s*\)/',
+            $content,
+            'Success log must be gated on $successCount > 0 to prevent false success entries (Issue #656)'
         );
     }
 

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -171,6 +171,30 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #656: partial admin alert failure must use LOG_CATEGORY_EMAIL_ERROR.
+     */
+    public function testTransferAdminAlertLogsPartialFailureUnderErrorCategory(): void
+    {
+        $filePath = $this->rootDir . '/usersc/includes/transfer_email_notifications.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('transfer_email_notifications.php not found');
+        }
+
+        $content = file_get_contents($filePath);
+
+        $this->assertStringContainsString(
+            '$failCount',
+            $content,
+            'sendTransferRequestAdminAlert() must track $failCount for partial-failure logging (Issue #656)'
+        );
+        $this->assertMatchesRegularExpression(
+            '/logger\s*\([^,]+,\s*LogCategories::LOG_CATEGORY_EMAIL_ERROR[^)]*\$failCount/',
+            $content,
+            'Partial admin alert failure must log under LOG_CATEGORY_EMAIL_ERROR with $failCount (Issue #656)'
+        );
+    }
+
+    /**
      * Regression test for Issue #657: user_settings.php must log verify-email delivery failures.
      */
     public function testUserSettingsPhpLogsEmailFailure(): void

--- a/usersc/includes/transfer_email_notifications.php
+++ b/usersc/includes/transfer_email_notifications.php
@@ -199,18 +199,19 @@ function sendTransferRequestAdminAlert(int $transferRequestId): bool
             if ($result === true) {
                 $successCount++;
             } else {
-                logger(0, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Failed to send admin alert to: {$adminEmail}");
+                logger(0, LogCategories::LOG_CATEGORY_EMAIL_ERROR,
+                    "Transfer request #$transferRequestId admin alert failed to send to: {$adminEmail}");
             }
         }
 
         $failCount = $totalCount - $successCount;
         if ($failCount > 0) {
             logger(0, LogCategories::LOG_CATEGORY_EMAIL_ERROR,
-                "Transfer request admin alerts: $successCount sent, $failCount FAILED out of $totalCount");
+                "Transfer request #$transferRequestId admin alerts: $successCount sent, $failCount FAILED out of $totalCount");
         }
         if ($successCount > 0) {
             logger($transferData->requested_by_user_id, LogCategories::LOG_CATEGORY_EMAIL_SUCCESS,
-                "Transfer request admin alerts sent to $successCount administrators");
+                "Transfer request #$transferRequestId admin alerts sent to $successCount of $totalCount administrators");
         }
         return $successCount > 0;
 

--- a/usersc/includes/transfer_email_notifications.php
+++ b/usersc/includes/transfer_email_notifications.php
@@ -191,6 +191,7 @@ function sendTransferRequestAdminAlert(int $transferRequestId): bool
         // Send email to all admins
         $subject = "[ELANREGISTRY] ADMIN ALERT: Transfer Request #$transferRequestId - " . $carData->year . " " . $carData->series . " (Chassis: " . $carData->chassis . ")";
 
+        $totalCount = count($adminEmails);
         $successCount = 0;
 
         foreach ($adminEmails as $adminEmail) {
@@ -202,7 +203,15 @@ function sendTransferRequestAdminAlert(int $transferRequestId): bool
             }
         }
 
-        logger($transferData->requested_by_user_id, LogCategories::LOG_CATEGORY_EMAIL_SUCCESS, "Transfer request admin alerts sent to $successCount administrators");
+        $failCount = $totalCount - $successCount;
+        if ($failCount > 0) {
+            logger(0, LogCategories::LOG_CATEGORY_EMAIL_ERROR,
+                "Transfer request admin alerts: $successCount sent, $failCount FAILED out of $totalCount");
+        }
+        if ($successCount > 0) {
+            logger($transferData->requested_by_user_id, LogCategories::LOG_CATEGORY_EMAIL_SUCCESS,
+                "Transfer request admin alerts sent to $successCount administrators");
+        }
         return $successCount > 0;
 
     } catch (Exception $e) {


### PR DESCRIPTION
## Summary

- Gates the summary success log in `sendTransferRequestAdminAlert()` on `$successCount > 0` — previously logged as success even when 0 emails were sent
- Adds a summary error-category log when `$failCount > 0`, so partial delivery failures appear in error-filtered log views alongside the existing per-address failure logs
- Moves `$totalCount = count($adminEmails)` before the loop (avoids re-counting after iteration)
- Adds regression test in `LogCategoriesUsageTest` to prevent future regressions

## Bug Escape Analysis

**Root cause:** The final `logger()` call was unconditional — written before the project established the pattern of gating success logs on actual success. The per-address failure logs inside the loop were correct; only the summary log had the wrong category.

**Testing gap:** `transfer_email_notifications.php` had zero unit or static tests. No test enforced that partial failure uses the error category.

**Preventive measure:** Static content scan in `LogCategoriesUsageTest::testTransferAdminAlertLogsPartialFailureUnderErrorCategory()` verifies `$failCount` exists and is used in a `LOG_CATEGORY_EMAIL_ERROR` logger call. Catches any future reversion.

## Test plan

- [x] `composer test:quick` — 739 tests pass including new regression test
- [x] No IDE diagnostics on modified files
- [x] Security review: clean (no user input in log values)
- [x] Architect review: "Ready to ship"

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)