### PR TITLE
fix: guard email_body() empty return in process-admin-contact.php (#650)

### DIFF
--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -143,6 +143,9 @@ if (Input::exists('post')) {
 
                 // Generate email body using template
                 $body = email_body('_email_admin_contact_owner.php', $template);
+                if ($body === '') {
+                    throw new AdminContactException('email_body() returned empty string for admin contact template');
+                }
 
                 // Send email
                 $result      = email($toEmail, $subject, $body);

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -324,6 +324,27 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #650: process-admin-contact.php must check email_body()
+     * return value before calling email(), so template failures are distinguishable from
+     * Brevo delivery failures in the logs.
+     */
+    public function testAdminContactChecksEmailBodyReturn(): void
+    {
+        $filePath = $this->rootDir . '/app/admin/includes/process-admin-contact.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('process-admin-contact.php not found');
+        }
+
+        $content = (string)file_get_contents($filePath);
+
+        $this->assertStringContainsString(
+            "\$body === ''",
+            $content,
+            'process-admin-contact.php must check email_body() return for empty string before calling email() (Issue #650)'
+        );
+    }
+
+    /**
      * Data provider for car endpoint files
      */
     public static function carEndpointFilesProvider(): array


### PR DESCRIPTION
## Summary

- Throws `AdminContactException` when `email_body()` returns an empty string, making template failures distinguishable from Brevo delivery failures in logs
- Adds regression test (`testAdminContactChecksEmailBodyReturn`) asserting the guard is present

## Bug Escape Analysis

**Root cause:** `email_body()` return value was not checked — a missing or invalid template would silently produce an empty body, sent to `email()` with no indication of why delivery appeared to succeed or fail.

**Testing gap:** No static content scan for this pattern.

**Preventive measure:** New `assertStringContainsString("\$body === ''", ...)` test catches any future reversion.

## Test plan

- [ ] `composer test:quick` passes including `testAdminContactChecksEmailBodyReturn`
- [ ] Admin contact form still sends successfully with valid template
- [ ] If `_email_admin_contact_owner.php` template is missing, `AdminContactException` is thrown and caught, showing safe error to admin

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)