### PR TITLE
fix: use getUserMessage() in edit.php catch blocks for user-facing errors (#658)

### DIFF
--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -97,7 +97,7 @@ if (!empty($_POST)) {
                             'Car add error: ' . $e->getMessage()
                         )->send();
                 } catch (\Exception $e) {
-                    ApiResponse::serverError('Failed to add car: ' . $e->getMessage())
+                    ApiResponse::serverError('Failed to add car: An unexpected error occurred.')
                         ->withLogging(
                             $user->data()->id,
                             LogCategories::LOG_CATEGORY_CAR_ERRORS,
@@ -149,7 +149,7 @@ if (!empty($_POST)) {
                             'Car update error: ' . $e->getMessage()
                         )->send();
                 } catch (\Exception $e) {
-                    ApiResponse::serverError('Failed to update car: ' . $e->getMessage())
+                    ApiResponse::serverError('Failed to update car: An unexpected error occurred.')
                         ->withLogging(
                             $user->data()->id,
                             LogCategories::LOG_CATEGORY_CAR_ERRORS,
@@ -639,6 +639,12 @@ function uploadImages(array &$cardetails): void
                             $resizeObj->saveImage($thumbname, 80);
                         } catch (ElanRegistryException $e) {
                             $resizeSuccess = false;
+                            logger(
+                                $user->data()->id,
+                                LogCategories::LOG_CATEGORY_FILE_ERROR,
+                                'Image resize failed for carId: ' . Input::get('car_id') .
+                                    ' file: ' . $newFileName . ' size: ' . $size . ' error: ' . $e->getMessage()
+                            );
                             break;
                         }
                     }

--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -90,7 +90,7 @@ if (!empty($_POST)) {
                         )->send();
 
                 } catch (ElanRegistryException $e) {
-                    ApiResponse::serverError('Failed to add car: ' . $e->getMessage())
+                    ApiResponse::serverError('Failed to add car: ' . $e->getUserMessage())
                         ->withLogging(
                             $user->data()->id,
                             LogCategories::LOG_CATEGORY_CAR_ERRORS,
@@ -142,7 +142,7 @@ if (!empty($_POST)) {
                         )->send();
 
                 } catch (ElanRegistryException $e) {
-                    ApiResponse::serverError('Failed to update car: ' . $e->getMessage())
+                    ApiResponse::serverError('Failed to update car: ' . $e->getUserMessage())
                         ->withLogging(
                             $user->data()->id,
                             LogCategories::LOG_CATEGORY_CAR_ERRORS,
@@ -202,10 +202,10 @@ function updateCar(array &$cardetails): void
         }
     } catch (CarValidationException $e) {
         logger($user->data()->id, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'Car Update Validation Error: ' . $e->getMessage());
-        $errors[] = 'Car Update Validation Error: ' . $e->getMessage();
+        $errors[] = 'Car Update Validation Error: ' . $e->getUserMessage();
     } catch (ElanRegistryException $e) {
         logger($user->data()->id, LogCategories::LOG_CATEGORY_CAR_ERRORS, 'Car Update Error: ' . $e->getMessage());
-        $errors[] = 'Car Update Error: ' . $e->getMessage();
+        $errors[] = 'Car Update Error: ' . $e->getUserMessage();
     }
 }
 /**
@@ -232,10 +232,10 @@ function addCar(array &$cardetails): void
         }
     } catch (CarValidationException $e) {
         logger($user->data()->id, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'Car Creation Validation Error: ' . $e->getMessage());
-        $errors[] = 'Car Creation Validation Error: ' . $e->getMessage();
+        $errors[] = 'Car Creation Validation Error: ' . $e->getUserMessage();
     } catch (ElanRegistryException $e) {
         logger($user->data()->id, LogCategories::LOG_CATEGORY_CAR_ERRORS, 'Car Creation Error: ' . $e->getMessage());
-        $errors[] = 'Car Creation Error: ' . $e->getMessage();
+        $errors[] = 'Car Creation Error: ' . $e->getUserMessage();
     }
 }
 
@@ -386,7 +386,7 @@ function updateChassis(array &$cardetails): void
             $validator = new ChassisValidator();
             $result = $validator->validate($chassis, $year, $model, $chassisOverride);
         } catch (ElanRegistryException $e) {
-            $errors[] = 'Chassis validation error: ' . $e->getMessage();
+            $errors[] = 'Chassis validation error: ' . $e->getUserMessage();
             return;
         }
         
@@ -660,7 +660,7 @@ function uploadImages(array &$cardetails): void
                 }
             } catch (ElanRegistryException $e) {
                 // Log security violation and reject file
-                $errors[] = "File upload rejected: " . $e->getMessage();
+                $errors[] = "File upload rejected: " . $e->getUserMessage();
                 logger(
                     $user->data()->id,
                     LogCategories::LOG_CATEGORY_FILE_ERROR,

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -255,6 +255,28 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #658: edit.php must not expose getMessage() in user-facing $errors[].
+     */
+    public function testEditPhpCatchBlocksUseGetUserMessage(): void
+    {
+        $filePath = $this->rootDir . '/app/cars/actions/edit.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('edit.php not found');
+        }
+
+        $content = file_get_contents($filePath);
+
+        // Find any $errors[] assignment that uses getMessage() — these expose technical messages to users
+        preg_match_all('/\$errors\[\]\s*=\s*[^;]*\$e->getMessage\(\)/', $content, $matches);
+
+        $this->assertEmpty(
+            $matches[0],
+            'app/cars/actions/edit.php must not use $e->getMessage() in $errors[] assignments. ' .
+            'Use $e->getUserMessage() instead (Issue #658). Found: ' . implode(', ', $matches[0])
+        );
+    }
+
+    /**
      * Data provider for car endpoint files
      */
     public static function carEndpointFilesProvider(): array


### PR DESCRIPTION
## Summary

- Replace `$e->getMessage()` with `$e->getUserMessage()` in all `$errors[]` assignments within `ElanRegistryException` (and subclass) catch blocks in `app/cars/actions/edit.php`
- All `logger()` calls retain `$e->getMessage()` for diagnostic detail
- Add regression test in `LogCategoriesUsageTest` that scans for any `$errors[] = ... $e->getMessage()` pattern

## Bug Escape Analysis

**Root cause:** Catch blocks written before the project established the `getUserMessage()` convention; technical exception messages were passed directly to user-facing `$errors[]` arrays.

**Testing gap:** No static content scan existed for this file; the pattern was invisible to existing test coverage.

**Preventive measure:** `testEditPhpCatchBlocksUseGetUserMessage()` in `LogCategoriesUsageTest` will fail if `getMessage()` ever reappears in an `$errors[]` assignment in edit.php.

## Test plan

- [x] `composer test:quick` — 743 tests pass
- [x] `mcp__ide__getDiagnostics` — no diagnostics on modified files

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)