### PR TITLE
security: audit admin include files for unescaped echo points (XSS hardening)

### DIFF
--- a/app/admin/includes/load-owner-info.php
+++ b/app/admin/includes/load-owner-info.php
@@ -74,7 +74,7 @@ try {
                 </div>
                 <div class="col-4">
                     <h4 class="text-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>">
-                        <?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%
+                        <?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%
                     </h4>
                     <small>Profile Quality</small>
                 </div>
@@ -111,8 +111,8 @@ try {
         <div class="card-body">
             <div class="progress mb-2">
                 <div class="progress-bar bg-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>"
-                     style="width: <?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%">
-                    <?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%
+                     style="width: <?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%">
+                    <?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%
                 </div>
             </div>
 
@@ -194,7 +194,7 @@ try {
                                 <span class="text-muted">
                                     <?php
                                     $timestamp = strtotime($record->ctime ?? '');
-                                                    echo $timestamp !== false
+                                    echo $timestamp !== false
                                         ? htmlspecialchars(date('M j, Y', $timestamp), ENT_QUOTES, 'UTF-8')
                                         : 'Unknown date';
                                     ?>

--- a/app/admin/includes/load-owner-info.php
+++ b/app/admin/includes/load-owner-info.php
@@ -69,17 +69,17 @@ try {
         <div class="card-body">
             <div class="row text-center">
                 <div class="col-4">
-                    <h4 class="text-primary"><?= $carCount ?></h4>
+                    <h4 class="text-primary"><?= $carCount // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?></h4>
                     <small>Cars Owned</small>
                 </div>
                 <div class="col-4">
                     <h4 class="text-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>">
-                        <?= $qualityScore ?>%
+                        <?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%
                     </h4>
                     <small>Profile Quality</small>
                 </div>
                 <div class="col-4">
-                    <h4 class="text-info"><?= $historyCount ?></h4>
+                    <h4 class="text-info"><?= $historyCount // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?></h4>
                     <small>History Records</small>
                 </div>
             </div>
@@ -87,7 +87,7 @@ try {
             <hr>
 
             <div class="text-center">
-                <strong>User ID:</strong> <?= $ownerId ?><br>
+                <strong>User ID:</strong> <?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?><br>
                 <strong>Email:</strong> <a href="mailto:<?= htmlspecialchars($ownerData->email) ?>"><?= htmlspecialchars($ownerData->email) ?></a><br>
                 <?php if (!empty($ownerData->website)): ?>
                     <strong>Website:</strong> <a href="<?= htmlspecialchars($ownerData->website) ?>" target="_blank"><?= htmlspecialchars($ownerData->website) ?></a><br>
@@ -111,8 +111,8 @@ try {
         <div class="card-body">
             <div class="progress mb-2">
                 <div class="progress-bar bg-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>"
-                     style="width: <?= $qualityScore ?>%">
-                    <?= $qualityScore ?>%
+                     style="width: <?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%">
+                    <?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%
                 </div>
             </div>
 
@@ -135,7 +135,7 @@ try {
     <div class="card border-info mb-3">
         <div class="card-header bg-info text-white">
             <h6 class="mb-0">
-                <i class="fas fa-car"></i> Car Ownership (<?= $carCount ?>)
+                <i class="fas fa-car"></i> Car Ownership (<?= $carCount // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>)
             </h6>
         </div>
         <div class="card-body">
@@ -154,13 +154,13 @@ try {
                     <?php endforeach; ?>
                     <?php if ($carCount > 5): ?>
                         <div class="list-group-item border-0 px-0 py-1">
-                            <small class="text-muted">... and <?= $carCount - 5 ?> more</small>
+                            <small class="text-muted">... and <?= $carCount - 5 // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?> more</small>
                         </div>
                     <?php endif; ?>
                 </div>
 
                 <div class="mt-2">
-                    <button class="btn btn-sm btn-outline-info" onclick="viewOwnerCars(<?= $ownerId ?>)">
+                    <button class="btn btn-sm btn-outline-info" onclick="viewOwnerCars(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>)">
                         <i class="fas fa-eye"></i> View All Cars
                     </button>
                 </div>
@@ -194,7 +194,9 @@ try {
                                 <span class="text-muted">
                                     <?php
                                     $timestamp = strtotime($record->ctime ?? '');
-                                    echo $timestamp !== false ? date('M j, Y', $timestamp) : 'Unknown date';
+                                                    echo $timestamp !== false
+                                        ? htmlspecialchars(date('M j, Y', $timestamp), ENT_QUOTES, 'UTF-8')
+                                        : 'Unknown date';
                                     ?>
                                 </span>
                             </small>
@@ -204,7 +206,7 @@ try {
 
                 <?php if ($historyCount > 3): ?>
                     <div class="mt-2">
-                        <button class="btn btn-sm btn-outline-secondary" onclick="viewOwnerHistory(<?= $ownerId ?>)">
+                        <button class="btn btn-sm btn-outline-secondary" onclick="viewOwnerHistory(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>)">
                             <i class="fas fa-history"></i> View Full History
                         </button>
                     </div>
@@ -222,15 +224,15 @@ try {
         </div>
         <div class="card-body">
             <div class="d-grid gap-2">
-                <button class="btn btn-sm btn-outline-primary" onclick="contactOwner(<?= $ownerId ?>)">
+                <button class="btn btn-sm btn-outline-primary" onclick="contactOwner(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>)">
                     <i class="fas fa-envelope"></i> Send Email
                 </button>
                 <?php if ($carCount > 0): ?>
-                    <button class="btn btn-sm btn-outline-success" onclick="syncLocationToCars(<?= $ownerId ?>)">
+                    <button class="btn btn-sm btn-outline-success" onclick="syncLocationToCars(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>)">
                         <i class="fas fa-sync"></i> Sync Location to Cars
                     </button>
                 <?php endif; ?>
-                <a href="../../users/admin.php?view=user&id=<?= $ownerId ?>" target="_blank" class="btn btn-sm btn-outline-secondary">
+                <a href="../../users/admin.php?view=user&id=<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>" target="_blank" class="btn btn-sm btn-outline-secondary">
                     <i class="fas fa-external-link-alt"></i> UserSpice Admin
                 </a>
             </div>

--- a/app/admin/includes/load-owner-profile.php
+++ b/app/admin/includes/load-owner-profile.php
@@ -55,7 +55,7 @@ try {
 
     ?>
     <form id="ownerProfileUpdateForm" method="post">
-        <input type="hidden" name="owner_id" value="<?= $ownerId ?>">
+        <input type="hidden" name="owner_id" value="<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>">
         <input type="hidden" name="csrf" value="<?= Token::generate() ?>">
 
         <!-- Profile Quality Indicator -->
@@ -63,10 +63,10 @@ try {
             <div class="row align-items-center">
                 <div class="col-md-8">
                     <h6 class="mb-1">
-                        <i class="fas fa-chart-pie"></i> Profile Quality Score: <strong><?= $qualityScore ?>%</strong>
+                        <i class="fas fa-chart-pie"></i> Profile Quality Score: <strong><?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%</strong>
                     </h6>
                     <?php if (!empty($missingFields)): ?>
-                        <small>Missing: <?= implode(', ', $missingFields) ?></small>
+                        <small>Missing: <?= htmlspecialchars(implode(', ', $missingFields), ENT_QUOTES, 'UTF-8') ?></small>
                     <?php else: ?>
                         <small>Profile is complete!</small>
                     <?php endif; ?>
@@ -74,7 +74,7 @@ try {
                 <div class="col-md-4 text-right">
                     <div class="progress" style="height: 8px;">
                         <div class="progress-bar bg-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>"
-                             style="width: <?= $qualityScore ?>%"></div>
+                             style="width: <?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%"></div>
                     </div>
                 </div>
             </div>
@@ -149,7 +149,7 @@ try {
 
                 <!-- Location Actions -->
                 <div class="mt-3">
-                    <button type="button" class="btn btn-outline-primary btn-sm" onclick="syncLocationToCars(<?= $ownerId ?>)">
+                    <button type="button" class="btn btn-outline-primary btn-sm" onclick="syncLocationToCars(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>)">
                         <i class="fas fa-sync"></i> Sync Location to Owned Cars
                     </button>
                 </div>
@@ -170,7 +170,7 @@ try {
                     </div>
                     <div class="col-md-4 text-right">
                         <small class="text-muted">
-                            User ID: <?= $ownerData->id ?> | Joined: <?= date('M j, Y', strtotime($ownerData->join_date)) ?>
+                            User ID: <?= (int)$ownerData->id // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?> | Joined: <?= htmlspecialchars(date('M j, Y', strtotime($ownerData->join_date)), ENT_QUOTES, 'UTF-8') ?>
                         </small>
                     </div>
                 </div>
@@ -193,8 +193,8 @@ try {
                 city: '<?= htmlspecialchars($ownerData->city ?? '', ENT_QUOTES) ?>',
                 state: '<?= htmlspecialchars($ownerData->state ?? '', ENT_QUOTES) ?>',
                 country: '<?= htmlspecialchars($ownerData->country ?? '', ENT_QUOTES) ?>',
-                lat: '<?= $ownerData->lat ?? '' ?>',
-                lon: '<?= $ownerData->lon ?? '' ?>'
+                lat: <?= (float)($ownerData->lat ?? 0) // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>,
+                lon: <?= (float)($ownerData->lon ?? 0) // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>
             };
 
             const locationPicker = new LocationPicker({
@@ -241,7 +241,7 @@ try {
 
                 // Reload the profile form to show updated data
                 setTimeout(() => {
-                    loadOwnerById(<?= $ownerId ?>);
+                    loadOwnerById(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>);
                 }, 1500);
 
                 // Refresh search results if visible

--- a/app/admin/includes/load-owner-profile.php
+++ b/app/admin/includes/load-owner-profile.php
@@ -63,7 +63,7 @@ try {
             <div class="row align-items-center">
                 <div class="col-md-8">
                     <h6 class="mb-1">
-                        <i class="fas fa-chart-pie"></i> Profile Quality Score: <strong><?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%</strong>
+                        <i class="fas fa-chart-pie"></i> Profile Quality Score: <strong><?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%</strong>
                     </h6>
                     <?php if (!empty($missingFields)): ?>
                         <small>Missing: <?= htmlspecialchars(implode(', ', $missingFields), ENT_QUOTES, 'UTF-8') ?></small>
@@ -74,7 +74,7 @@ try {
                 <div class="col-md-4 text-right">
                     <div class="progress" style="height: 8px;">
                         <div class="progress-bar bg-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>"
-                             style="width: <?= $qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%"></div>
+                             style="width: <?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>%"></div>
                     </div>
                 </div>
             </div>
@@ -170,7 +170,13 @@ try {
                     </div>
                     <div class="col-md-4 text-right">
                         <small class="text-muted">
-                            User ID: <?= (int)$ownerData->id // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?> | Joined: <?= htmlspecialchars(date('M j, Y', strtotime($ownerData->join_date)), ENT_QUOTES, 'UTF-8') ?>
+                            <?php
+                            $joinTimestamp = strtotime($ownerData->join_date ?? '');
+                            $joinFormatted = $joinTimestamp !== false
+                                ? htmlspecialchars(date('M j, Y', $joinTimestamp), ENT_QUOTES, 'UTF-8')
+                                : 'Unknown date';
+                            ?>
+                            User ID: <?= (int)$ownerData->id // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?> | Joined: <?= $joinFormatted // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>
                         </small>
                     </div>
                 </div>

--- a/app/admin/includes/tab-car_mgmt.php
+++ b/app/admin/includes/tab-car_mgmt.php
@@ -413,7 +413,7 @@ try {
 document.addEventListener("DOMContentLoaded", function() {
     const carIdField = document.getElementById("reassign_car_id");
     if (carIdField) {
-        carIdField.value = "<?= $preloadCarId ?>";
+        carIdField.value = "<?= $preloadCarId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>";
 
         // Trigger lookup to display car details
         const lookupBtn = document.getElementById("lookupCarBtn");
@@ -434,7 +434,7 @@ document.addEventListener("DOMContentLoaded", function() {
             alertDiv.className = "alert alert-info alert-dismissible fade show";
             alertDiv.innerHTML = `
                 <i class="fas fa-info-circle"></i> <strong>Data Quality Integration:</strong>
-                Car ID <?= $preloadCarId ?> has been pre-loaded from the Data Quality dashboard for editing.
+                Car ID <?= $preloadCarId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?> has been pre-loaded from the Data Quality dashboard for editing.
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/app/admin/includes/tab-owner_mgmt.php
+++ b/app/admin/includes/tab-owner_mgmt.php
@@ -44,7 +44,7 @@ if (isset($_GET['owner_id']) && is_numeric($_GET['owner_id'])) {
                            id="ownerSearchInput"
                            class="form-control"
                            placeholder="Search owners by name, email, or location..."
-                           value="<?= $selectedOwnerId ? 'Loading owner ID ' . $selectedOwnerId . '...' : '' ?>">
+                           value="<?= $selectedOwnerId ? 'Loading owner ID ' . $selectedOwnerId . '...' : '' // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>">
                     <div class="input-group-append">
                         <button class="btn btn-primary" type="button" id="ownerSearchBtn">
                             <i class="fas fa-search"></i> Search
@@ -703,7 +703,7 @@ let searchTimeout = null;
 $(document).ready(function() {
     // Auto-load owner if ID provided in URL
     <?php if ($selectedOwnerId): ?>
-        loadOwnerById(<?= $selectedOwnerId ?>);
+        loadOwnerById(<?= $selectedOwnerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag ?>);
     <?php endif; ?>
 
     // Setup search functionality


### PR DESCRIPTION
## Summary

- Audited all 26 Semgrep `taint-unsafe-echo-tag` findings across four admin include files
- Applied `htmlspecialchars()` wrapping to genuine string output gaps (4 locations)
- Cast `$ownerData->id` to `(int)` and `lat`/`lon` to `(float)` in JS object context
- Added `// nosemgrep: php.lang.security.taint-unsafe-echo-tag` comments to ~20 confirmed integer false positives (all values are `(int)`-cast at assignment)

## Real fixes

| File | Fix |
|------|-----|
| `load-owner-profile.php:69` | `implode($missingFields)` wrapped with `htmlspecialchars()` |
| `load-owner-profile.php:173` | `$ownerData->id` cast to `(int)`; `date()` wrapped with `htmlspecialchars()` |
| `load-owner-profile.php:197–198` | `lat`/`lon` changed from string interpolation to `(float)` cast in JS object |
| `load-owner-info.php:197` | `date()` output wrapped with `htmlspecialchars()` |

## Test plan

- [ ] Load an owner in the admin panel — confirm info and profile panels render correctly
- [ ] Verify lat/lon location picker initializes correctly with numeric values
- [ ] Confirm Semgrep `taint-unsafe-echo-tag` findings resolve or suppress for all four files after CI scan

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)