### PR TITLE
fix: replace getMessage() with static message in manage-consolidated catch (#659)

### DIFF
--- a/app/admin/manage-consolidated.php
+++ b/app/admin/manage-consolidated.php
@@ -198,7 +198,7 @@ if (Input::exists('post')) {
                             $errors[] = "Failed to reassign car ID $car_id";
                         }
                     } catch (Exception $e) {
-                        $errors[] = "Transfer failed: " . $e->getMessage();
+                        $errors[] = 'Transfer failed. Please try again.';
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Car reassignment failed for Car ID $car_id: " . $e->getMessage());
                     }
                     break;

--- a/app/admin/manage-consolidated.php
+++ b/app/admin/manage-consolidated.php
@@ -199,7 +199,7 @@ if (Input::exists('post')) {
                         }
                     } catch (Exception $e) {
                         $errors[] = 'Transfer failed. Please try again.';
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Car reassignment failed for Car ID $car_id: " . $e->getMessage());
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed for Car ID $car_id: " . $e->getMessage());
                     }
                     break;
 

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -259,20 +259,41 @@ class LogCategoriesUsageTest extends TestCase
      */
     public function testEditPhpCatchBlocksUseGetUserMessage(): void
     {
-        $filePath = $this->rootDir . '/app/cars/actions/edit.php';
+        $this->assertNoGetMessageInErrorsArray(
+            'app/cars/actions/edit.php',
+            'Use $e->getUserMessage() instead (Issue #658).'
+        );
+    }
+
+    /**
+     * Regression test for Issue #659: manage-consolidated.php must not expose getMessage() in $errors[].
+     */
+    public function testManageConsolidatedPhpCatchBlocksDoNotExposeGetMessage(): void
+    {
+        $this->assertNoGetMessageInErrorsArray(
+            'app/admin/manage-consolidated.php',
+            'Use a safe static message instead (Issue #659).'
+        );
+    }
+
+    /**
+     * Assert that no $errors[] assignment in a file uses $e->getMessage() directly.
+     * Such assignments expose technical exception messages to users.
+     */
+    private function assertNoGetMessageInErrorsArray(string $relativePath, string $hint): void
+    {
+        $filePath = $this->rootDir . '/' . $relativePath;
         if (!file_exists($filePath)) {
-            $this->markTestSkipped('edit.php not found');
+            $this->markTestSkipped("File not found: $relativePath");
         }
 
-        $content = file_get_contents($filePath);
-
-        // Find any $errors[] assignment that uses getMessage() — these expose technical messages to users
+        $content = (string)file_get_contents($filePath);
         preg_match_all('/\$errors\[\]\s*=\s*[^;]*\$e->getMessage\(\)/', $content, $matches);
 
         $this->assertEmpty(
             $matches[0],
-            'app/cars/actions/edit.php must not use $e->getMessage() in $errors[] assignments. ' .
-            'Use $e->getUserMessage() instead (Issue #658). Found: ' . implode(', ', $matches[0])
+            "$relativePath must not use \$e->getMessage() in \$errors[] assignments. $hint Found: "
+                . implode(', ', $matches[0])
         );
     }
 


### PR DESCRIPTION
## Summary

- Replace `$e->getMessage()` in the car reassignment `catch (Exception $e)` block with a static user-safe string (`'Transfer failed. Please try again.'`); technical message retained in `logger()` call
- Add regression test `testManageConsolidatedPhpCatchBlocksDoNotExposeGetMessage()` to catch any future reversion
- Extract `assertNoGetMessageInErrorsArray()` private helper in `LogCategoriesUsageTest` to eliminate regex duplication between #658 and #659 regression tests

## Bug Escape Analysis

**Root cause:** Catch block written before the project established the convention of keeping `getMessage()` out of user-facing output; plain `Exception` (no `getUserMessage()`) was caught and its technical message was passed directly to `$errors[]`.

**Testing gap:** No static content scan existed for `manage-consolidated.php`; the pattern was invisible to existing test coverage.

**Preventive measure:** `testManageConsolidatedPhpCatchBlocksDoNotExposeGetMessage()` will fail if `getMessage()` reappears in any `$errors[]` assignment in this file.

## Test plan

- [x] `composer test:quick` — 744 tests pass
- [x] `mcp__ide__getDiagnostics` — no diagnostics on modified files

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)