### PR TITLE
chore: auto-update VERSION file via post-commit/post-checkout git hooks

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,5 @@
+#!/bin/sh
+# $3 is 1 for branch checkout, 0 for file checkout (git checkout -- file).
+# Only regenerate VERSION on branch switches to avoid unnecessary writes.
+[ "$3" = "1" ] || exit 0
+git describe --tags --always > VERSION

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Update VERSION file after every commit so the local dev footer shows the
+# correct version without relying on the PHP fallback in ApplicationVersion.
+git describe --tags --always > VERSION

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Update VERSION file after git pull / git merge.
+git describe --tags --always > VERSION

--- a/app/version.php
+++ b/app/version.php
@@ -22,8 +22,9 @@ class ApplicationVersion
             $version    = trim((string) file_get_contents($versionFile));
             $deployTime = filemtime($versionFile);
         } else {
-            // Local dev: VERSION file is absent (post-receive hook has not run).
-            // shell_exec is safe here — the command is a hardcoded string with no user input.
+            // Last-resort fallback: VERSION is absent when git hooks have not been configured
+            // (e.g. fresh clone before running setup-git-hooks.sh, CI environments, GitHub
+            // Actions). The command is a hardcoded string with no user input — safe to use.
             // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
             $gitVersion = trim((string) shell_exec('git describe --tags --always 2>/dev/null'));
             $version    = $gitVersion !== '' ? $gitVersion : 'unknown';

--- a/docs/releases/RELEASE_NOTES_v2.18.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.18.0.md
@@ -1,0 +1,59 @@
+# Elan Registry v2.18.0 Release Notes
+
+**Release Date:** [DATE]
+**Type:** Minor Release - Documentation v2
+
+## Required Actions After Deployment
+
+1. Run database migration to add `turnstile_site_key` column (if #630 is included):
+
+   ```sql
+   ALTER TABLE settings ADD COLUMN turnstile_site_key VARCHAR(100);
+   ```
+
+2. Add `TURNSTILE_SECRET_KEY` to `.env.enc` (if #630 is included)
+3. Set `turnstile_site_key` in site settings after deployment (if #630 is included)
+4. Verify URL redirects in `docs/.htaccess` are working after docs reorganization (#559)
+5. Run `./scripts/setup-git-hooks.sh` on each developer machine to install new git hooks (#684)
+
+## User-Facing Changes
+
+### New Features
+
+- **Cloudflare Turnstile CAPTCHA** ([#630](https://github.com/unibrain1/elanregistry/issues/630)):
+  Login, registration, and password-reset forms now use Cloudflare Turnstile instead of
+  Google reCAPTCHA, eliminating Google data sharing and improving GDPR posture for EU members.
+
+### Improvements
+
+- **Documentation reorganized by intent** ([#559](https://github.com/unibrain1/elanregistry/issues/559)):
+  Documentation is now structured around owner intent — "How do I use the registry?" (Owner
+  Guides) vs. "Tell me about my car" (Technical Reference) — with a simplified 5-item
+  navigation menu replacing the previous 9-item structure.
+
+## Technical Changes
+
+- **Documentation portal template consolidation** ([#350](https://github.com/unibrain1/elanregistry/issues/350)):
+  Shared `DocumentPortalTemplate` class eliminates ~60% of duplicated HTML across
+  documentation portal pages.
+- **MarkdownParser XSS hardening** ([#635](https://github.com/unibrain1/elanregistry/issues/635)):
+  `sanitizeHtml()` now strips event handler attributes and `javascript:` URIs from allowed
+  HTML tags.
+- **Admin include XSS hardening** ([#675](https://github.com/unibrain1/elanregistry/issues/675)):
+  Audit and hardening of 26 Semgrep-flagged echo points across four admin include files.
+- **VERSION file auto-update via git hooks** ([#684](https://github.com/unibrain1/elanregistry/issues/684)):
+  Post-commit, post-merge, and post-checkout hooks keep the VERSION file current on developer
+  machines without relying on the PHP fallback in ApplicationVersion.
+
+## Issues Resolved
+
+- [#350](https://github.com/unibrain1/elanregistry/issues/350) — Consolidate Documentation Portal Templates and Reduce Duplication
+- [#559](https://github.com/unibrain1/elanregistry/issues/559) — Reorganize documentation by user intent instead of format
+- [#630](https://github.com/unibrain1/elanregistry/issues/630) — Replace Google reCAPTCHA plugin with Cloudflare Turnstile
+- [#635](https://github.com/unibrain1/elanregistry/issues/635) — Improve MarkdownParser::sanitizeHtml() to strip event handlers from allowed tags
+- [#675](https://github.com/unibrain1/elanregistry/issues/675) — security: audit admin include files for unescaped echo points (XSS hardening)
+- [#684](https://github.com/unibrain1/elanregistry/issues/684) — chore: auto-update VERSION file via post-commit/post-checkout git hooks
+
+## Summary
+
+[To be completed on release: total issues resolved, PRs merged, key themes.]


### PR DESCRIPTION
## Summary

- Add `post-commit`, `post-merge`, and `post-checkout` hooks to `.githooks/` so the `VERSION` file is kept current on developer machines automatically
- The `post-checkout` hook filters on `$3=1` to skip file-level checkouts (only fires on branch switches)
- Update the `shell_exec` fallback comment in `ApplicationVersion::get()` to clarify it is a last resort for environments where hooks have not been configured (fresh clone, CI, GitHub Actions)
- No changes to `setup-git-hooks.sh` — the existing `chmod +x .githooks/*` glob already picks up the new hooks automatically

## Test plan

- [ ] Run `./scripts/setup-git-hooks.sh` — confirm no errors
- [ ] Make an empty commit (`git commit --allow-empty -m "test"`) — confirm `VERSION` file is written in repo root
- [ ] Switch branches (`git checkout main && git checkout -`) — confirm `VERSION` updates
- [ ] Run `git checkout -- somefile` (file checkout) — confirm `VERSION` does NOT update
- [ ] Check site footer shows correct version matching `git describe --tags --always`
- [ ] Confirm `shell_exec` fallback still present in `app/version.php`

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)