### PR TITLE
fix: add PHPDoc to cleanString() and fix hardcoded logger user ID in send-feedback.php (#600)

### DIFF
--- a/app/contact/send-feedback.php
+++ b/app/contact/send-feedback.php
@@ -24,6 +24,19 @@ $errors = [];
 $email_sent = false;
 $post_attempted = isset($_POST['email']);
 
+/**
+ * Remove suspicious email-header keywords from user input.
+ *
+ * This is a legacy defense-in-depth measure. Email is sent via the Brevo
+ * API (not raw SMTP headers), so header injection via concatenation is not
+ * a risk. The function also strips "href" from comment text.
+ *
+ * Note: str_replace is not a robust injection defense — it can be bypassed
+ * with nested tokens. Retained for backward compatibility and minimal harm.
+ *
+ * @param string $string Raw user input
+ * @return string String with header keywords removed
+ */
 function cleanString(string $string): string
 {
     $bad = array("content-type", "bcc:", "to:", "cc:", "href");
@@ -88,7 +101,7 @@ if ($post_attempted) {
         $body = email_body('_email_feedback.php', $template);
 
         if (empty($body)) {
-            logger(1, LogCategories::LOG_CATEGORY_FEEDBACK_FORM, "send-feedback.php: email_body() returned empty — template missing or failed");
+            logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_FEEDBACK_FORM, "send-feedback.php: email_body() returned empty — template missing or failed");
             $errors[] = 'Your message could not be sent due to a server configuration error. Please contact the administrator.';
         }
     }
@@ -99,10 +112,10 @@ if ($post_attempted) {
         $result = email($email_to, $email_subject, $body, ['replyTo' => $email_from, 'reply_name' => $name]);
 
         if ($result !== true) {
-            logger(1, LogCategories::LOG_CATEGORY_FEEDBACK_FORM, "Error sending feedback email: unknown delivery error");
+            logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_FEEDBACK_FORM, "Error sending feedback email: unknown delivery error");
             $errors[] = 'Your message could not be delivered. Please try again or contact the administrator.';
         } else {
-            logger(1, LogCategories::LOG_CATEGORY_FEEDBACK_FORM, "Complete: sent to " . $email_to . " with subject '" . $email_subject . "'");
+            logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_FEEDBACK_FORM, "Complete: sent to " . $email_to . " with subject '" . $email_subject . "'");
             $email_sent = true;
         }
     }

--- a/app/contact/send-feedback.php
+++ b/app/contact/send-feedback.php
@@ -29,10 +29,12 @@ $post_attempted = isset($_POST['email']);
  *
  * This is a legacy defense-in-depth measure. Email is sent via the Brevo
  * API (not raw SMTP headers), so header injection via concatenation is not
- * a risk. The function also strips "href" from comment text.
+ * a risk. The function also strips "href" from all input fields to reduce
+ * link injection in rendered output.
  *
  * Note: str_replace is not a robust injection defense — it can be bypassed
- * with nested tokens. Retained for backward compatibility and minimal harm.
+ * by wrapping the target string within itself (e.g. "ccontent-typeontent-type").
+ * Retained for backward compatibility and minimal harm.
  *
  * @param string $string Raw user input
  * @return string String with header keywords removed

--- a/docs/releases/RELEASE_NOTES_v2.17.3.md
+++ b/docs/releases/RELEASE_NOTES_v2.17.3.md
@@ -24,7 +24,7 @@ None
 - **Transfer admin alert partial failure** ([#656](https://github.com/unibrain1/elanregistry/issues/656)): Partial delivery failures to admin recipients now logged under error category with sent/failed counts.
 - **Modernize send-feedback.php** ([#600](https://github.com/unibrain1/elanregistry/issues/600)): Add type hints and PHPDoc; move functions to file scope; fix unconditional success log on failure path.
 - **Configurable admin email addresses** ([#368](https://github.com/unibrain1/elanregistry/issues/368)): Replace hardcoded admin email address in feedback form and other locations with `$settings->elan_admin_emails`.
-- **email_body() empty return guard** ([#650](https://github.com/unibrain1/elanregistry/issues/650)): Check `email_body()` return value before calling `email()` in `process-admin-contact.php`; restore template-not-found logging in `helpers.php`.
+- **email_body() empty return guard** ([#650](https://github.com/unibrain1/elanregistry/issues/650)): Check `email_body()` return value before calling `email()` in `process-admin-contact.php` so template failures are distinguishable from Brevo delivery failures in logs.
 - **Brevo email system documentation** ([#354](https://github.com/unibrain1/elanregistry/issues/354)): New `docs/development/EMAIL_SYSTEM.md` covering plugin setup, configuration, environment setup, and troubleshooting.
 
 ## Issues Resolved

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -28,6 +28,15 @@ class LogCategoriesUsageTest extends TestCase
         'usersc/includes/transfer_email_notifications.php',
     ];
 
+    /**
+     * Contact-related PHP files that should use LogCategories constants
+     * for all logging category parameters.
+     */
+    private const CONTACT_ENDPOINT_FILES = [
+        'app/contact/send-feedback.php',
+        'app/contact/send-owner-email.php',
+    ];
+
     private string $rootDir;
 
     protected function setUp(): void
@@ -71,6 +80,67 @@ class LogCategoriesUsageTest extends TestCase
      * @dataProvider carEndpointFilesProvider
      */
     public function testNoHardcodedLoggerStrings(string $relativePath): void
+    {
+        $filePath = $this->rootDir . '/' . $relativePath;
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped("File not found: $relativePath");
+        }
+
+        $content = file_get_contents($filePath);
+
+        // Match logger() calls that use string literals for the category parameter
+        // Pattern: logger(anything, 'SomeString', anything)
+        $pattern = '/\blogger\s*\([^,]+,\s*[\'"][A-Za-z]+[\'"]/';
+
+        $matches = [];
+        preg_match_all($pattern, $content, $matches);
+
+        $this->assertEmpty(
+            $matches[0],
+            sprintf(
+                "File %s contains hardcoded string literals in logger() calls. " .
+                "Use LogCategories constants instead.\nFound: %s",
+                $relativePath,
+                implode(', ', $matches[0])
+            )
+        );
+    }
+
+    /**
+     * @dataProvider contactEndpointFilesProvider
+     */
+    public function testNoHardcodedWithLoggingStringsInContactFiles(string $relativePath): void
+    {
+        $filePath = $this->rootDir . '/' . $relativePath;
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped("File not found: $relativePath");
+        }
+
+        $content = file_get_contents($filePath);
+
+        // Match withLogging calls that use string literals for the category parameter
+        // Pattern: ->withLogging(anything, 'SomeString', anything)
+        // The category is the second argument after the user ID
+        $pattern = '/->withLogging\s*\([^,]+,\s*[\'"][A-Za-z]+[\'"]/';
+
+        $matches = [];
+        preg_match_all($pattern, $content, $matches);
+
+        $this->assertEmpty(
+            $matches[0],
+            sprintf(
+                "File %s contains hardcoded string literals in withLogging() calls. " .
+                "Use LogCategories constants instead.\nFound: %s",
+                $relativePath,
+                implode(', ', $matches[0])
+            )
+        );
+    }
+
+    /**
+     * @dataProvider contactEndpointFilesProvider
+     */
+    public function testNoHardcodedLoggerStringsInContactFiles(string $relativePath): void
     {
         $filePath = $this->rootDir . '/' . $relativePath;
         if (!file_exists($filePath)) {
@@ -345,12 +415,51 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #600: send-feedback.php modernization checks.
+     */
+    public function testSendFeedbackPhpIsModernized(): void
+    {
+        $filePath = $this->rootDir . '/app/contact/send-feedback.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('send-feedback.php not found');
+        }
+
+        $content = (string)file_get_contents($filePath);
+
+        // cleanString() must have a PHPDoc block
+        $this->assertMatchesRegularExpression(
+            '/\/\*\*.*?cleanString/s',
+            $content,
+            'send-feedback.php cleanString() must have a PHPDoc block (#600)'
+        );
+
+        // logger() calls must not use hardcoded user ID 1
+        $this->assertDoesNotMatchRegularExpression(
+            '/\blogger\s*\(\s*1\s*,/',
+            $content,
+            'send-feedback.php must not use hardcoded user ID 1 in logger() calls (#600)'
+        );
+    }
+
+    /**
      * Data provider for car endpoint files
      */
     public static function carEndpointFilesProvider(): array
     {
         $data = [];
         foreach (self::CAR_ENDPOINT_FILES as $file) {
+            $data[$file] = [$file];
+        }
+        return $data;
+    }
+
+    /**
+     * Data provider for contact endpoint files
+     */
+    public static function contactEndpointFilesProvider(): array
+    {
+        $data = [];
+        foreach (self::CONTACT_ENDPOINT_FILES as $file) {
             $data[$file] = [$file];
         }
         return $data;


### PR DESCRIPTION
## Summary

- Add PHPDoc block to `cleanString()` documenting its legacy defense-in-depth rationale and `str_replace` limitations
- Replace hardcoded `logger(1, ...)` calls with `logger((int)$user->data()->id, ...)` in all three logger call sites — the form is behind `securePage()` so `$user` is always authenticated
- Add `CONTACT_ENDPOINT_FILES` constant to `LogCategoriesUsageTest` covering `send-feedback.php` and `send-owner-email.php`, with data-provider tests for hardcoded string literals
- Add `testSendFeedbackPhpIsModernized()` regression test asserting PHPDoc presence and absence of hardcoded user ID

## Test plan

- [ ] `composer test:quick` passes (751 tests, 3848+ assertions)
- [ ] `testSendFeedbackPhpIsModernized` passes
- [ ] `testNoHardcodedLoggerStringsInContactFiles` passes for both contact files
- [ ] Feedback form still submits and logs under the authenticated user's ID

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)