### PR TITLE
fix: replace hardcoded $currentUserId fallback with currentUserId() guard (#669)

### DIFF
--- a/app/admin/manage-consolidated.php
+++ b/app/admin/manage-consolidated.php
@@ -29,18 +29,15 @@ if (!securePage($php_self)) {
 // Initialize database connection
 $db = DB::getInstance();
 
-// Ensure user object is available and get current user ID
-$currentUserId = null;
-if (isset($user) && $user->data() && $user->data()->id) {
-    $currentUserId = $user->data()->id;
-} else {
-    // Fallback: try to get user ID from session or other methods
-    if (isset($_SESSION['user']) && isset($_SESSION['user']['id'])) {
-        $currentUserId = $_SESSION['user']['id'];
-    } else {
-        // Last resort: set a default admin user ID
-        $currentUserId = 1; // Assuming admin user ID 1 exists
-    }
+// Abort immediately if no authenticated session exists.
+// securePage() above handles access control; this guard ensures the audit trail
+// always has a real, authenticated user ID — never a fabricated fallback.
+try {
+    $currentUserId = currentUserId();
+} catch (RuntimeException $e) {
+    logger(0, LogCategories::LOG_CATEGORY_SECURITY,
+        "Admin page accessed with invalid user session on $php_self");
+    Redirect::to($us_url_root . 'users/login.php');
 }
 
 // Tab routing - determine which tab to show

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -298,6 +298,32 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #669: manage-consolidated.php must not use a hardcoded
+     * $currentUserId fallback or raw $_SESSION access for the user ID.
+     * A fabricated user ID would corrupt the audit trail for destructive admin operations.
+     */
+    public function testManageConsolidatedPhpHasNoUserIdFallback(): void
+    {
+        $filePath = $this->rootDir . '/app/admin/manage-consolidated.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('manage-consolidated.php not found');
+        }
+
+        $content = (string)file_get_contents($filePath);
+
+        $this->assertStringNotContainsString(
+            '$currentUserId = 1',
+            $content,
+            'manage-consolidated.php must not fall back to a hardcoded user ID — this corrupts the audit trail (Issue #669)'
+        );
+        $this->assertStringNotContainsString(
+            '$_SESSION[\'user\'][\'id\']',
+            $content,
+            'manage-consolidated.php must not access $_SESSION directly for the user ID — use the $user object (Issue #669)'
+        );
+    }
+
+    /**
      * Data provider for car endpoint files
      */
     public static function carEndpointFilesProvider(): array


### PR DESCRIPTION
## Summary

- Remove the `$_SESSION` fallback and hardcoded `$currentUserId = 1` that silently corrupted the admin audit trail with a fabricated user ID
- Replace with a `try/catch` around the existing `currentUserId()` helper (uses canonical `isLoggedIn()` check), redirecting to login and logging a security event on failure
- Add regression test asserting neither the hardcoded ID nor raw `$_SESSION` access can reappear in this file

## Bug Escape Analysis

**Root cause:** The user ID block was written defensively with nested fallbacks; the "last resort" `$currentUserId = 1` was always wrong for an admin page that performs irreversible operations — destructive actions would be attributed to user 1 in the audit log regardless of who actually performed them.

**Testing gap:** No static content scan existed for `manage-consolidated.php`; the fallback was invisible to existing test coverage.

**Preventive measure:** `testManageConsolidatedPhpHasNoUserIdFallback()` catches both `$currentUserId = 1` and `$_SESSION['user']['id']` patterns. A security event is now logged whenever the guard fires, making anomalous session states visible.

## Test plan

- [x] `composer test:quick` — 745 tests pass
- [x] `mcp__ide__getDiagnostics` — no diagnostics on modified files

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)