### PR TITLE
fix: replace hardcoded admin email with getFeedbackEmail() in verify template (#368)

### DIFF
--- a/app/admin/includes/tab-settings.php
+++ b/app/admin/includes/tab-settings.php
@@ -30,7 +30,12 @@ if (!function_exists('processSettingsAutoCreation')) {
 
         // Email & Communication settings
         $emailSettingsFields = [
-            'elan_admin_emails' => ['type' => 'TEXT', 'default' => 'registrar@elanregistry.org', 'description' => 'Comma-separated admin email addresses for system notifications and administrative alerts']
+            'elan_admin_emails' => ['type' => 'TEXT', 'default' => 'registrar@elanregistry.org', 'description' => 'Comma-separated admin email addresses for system notifications and administrative alerts'],
+            'elan_feedback_email' => [
+                'type' => 'TEXT',
+                'default' => 'registrar@elanregistry.org',
+                'description' => 'Email address for receiving user feedback form submissions'
+            ],
         ];
 
         // System Maintenance settings

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -1306,7 +1306,8 @@ if (!function_exists('getBaseUrl')) {
 if (!function_exists('getFeedbackEmail')) {
     /**
      * Mock getFeedbackEmail function for testing
-     * Returns a predictable feedback email for assertions
+     * Returns 'registrar@elanregistry.org' — mirrors the production fallback in
+     * custom_functions.php so that render assertions reflect real-world behavior.
      */
     function getFeedbackEmail(): string
     {

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -1302,6 +1302,18 @@ if (!function_exists('getBaseUrl')) {
     }
 }
 
+// Mock getFeedbackEmail function - needed by verify-new-email template
+if (!function_exists('getFeedbackEmail')) {
+    /**
+     * Mock getFeedbackEmail function for testing
+     * Returns a predictable feedback email for assertions
+     */
+    function getFeedbackEmail(): string
+    {
+        return 'registrar@elanregistry.org';
+    }
+}
+
 // Mock getAdminEmails function - needed by transfer email templates
 if (!function_exists('getAdminEmails')) {
     /**

--- a/tests/unit/classes/EmailTemplateTest.php
+++ b/tests/unit/classes/EmailTemplateTest.php
@@ -908,6 +908,31 @@ final class EmailTemplateTest extends TestCase
         $this->assertStringContainsString('users/verify.php', $html);
     }
 
+    public function testVerifyNewEmailViewContainsAdminContactEmail(): void
+    {
+        // getFeedbackEmail() mock returns 'registrar@elanregistry.org'.
+        // Verify the template renders the dynamic address into the mailto: href
+        // and visible link text — not any hardcoded value.
+        $html = $this->renderView('_email_template_verify_new.php', [
+            'fname'                => 'Carol',
+            'email'                => 'carol@example.com',
+            'vericode'             => 'NEWCODE77',
+            'user_id'              => 12,
+            'join_vericode_expiry' => 24,
+        ]);
+
+        $this->assertStringContainsString(
+            'href="mailto:registrar@elanregistry.org"',
+            $html,
+            '_email_template_verify_new.php must build mailto: href from getFeedbackEmail() (#368)'
+        );
+        $this->assertStringContainsString(
+            '>registrar@elanregistry.org<',
+            $html,
+            '_email_template_verify_new.php must display the configured feedback address in link text (#368)'
+        );
+    }
+
     // ============================================================
     // TRANSFER EMAIL TEMPLATE VIEW TESTS
     //

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -442,7 +442,8 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
-     * Regression test for Issue #368: no hardcoded admin email addresses in email templates.
+     * Regression test for Issue #368: _email_template_verify_new.php must not contain
+     * a hardcoded admin email address and must call getFeedbackEmail() instead.
      */
     public function testNoHardcodedAdminEmailInVerifyTemplate(): void
     {
@@ -466,7 +467,9 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
-     * Regression test for Issue #368: elan_feedback_email must be in settings auto-creation.
+     * Regression test for Issue #368: elan_feedback_email must appear in the
+     * processSettingsAutoCreation() defaults array in tab-settings.php,
+     * ensuring it is inserted into the database on fresh installs.
      */
     public function testFeedbackEmailSettingIsAutoCreated(): void
     {

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -442,6 +442,49 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #368: no hardcoded admin email addresses in email templates.
+     */
+    public function testNoHardcodedAdminEmailInVerifyTemplate(): void
+    {
+        $filePath = $this->rootDir . '/usersc/views/_email_template_verify_new.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('_email_template_verify_new.php not found');
+        }
+
+        $content = (string)file_get_contents($filePath);
+
+        $this->assertStringNotContainsString(
+            'admin@elanregistry.org',
+            $content,
+            '_email_template_verify_new.php must not contain hardcoded admin@elanregistry.org (#368)'
+        );
+        $this->assertStringContainsString(
+            'getFeedbackEmail()',
+            $content,
+            '_email_template_verify_new.php must call getFeedbackEmail() for admin contact (#368)'
+        );
+    }
+
+    /**
+     * Regression test for Issue #368: elan_feedback_email must be in settings auto-creation.
+     */
+    public function testFeedbackEmailSettingIsAutoCreated(): void
+    {
+        $filePath = $this->rootDir . '/app/admin/includes/tab-settings.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('tab-settings.php not found');
+        }
+
+        $content = (string)file_get_contents($filePath);
+
+        $this->assertMatchesRegularExpression(
+            '/[\'"]elan_feedback_email[\'"]\s*=>/m',
+            $content,
+            'tab-settings.php must include elan_feedback_email in settings auto-creation (#368)'
+        );
+    }
+
+    /**
      * Data provider for car endpoint files
      */
     public static function carEndpointFilesProvider(): array

--- a/usersc/views/_email_template_verify_new.php
+++ b/usersc/views/_email_template_verify_new.php
@@ -25,6 +25,8 @@ $verifyUrl = getBaseUrl() . '/users/verify.php?new=1'
     . '&vericode=' . rawurlencode($vericode ?? '')
     . '&user_id=' . (int)($user_id ?? 0);
 
+$adminContact = getFeedbackEmail();
+
 $content = "
     <p>Hello <strong>" . htmlspecialchars($fname, ENT_QUOTES, 'UTF-8') . "</strong>,</p>
 
@@ -35,7 +37,7 @@ $content = "
     <p>Or copy and paste this link into your browser:</p>
     <p style=\"word-break:break-all;font-size:13px;color:#6c757d;\">" . htmlspecialchars($verifyUrl, ENT_QUOTES, 'UTF-8') . "</p>
 
-    <p><strong>Didn't request this change?</strong> Contact <a href=\"mailto:admin@elanregistry.org\">admin@elanregistry.org</a> immediately — your account may be at risk.</p>
+    <p><strong>Didn't request this change?</strong> Contact <a href=\"mailto:" . htmlspecialchars($adminContact, ENT_QUOTES, 'UTF-8') . "\">" . htmlspecialchars($adminContact, ENT_QUOTES, 'UTF-8') . "</a> immediately — your account may be at risk.</p>
 
     <p>This verification link expires in <strong>" . htmlspecialchars((string)$join_vericode_expiry, ENT_QUOTES, 'UTF-8') . " hours</strong>. Until verified, your previous email address will remain active.</p>
 ";


### PR DESCRIPTION
## Summary

- Replace hardcoded `admin@elanregistry.org` in `_email_template_verify_new.php` with `getFeedbackEmail()` — the settings-based contact address
- Add `elan_feedback_email` to `processSettingsAutoCreation()` in `tab-settings.php` so fresh installs auto-create the column with a default value
- Add regression tests for both gaps; add `getFeedbackEmail()` mock to test bootstrap

Closes #368

## Test plan

- [ ] `composer test:quick` passes (753 tests)
- [ ] `testNoHardcodedAdminEmailInVerifyTemplate` asserts template uses `getFeedbackEmail()`
- [ ] `testFeedbackEmailSettingIsAutoCreated` asserts `tab-settings.php` includes `elan_feedback_email` in auto-creation array
- [ ] Fresh-install: `elan_feedback_email` column auto-created with default `registrar@elanregistry.org`
- [ ] Verify-email template renders with the settings-based address

🤖 Generated with [Claude Code](https://claude.com/claude-code)