### PR TITLE
refactor: consolidate documentation portal templates (#350)

### DIFF
--- a/docs/faq/admin/index.php
+++ b/docs/faq/admin/index.php
@@ -2,18 +2,16 @@
 /**
  * Administrative Documentation - Lotus Elan Registry
  *
- * This page displays administrator and technical documentation.
  * Requires administrator privileges to access.
  *
  * @package ElanRegistry
- * @version 2.9.0
- * @author Jim Boone
  */
 
 require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
 
-// Security check - ensure page access is authorized
+use ElanRegistry\Documentation\DocumentPortalTemplate;
+
 if (!securePage($php_self)) {
     die();
 }
@@ -23,201 +21,138 @@ if (!$user->isLoggedIn() || !hasPerm([2], $user->data()->id)) {
     Redirect::to($us_url_root . 'users/login.php');
 }
 
+$carTransferCards = [
+    [
+        'title'       => 'Administrator Guide',
+        'icon'        => 'fa-book',
+        'url'         => '../../view.php?doc=CAR_TRANSFER_ADMIN_GUIDE.md',
+        'buttonText'  => 'Read Guide',
+        'buttonIcon'  => 'fa-book-open',
+        'headerClass' => 'bg-primary text-white',
+        'buttonClass' => 'btn-primary btn-sm',
+        'description' => 'Comprehensive guide for managing car ownership transfer requests, handling disputes, and system administration.',
+        'metadata'    => '8,000+ words • Complete procedures',
+    ],
+    [
+        'title'       => 'Quick Reference',
+        'icon'        => 'fa-tachometer-alt',
+        'url'         => '../../view.php?doc=CAR_TRANSFER_ADMIN_QUICK_REFERENCE.md',
+        'buttonText'  => 'Quick Access',
+        'buttonIcon'  => 'fa-lightning-bolt',
+        'headerClass' => 'bg-success text-white',
+        'buttonClass' => 'btn-success btn-sm',
+        'description' => 'Daily admin tasks, decision trees, emergency procedures, and quick fixes for common transfer issues.',
+        'metadata'    => 'Print-friendly • Mobile-accessible',
+    ],
+    [
+        'title'       => 'Troubleshooting',
+        'icon'        => 'fa-wrench',
+        'url'         => '../../view.php?doc=CAR_TRANSFER_TROUBLESHOOTING.md',
+        'buttonText'  => 'Troubleshoot',
+        'buttonIcon'  => 'fa-tools',
+        'headerClass' => 'bg-warning text-dark',
+        'buttonClass' => 'btn-warning btn-sm',
+        'description' => 'Systematic diagnostic procedures, problem classification, and resolution strategies for transfer system issues.',
+        'metadata'    => '4-level classification • Step-by-step fixes',
+    ],
+];
+
+$technicalCards = [
+    [
+        'title'       => 'Database Schema',
+        'icon'        => 'fa-database',
+        'url'         => '../../view.php?doc=development/DATABASE.md',
+        'buttonText'  => 'View Schema',
+        'buttonIcon'  => 'fa-table',
+        'headerClass' => 'bg-info text-white',
+        'buttonClass' => 'btn-info btn-sm',
+        'description' => 'Complete database documentation including table relationships, indexes, and data integrity constraints.',
+        'metadata'    => 'Schema diagrams • Relationship mapping',
+    ],
+    [
+        'title'       => 'Product Requirements',
+        'icon'        => 'fa-file-contract',
+        'url'         => '../../view.php?doc=PRD.md',
+        'buttonText'  => 'View PRD',
+        'buttonIcon'  => 'fa-clipboard-list',
+        'headerClass' => 'bg-dark text-white',
+        'buttonClass' => 'btn-dark btn-sm',
+        'description' => 'Product Requirements Document (PRD) with feature specifications, business requirements, and system architecture.',
+        'metadata'    => 'Business logic • Feature specs',
+    ],
+    [
+        'title'       => 'Email Guidelines',
+        'icon'        => 'fa-envelope',
+        'url'         => '../../view.php?doc=EMAIL_STYLING_GUIDELINES.md',
+        'buttonText'  => 'View Guidelines',
+        'buttonIcon'  => 'fa-palette',
+        'headerClass' => 'bg-secondary text-white',
+        'buttonClass' => 'btn-secondary btn-sm',
+        'description' => 'Email template styling standards, guidelines for notifications, and best practices for user communication.',
+        'metadata'    => 'Template standards • Communication guidelines',
+    ],
+];
+
+$sysAdminCards = [
+    [
+        'title'       => 'Spam Cleanup System',
+        'icon'        => 'fa-broom',
+        'url'         => '../../view.php?doc=SPAM_CLEANUP_SYSTEM.md',
+        'buttonText'  => 'View System',
+        'buttonIcon'  => 'fa-shield-alt',
+        'headerClass' => 'bg-danger text-white',
+        'buttonClass' => 'btn-danger btn-sm',
+        'description' => 'Automated user cleanup system documentation including criteria, processes, and safety measures for spam account removal.',
+        'metadata'    => 'Automated cleanup • Safety protocols',
+        'colClass'    => 'col-lg-6',
+    ],
+    [
+        'title'       => 'Administrative Tools',
+        'icon'        => 'fa-cogs',
+        'url'         => $us_url_root . 'app/admin/manage-consolidated.php',
+        'buttonText'  => 'Open Admin Panel',
+        'buttonIcon'  => 'fa-external-link-alt',
+        'headerClass' => 'bg-primary text-white',
+        'buttonClass' => 'btn-primary btn-sm',
+        'description' => 'Access to the main administrative interface for managing cars, users, and system operations.',
+        'colClass'    => 'col-lg-6',
+        'listItems'   => [
+            ['icon' => 'fa-check text-success', 'text' => 'Car/Owner Management'],
+            ['icon' => 'fa-check text-success', 'text' => 'Transfer Administration'],
+            ['icon' => 'fa-check text-success', 'text' => 'Data Quality Monitoring'],
+            ['icon' => 'fa-check text-success', 'text' => 'System Reports'],
+        ],
+    ],
+];
+
+$navLinks = [
+    ['label' => 'Registry Home',  'url' => $us_url_root,                    'icon' => 'fa-home',            'btnClass' => 'btn-outline-primary'],
+    ['label' => 'User FAQ',       'url' => '../index.php',                   'icon' => 'fa-question-circle', 'btnClass' => 'btn-outline-info'],
+    ['label' => 'Admin Dashboard', 'url' => $us_url_root . 'app/admin/',     'icon' => 'fa-tools',           'btnClass' => 'btn-outline-success'],
+];
+
 ?>
 <div class="page-wrapper">
-    <!-- Page Content -->
     <div class='container'>
-        <!-- Heading Row -->
-        <div class='row'>
-            <div class='col-12'>
-                <div class='card registry-card'>
-                    <div class='card-header bg-danger text-white'>
-                        <h1 class='mb-0'><i class='fas fa-tools'></i> Administrative Documentation</h1>
-                        <p class='text-muted mb-0'>Technical guides and administrative procedures for registry management</p>
-                    </div>
-                    <div class='card-body'>
-                        <div class="alert alert-warning">
-                            <i class="fas fa-exclamation-triangle"></i> <strong>Administrator Access Required</strong><br>
-                            This documentation is intended for registry administrators and technical staff only.
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <?= DocumentPortalTemplate::renderPortalHeader([
+            'title'       => 'Administrative Documentation',
+            'titleIcon'   => 'fa-tools',
+            'description' => 'Technical guides and administrative procedures for registry management',
+            'headerClass' => 'bg-danger text-white',
+            'isAdmin'     => true,
+        ]) ?>
 
-        <!-- Administrative Documentation -->
-        <div class='row mt-4'>
-            <div class='col-12'>
-                <h2><i class='fas fa-user-shield text-primary'></i> Car Transfer Administration</h2>
-            </div>
-        </div>
+        <?= DocumentPortalTemplate::renderSectionHeading('fa-user-shield', 'Car Transfer Administration', 'text-primary') ?>
+        <?= DocumentPortalTemplate::renderDocumentCardGrid($carTransferCards) ?>
 
-        <div class='row'>
-            <!-- Admin Guide -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-primary text-white'>
-                        <h5 class='mb-0'><i class='fas fa-book'></i> Administrator Guide</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Comprehensive guide for managing car ownership transfer requests, handling disputes, and system administration.</p>
-                        <p class='small text-muted'>8,000+ words • Complete procedures</p>
-                        <div class='mt-auto'>
-                            <a href='../../view.php?doc=CAR_TRANSFER_ADMIN_GUIDE.md' class='btn btn-primary btn-sm'><i class='fas fa-book-open'></i> Read Guide</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
+        <?= DocumentPortalTemplate::renderSectionHeading('fa-code', 'Technical Documentation', 'text-info') ?>
+        <?= DocumentPortalTemplate::renderDocumentCardGrid($technicalCards) ?>
 
-            <!-- Quick Reference -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-success text-white'>
-                        <h5 class='mb-0'><i class='fas fa-tachometer-alt'></i> Quick Reference</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Daily admin tasks, decision trees, emergency procedures, and quick fixes for common transfer issues.</p>
-                        <p class='small text-muted'>Print-friendly • Mobile-accessible</p>
-                        <div class='mt-auto'>
-                            <a href='../../view.php?doc=CAR_TRANSFER_ADMIN_QUICK_REFERENCE.md' class='btn btn-success btn-sm'><i class='fas fa-lightning-bolt'></i> Quick Access</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
+        <?= DocumentPortalTemplate::renderSectionHeading('fa-server', 'System Administration', 'text-danger') ?>
+        <?= DocumentPortalTemplate::renderDocumentCardGrid($sysAdminCards) ?>
 
-            <!-- Troubleshooting -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-warning text-dark'>
-                        <h5 class='mb-0'><i class='fas fa-wrench'></i> Troubleshooting</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Systematic diagnostic procedures, problem classification, and resolution strategies for transfer system issues.</p>
-                        <p class='small text-muted'>4-level classification • Step-by-step fixes</p>
-                        <div class='mt-auto'>
-                            <a href='../../view.php?doc=CAR_TRANSFER_TROUBLESHOOTING.md' class='btn btn-warning btn-sm'><i class='fas fa-tools'></i> Troubleshoot</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <?= DocumentPortalTemplate::renderNavFooter($navLinks) ?>
+    </div>
+</div>
 
-        <!-- Technical Documentation -->
-        <div class='row mt-4'>
-            <div class='col-12'>
-                <h2><i class='fas fa-code text-info'></i> Technical Documentation</h2>
-            </div>
-        </div>
-
-        <div class='row'>
-            <!-- Database Documentation -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-info text-white'>
-                        <h5 class='mb-0'><i class='fas fa-database'></i> Database Schema</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Complete database documentation including table relationships, indexes, and data integrity constraints.</p>
-                        <p class='small text-muted'>Schema diagrams • Relationship mapping</p>
-                        <div class='mt-auto'>
-                            <a href='../../view.php?doc=development/DATABASE.md' class='btn btn-info btn-sm'><i class='fas fa-table'></i> View Schema</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Product Requirements -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-dark text-white'>
-                        <h5 class='mb-0'><i class='fas fa-file-contract'></i> Product Requirements</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Product Requirements Document (PRD) with feature specifications, business requirements, and system architecture.</p>
-                        <p class='small text-muted'>Business logic • Feature specs</p>
-                        <div class='mt-auto'>
-                            <a href='../../view.php?doc=PRD.md' class='btn btn-dark btn-sm'><i class='fas fa-clipboard-list'></i> View PRD</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Email Guidelines -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-secondary text-white'>
-                        <h5 class='mb-0'><i class='fas fa-envelope'></i> Email Guidelines</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Email template styling standards, guidelines for notifications, and best practices for user communication.</p>
-                        <p class='small text-muted'>Template standards • Communication guidelines</p>
-                        <div class='mt-auto'>
-                            <a href='../../view.php?doc=EMAIL_STYLING_GUIDELINES.md' class='btn btn-secondary btn-sm'><i class='fas fa-palette'></i> View Guidelines</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- System Administration -->
-        <div class='row mt-4'>
-            <div class='col-12'>
-                <h2><i class='fas fa-server text-danger'></i> System Administration</h2>
-            </div>
-        </div>
-
-        <div class='row'>
-            <!-- Spam Cleanup -->
-            <div class='col-lg-6 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-danger text-white'>
-                        <h5 class='mb-0'><i class='fas fa-broom'></i> Spam Cleanup System</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Automated user cleanup system documentation including criteria, processes, and safety measures for spam account removal.</p>
-                        <p class='small text-muted'>Automated cleanup • Safety protocols</p>
-                        <div class='mt-auto'>
-                            <a href='../../view.php?doc=SPAM_CLEANUP_SYSTEM.md' class='btn btn-danger btn-sm'><i class='fas fa-shield-alt'></i> View System</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Admin Tools -->
-            <div class='col-lg-6 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-primary text-white'>
-                        <h5 class='mb-0'><i class='fas fa-cogs'></i> Administrative Tools</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Access to the main administrative interface for managing cars, users, and system operations.</p>
-                        <ul class='list-unstyled small'>
-                            <li><i class='fas fa-check text-success'></i> Car/Owner Management</li>
-                            <li><i class='fas fa-check text-success'></i> Transfer Administration</li>
-                            <li><i class='fas fa-check text-success'></i> Data Quality Monitoring</li>
-                            <li><i class='fas fa-check text-success'></i> System Reports</li>
-                        </ul>
-                        <div class='mt-auto'>
-                            <a href='<?= $us_url_root ?>app/admin/manage-consolidated.php' class='btn btn-primary btn-sm'><i class='fas fa-external-link-alt'></i> Open Admin Panel</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Navigation Links -->
-        <div class='row mt-4 mb-4'>
-            <div class='col-12 text-center'>
-                <a href='<?= $us_url_root ?>' class='btn btn-outline-primary mr-2'><i class='fas fa-home'></i> Registry Home</a>
-                <a href='../index.php' class='btn btn-outline-info mr-2'><i class='fas fa-question-circle'></i> User FAQ</a>
-                <a href='<?= $us_url_root ?>app/admin/' class='btn btn-outline-success'><i class='fas fa-tools'></i> Admin Dashboard</a>
-            </div>
-        </div>
-
-    </div> <!-- /.container -->
-</div><!-- .page-wrapper -->
-
-<!-- footers -->
-<?php
-require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //custom template footer
-?>
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/docs/faq/index.php
+++ b/docs/faq/index.php
@@ -2,165 +2,117 @@
 /**
  * FAQ and User Documentation - Lotus Elan Registry
  *
- * This page displays user-facing documentation including guides, FAQ, and policies.
- *
  * @package ElanRegistry
- * @version 2.9.0
- * @author Jim Boone
  */
 
 require_once '../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
 
-// Security check - ensure page access is authorized
+use ElanRegistry\Documentation\DocumentPortalTemplate;
+
 if (!securePage($php_self)) {
     die();
 }
 
+$cards = [
+    [
+        'title'       => 'How to Add Your Car',
+        'icon'        => 'fa-car',
+        'url'         => '../view.php?doc=ADD_CAR_GUIDE.md',
+        'buttonText'  => 'Read Guide',
+        'buttonIcon'  => 'fa-book-open',
+        'headerClass' => 'bg-success text-white',
+        'buttonClass' => 'btn-success btn-sm',
+        'description' => "Step-by-step guide to registering your Lotus Elan or +2. Learn about chassis validation, photo uploads, and completing your car's profile.",
+    ],
+    [
+        'title'       => 'Identification Guide',
+        'icon'        => 'fa-search',
+        'url'         => '../view.php?doc=IDENTIFICATION_GUIDE.md',
+        'buttonText'  => 'View Guide',
+        'buttonIcon'  => 'fa-book-open',
+        'headerClass' => 'bg-danger text-white',
+        'buttonClass' => 'btn-danger btn-sm',
+        'description' => 'Complete guide to identifying different Lotus Elan models and variants. Includes detailed descriptions and photos of Roadster, Coupe, Racing, and Plus 2 models.',
+    ],
+    [
+        'title'       => 'Chassis Validation Rules',
+        'icon'        => 'fa-barcode',
+        'url'         => '../chassis-validation.php',
+        'buttonText'  => 'View Rules',
+        'buttonIcon'  => 'fa-book-open',
+        'headerClass' => 'bg-warning text-dark',
+        'buttonClass' => 'btn-warning btn-sm',
+        'description' => 'Comprehensive guide to Lotus Elan chassis numbering formats and validation requirements. Detailed specifications for pre-1970, 1970 transition, and post-1970 formats.',
+    ],
+    [
+        'title'       => 'Car Transfer Guide',
+        'icon'        => 'fa-exchange-alt',
+        'url'         => '../view.php?doc=CAR_TRANSFER_USER_GUIDE.md',
+        'buttonText'  => 'Read Guide',
+        'buttonIcon'  => 'fa-book-open',
+        'headerClass' => 'bg-primary text-white',
+        'buttonClass' => 'btn-primary btn-sm',
+        'description' => 'Complete guide for requesting ownership transfers of cars in the registry. Learn the step-by-step process and what to expect.',
+    ],
+    [
+        'title'       => 'Transfer FAQ',
+        'icon'        => 'fa-question',
+        'url'         => '../view.php?doc=CAR_TRANSFER_FAQ.md',
+        'buttonText'  => 'View FAQ',
+        'buttonIcon'  => 'fa-question-circle',
+        'headerClass' => 'bg-info text-white',
+        'buttonClass' => 'btn-info btn-sm',
+        'description' => 'Frequently asked questions about car ownership transfers, common issues, and quick solutions.',
+    ],
+    [
+        'title'       => 'Paint Colors Guide',
+        'icon'        => 'fa-palette',
+        'url'         => 'paint-colors.php',
+        'buttonText'  => 'View Guide',
+        'buttonIcon'  => 'fa-book-open',
+        'headerClass' => 'bg-danger text-white',
+        'headerStyle' => 'background-color: #8e44ad !important;',
+        'buttonClass' => 'btn-sm',
+        'buttonStyle' => 'background-color: #8e44ad; color: white;',
+        'description' => 'Complete reference to Lotus Elan and Plus 2 factory paint colors, codes, date ranges, and supplier cross-references for restoration.',
+    ],
+    [
+        'title'       => 'Privacy Policy',
+        'icon'        => 'fa-shield-alt',
+        'url'         => '../view.php?doc=PRIVACY.md',
+        'buttonText'  => 'Read Policy',
+        'buttonIcon'  => 'fa-file-alt',
+        'headerClass' => 'bg-dark text-white',
+        'buttonClass' => 'btn-dark btn-sm',
+        'description' => 'Our privacy policy explaining how we collect, use, and protect your personal information in the registry.',
+    ],
+];
+
+// Build nav links — conditional on login state
+$navLinks = [
+    ['label' => 'Registry Home', 'url' => $us_url_root,               'icon' => 'fa-home', 'btnClass' => 'btn-outline-primary'],
+    ['label' => 'Browse Cars',   'url' => $us_url_root . 'app/cars/', 'icon' => 'fa-car',  'btnClass' => 'btn-outline-success'],
+];
+
+if ($user->isLoggedIn()) {
+    $navLinks[] = ['label' => 'My Account', 'url' => $us_url_root . 'users/account.php', 'icon' => 'fa-user',        'btnClass' => 'btn-outline-info'];
+} else {
+    $navLinks[] = ['label' => 'Login',      'url' => $us_url_root . 'users/login.php',   'icon' => 'fa-sign-in-alt', 'btnClass' => 'btn-outline-warning'];
+}
+
 ?>
 <div class="page-wrapper">
-    <!-- Page Content -->
     <div class='container'>
-        <!-- Heading Row -->
-        <div class='row'>
-            <div class='col-12'>
-                <div class='card registry-card'>
-                    <div class='card-header'>
-                        <h1 class='mb-0'><i class='fas fa-question-circle'></i> FAQ & User Guides</h1>
-                        <p class='text-muted'>Documentation and guides for using the Lotus Elan Registry</p>
-                    </div>
-                    <div class='card-body'>
-                        <p class="lead">Find answers to common questions and learn how to use the registry effectively.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <?= DocumentPortalTemplate::renderPortalHeader([
+            'title'       => 'FAQ & User Guides',
+            'titleIcon'   => 'fa-question-circle',
+            'description' => 'Documentation and guides for using the Lotus Elan Registry',
+            'leadText'    => 'Find answers to common questions and learn how to use the registry effectively.',
+        ]) ?>
+        <?= DocumentPortalTemplate::renderDocumentCardGrid($cards) ?>
+        <?= DocumentPortalTemplate::renderNavFooter($navLinks) ?>
+    </div>
+</div>
 
-        <!-- Documentation Cards -->
-        <div class='row mt-4'>
-            <!-- Add Car Guide -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-success text-white'>
-                        <h5 class='mb-0'><i class='fas fa-car'></i> How to Add Your Car</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Step-by-step guide to registering your Lotus Elan or +2. Learn about chassis validation, photo uploads, and completing your car's profile.</p>
-                        <div class='mt-auto'>
-                            <a href='../view.php?doc=ADD_CAR_GUIDE.md' class='btn btn-success btn-sm'><i class='fas fa-book-open'></i> Read Guide</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Identification Guide -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-danger text-white'>
-                        <h5 class='mb-0'><i class='fas fa-search'></i> Identification Guide</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Complete guide to identifying different Lotus Elan models and variants. Includes detailed descriptions and photos of Roadster, Coupe, Racing, and Plus 2 models.</p>
-                        <div class='mt-auto'>
-                            <a href='../view.php?doc=IDENTIFICATION_GUIDE.md' class='btn btn-danger btn-sm'><i class='fas fa-book-open'></i> View Guide</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Chassis Validation Rules -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-warning text-dark'>
-                        <h5 class='mb-0'><i class='fas fa-barcode'></i> Chassis Validation Rules</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Comprehensive guide to Lotus Elan chassis numbering formats and validation requirements. Detailed specifications for pre-1970, 1970 transition, and post-1970 formats.</p>
-                        <div class='mt-auto'>
-                            <a href='../chassis-validation.php' class='btn btn-warning btn-sm'><i class='fas fa-book-open'></i> View Rules</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Car Transfer User Guide -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-primary text-white'>
-                        <h5 class='mb-0'><i class='fas fa-exchange-alt'></i> Car Transfer Guide</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Complete guide for requesting ownership transfers of cars in the registry. Learn the step-by-step process and what to expect.</p>
-                        <div class='mt-auto'>
-                            <a href='../view.php?doc=CAR_TRANSFER_USER_GUIDE.md' class='btn btn-primary btn-sm'><i class='fas fa-book-open'></i> Read Guide</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Transfer FAQ -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-info text-white'>
-                        <h5 class='mb-0'><i class='fas fa-question'></i> Transfer FAQ</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Frequently asked questions about car ownership transfers, common issues, and quick solutions.</p>
-                        <div class='mt-auto'>
-                            <a href='../view.php?doc=CAR_TRANSFER_FAQ.md' class='btn btn-info btn-sm'><i class='fas fa-question-circle'></i> View FAQ</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Paint Colors Guide -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-danger text-white' style='background-color: #8e44ad !important;'>
-                        <h5 class='mb-0'><i class='fas fa-palette'></i> Paint Colors Guide</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Complete reference to Lotus Elan and Plus 2 factory paint colors, codes, date ranges, and supplier cross-references for restoration.</p>
-                        <div class='mt-auto'>
-                            <a href='paint-colors.php' class='btn btn-sm' style='background-color: #8e44ad; color: white;'><i class='fas fa-book-open'></i> View Guide</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Privacy Policy -->
-            <div class='col-lg-4 mb-4'>
-                <div class='card registry-card h-100'>
-                    <div class='card-header bg-dark text-white'>
-                        <h5 class='mb-0'><i class='fas fa-shield-alt'></i> Privacy Policy</h5>
-                    </div>
-                    <div class='card-body d-flex flex-column'>
-                        <p class='card-text'>Our privacy policy explaining how we collect, use, and protect your personal information in the registry.</p>
-                        <div class='mt-auto'>
-                            <a href='../view.php?doc=PRIVACY.md' class='btn btn-dark btn-sm'><i class='fas fa-file-alt'></i> Read Policy</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Navigation Links -->
-        <div class='row mt-4 mb-4'>
-            <div class='col-12 text-center'>
-                <a href='<?= $us_url_root ?>' class='btn btn-outline-primary mr-2'><i class='fas fa-home'></i> Registry Home</a>
-                <a href='<?= $us_url_root ?>app/cars/' class='btn btn-outline-success mr-2'><i class='fas fa-car'></i> Browse Cars</a>
-                <?php if ($user->isLoggedIn()) { ?>
-                    <a href='<?= $us_url_root ?>users/account.php' class='btn btn-outline-info'><i class='fas fa-user'></i> My Account</a>
-                <?php } else { ?>
-                    <a href='<?= $us_url_root ?>users/login.php' class='btn btn-outline-warning'><i class='fas fa-sign-in-alt'></i> Login</a>
-                <?php } ?>
-            </div>
-        </div>
-
-    </div> <!-- /.container -->
-</div><!-- .page-wrapper -->
-
-<!-- footers -->
-<?php
-require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //custom template footer
-?>
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/docs/index.php
+++ b/docs/index.php
@@ -9,9 +9,48 @@
 require_once '../users/init.php';
 require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
 
+use ElanRegistry\Documentation\DocumentPortalTemplate;
+
 if (!securePage($php_self)) {
     die();
 }
+
+$portalCards = [
+    [
+        'title'       => 'Reference Library',
+        'icon'        => 'fa-book',
+        'url'         => 'reference-library.php',
+        'buttonText'  => 'View Reference Library',
+        'buttonIcon'  => 'fa-arrow-right',
+        'headerClass' => 'bg-primary text-white',
+        'buttonClass' => 'btn-primary',
+        'cardClass'   => 'border-primary',
+        'description' => 'Technical documentation, workshop manuals, parts lists, and owner guides. Everything you need for maintenance and restoration.',
+        'listItems'   => [
+            ['icon' => 'fa-wrench text-primary',  'text' => 'Workshop Manuals'],
+            ['icon' => 'fa-cogs text-primary',    'text' => 'Parts Lists'],
+            ['icon' => 'fa-tools text-primary',   'text' => 'Technical Guides'],
+            ['icon' => 'fa-barcode text-primary', 'text' => 'Chassis Validation'],
+        ],
+    ],
+    [
+        'title'       => 'Car Stories',
+        'icon'        => 'fa-book-open',
+        'url'         => 'car-stories.php',
+        'buttonText'  => 'Read Car Stories',
+        'buttonIcon'  => 'fa-arrow-right',
+        'headerClass' => 'bg-success text-white',
+        'buttonClass' => 'btn-success',
+        'cardClass'   => 'border-success',
+        'description' => 'Individual car histories, owner stories, and community articles. Discover the unique tales behind registry vehicles.',
+        'listItems'   => [
+            ['icon' => 'fa-history text-success',   'text' => 'Individual Car Histories'],
+            ['icon' => 'fa-users text-success',     'text' => 'Owner Stories'],
+            ['icon' => 'fa-newspaper text-success', 'text' => 'Magazine Articles'],
+            ['icon' => 'fa-archive text-success',   'text' => 'Historical Archives'],
+        ],
+    ],
+];
 
 ?>
 <div class="page-wrapper">
@@ -24,64 +63,14 @@ if (!securePage($php_self)) {
                             <p class="text-muted">Our documentation has been reorganized for better navigation</p>
                         </div>
                         <div class="card-body">
-                            
+
                             <div class="alert alert-info mb-4">
                                 <i class="fas fa-info-circle"></i>
-                                <strong>Updated Organization:</strong> We've split our documentation into focused sections 
+                                <strong>Updated Organization:</strong> We've split our documentation into focused sections
                                 to make it easier to find what you're looking for.
                             </div>
 
-                            <div class="row">
-                                <div class="col-md-6 mb-4">
-                                    <div class="card border-primary">
-                                        <div class="card-header bg-primary text-white">
-                                            <h5 class="mb-0">
-                                                <i class="fas fa-book"></i> Reference Library
-                                            </h5>
-                                        </div>
-                                        <div class="card-body">
-                                            <p class="card-text">
-                                                Technical documentation, workshop manuals, parts lists, and owner guides. 
-                                                Everything you need for maintenance and restoration.
-                                            </p>
-                                            <ul class="list-unstyled">
-                                                <li><i class="fas fa-wrench text-primary"></i> Workshop Manuals</li>
-                                                <li><i class="fas fa-cogs text-primary"></i> Parts Lists</li>
-                                                <li><i class="fas fa-tools text-primary"></i> Technical Guides</li>
-                                                <li><i class="fas fa-barcode text-primary"></i> Chassis Validation</li>
-                                            </ul>
-                                            <a href="reference-library.php" class="btn btn-primary">
-                                                <i class="fas fa-arrow-right"></i> View Reference Library
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="col-md-6 mb-4">
-                                    <div class="card border-success">
-                                        <div class="card-header bg-success text-white">
-                                            <h5 class="mb-0">
-                                                <i class="fas fa-book-open"></i> Car Stories
-                                            </h5>
-                                        </div>
-                                        <div class="card-body">
-                                            <p class="card-text">
-                                                Individual car histories, owner stories, and community articles. 
-                                                Discover the unique tales behind registry vehicles.
-                                            </p>
-                                            <ul class="list-unstyled">
-                                                <li><i class="fas fa-history text-success"></i> Individual Car Histories</li>
-                                                <li><i class="fas fa-users text-success"></i> Owner Stories</li>
-                                                <li><i class="fas fa-newspaper text-success"></i> Magazine Articles</li>
-                                                <li><i class="fas fa-archive text-success"></i> Historical Archives</li>
-                                            </ul>
-                                            <a href="car-stories.php" class="btn btn-success">
-                                                <i class="fas fa-arrow-right"></i> Read Car Stories
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            <?= DocumentPortalTemplate::renderDocumentCardGrid($portalCards, 'col-md-6') ?>
 
                             <!-- Quick Access Links -->
                             <div class="mt-4">

--- a/tests/unit/classes/DocumentPortalTemplateTest.php
+++ b/tests/unit/classes/DocumentPortalTemplateTest.php
@@ -1,0 +1,537 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use ElanRegistry\Documentation\DocumentPortalTemplate;
+
+/**
+ * DocumentPortalTemplate class tests
+ *
+ * Tests static rendering utilities for documentation portal pages.
+ *
+ * @group fast
+ * @group documentation
+ */
+final class DocumentPortalTemplateTest extends TestCase
+{
+    // ============================================================
+    // renderPortalHeader TESTS
+    // ============================================================
+
+    public function testRenderPortalHeaderContainsTitleAndDescription(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'Portal Title',
+            'description' => 'Portal description text',
+        ]);
+
+        $this->assertStringContainsString('Portal Title', $html);
+        $this->assertStringContainsString('Portal description text', $html);
+    }
+
+    public function testRenderPortalHeaderAppliesHeaderClass(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'Title',
+            'description' => 'Desc',
+            'headerClass' => 'bg-danger',
+        ]);
+
+        $this->assertStringContainsString('card-header bg-danger', $html);
+    }
+
+    public function testRenderPortalHeaderShowsLeadTextWhenProvided(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'Title',
+            'description' => 'Desc',
+            'leadText' => 'This is lead text',
+        ]);
+
+        $this->assertStringContainsString("class='lead'", $html);
+        $this->assertStringContainsString('This is lead text', $html);
+    }
+
+    public function testRenderPortalHeaderOmitsLeadTextWhenAbsent(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'Title',
+            'description' => 'Desc',
+        ]);
+
+        $this->assertStringNotContainsString("class='lead'", $html);
+    }
+
+    public function testRenderPortalHeaderShowsAdminBannerWhenIsAdminTrue(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'Title',
+            'description' => 'Desc',
+            'isAdmin' => true,
+        ]);
+
+        $this->assertStringContainsString('alert-warning', $html);
+        $this->assertStringContainsString('Administrator Access Required', $html);
+    }
+
+    public function testRenderPortalHeaderHidesAdminBannerByDefault(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'Title',
+            'description' => 'Desc',
+        ]);
+
+        $this->assertStringNotContainsString('alert-warning', $html);
+    }
+
+    public function testRenderPortalHeaderEscapesTitle(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => '<script>alert("xss")</script>',
+            'description' => 'Desc',
+        ]);
+
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
+    public function testRenderPortalHeaderShowsTitleIconWhenProvided(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'FAQ & User Guides',
+            'description' => 'Desc',
+            'titleIcon' => 'fa-question-circle',
+        ]);
+
+        $this->assertStringContainsString("<i class='fas fa-question-circle'></i>", $html);
+        $this->assertStringContainsString("<h1 class='mb-0'><i class='fas fa-question-circle'></i> FAQ &amp; User Guides</h1>", $html);
+    }
+
+    public function testRenderPortalHeaderOmitsTitleIconWhenAbsent(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'Title',
+            'description' => 'Desc',
+        ]);
+
+        $this->assertStringNotContainsString("<i class='fas", $html);
+    }
+
+    public function testRenderPortalHeaderThrowsOnMissingTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DocumentPortalTemplate::renderPortalHeader([
+            'description' => 'Desc',
+        ]);
+    }
+
+    public function testRenderPortalHeaderThrowsOnMissingDescription(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DocumentPortalTemplate::renderPortalHeader([
+            'title' => 'Title',
+        ]);
+    }
+
+    // ============================================================
+    // renderDocumentCard TESTS
+    // ============================================================
+
+    public function testRenderDocumentCardContainsTitle(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Card Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+        ]);
+
+        $this->assertStringContainsString('Card Title', $html);
+        $this->assertStringContainsString('<h5', $html);
+    }
+
+    public function testRenderDocumentCardContainsIcon(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+        ]);
+
+        $this->assertStringContainsString('fas fa-car', $html);
+    }
+
+    public function testRenderDocumentCardContainsLink(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/docs/page',
+            'buttonText' => 'View',
+        ]);
+
+        $this->assertStringContainsString("href='/docs/page'", $html);
+    }
+
+    public function testRenderDocumentCardContainsButtonText(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'Open Document',
+        ]);
+
+        $this->assertStringContainsString('Open Document', $html);
+    }
+
+    public function testRenderDocumentCardAppliesHeaderClass(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'headerClass' => 'bg-success text-white',
+        ]);
+
+        $this->assertStringContainsString('card-header bg-success text-white', $html);
+    }
+
+    public function testRenderDocumentCardAppliesButtonClass(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'buttonClass' => 'btn-danger btn-lg',
+        ]);
+
+        $this->assertStringContainsString('btn btn-danger btn-lg', $html);
+    }
+
+    public function testRenderDocumentCardAppliesCustomCardClass(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'cardClass' => 'custom-card-class',
+        ]);
+
+        $this->assertStringContainsString('custom-card-class', $html);
+        $this->assertStringNotContainsString('registry-card', $html);
+    }
+
+    public function testRenderDocumentCardUsesDefaultCardClass(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+        ]);
+
+        $this->assertStringContainsString('registry-card', $html);
+    }
+
+    public function testRenderDocumentCardShowsDescriptionWhenProvided(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'description' => 'A detailed description',
+        ]);
+
+        $this->assertStringContainsString('card-text', $html);
+        $this->assertStringContainsString('A detailed description', $html);
+    }
+
+    public function testRenderDocumentCardOmitsDescriptionWhenAbsent(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+        ]);
+
+        $this->assertStringNotContainsString('card-text', $html);
+    }
+
+    public function testRenderDocumentCardShowsMetadataWhenProvided(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'metadata' => 'Last updated: 2024-01-01',
+        ]);
+
+        $this->assertStringContainsString('small text-muted', $html);
+        $this->assertStringContainsString('Last updated: 2024-01-01', $html);
+    }
+
+    public function testRenderDocumentCardRendersListItems(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'listItems' => [
+                ['icon' => 'fa-check', 'text' => 'Item one'],
+                ['icon' => 'fa-star', 'text' => 'Item two'],
+            ],
+        ]);
+
+        $this->assertStringContainsString('list-unstyled', $html);
+        $this->assertStringContainsString('Item one', $html);
+        $this->assertStringContainsString('Item two', $html);
+        $this->assertStringContainsString('fas fa-check', $html);
+        $this->assertStringContainsString('fas fa-star', $html);
+    }
+
+    public function testRenderDocumentCardOmitsListWhenEmpty(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+        ]);
+
+        $this->assertStringNotContainsString('list-unstyled', $html);
+    }
+
+    public function testRenderDocumentCardAppliesHeaderStyle(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'headerStyle' => 'background-color: #ff0000',
+        ]);
+
+        $this->assertStringContainsString("style='background-color: #ff0000'", $html);
+    }
+
+    public function testRenderDocumentCardAppliesButtonStyle(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'buttonStyle' => 'min-width: 120px',
+        ]);
+
+        $this->assertStringContainsString("style='min-width: 120px'", $html);
+    }
+
+    public function testRenderDocumentCardRendersButtonIcon(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+            'buttonIcon' => 'fa-arrow-right',
+        ]);
+
+        $this->assertStringContainsString('fas fa-arrow-right', $html);
+    }
+
+    public function testRenderDocumentCardEscapesTitle(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title' => '<script>xss</script>',
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+        ]);
+
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
+    public function testRenderDocumentCardThrowsOnMissingTitle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DocumentPortalTemplate::renderDocumentCard([
+            'icon' => 'fa-car',
+            'url' => '/test',
+            'buttonText' => 'View',
+        ]);
+    }
+
+    // ============================================================
+    // renderDocumentCardGrid TESTS
+    // ============================================================
+
+    public function testRenderDocumentCardGridWrapsInRow(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCardGrid([
+            ['title' => 'T', 'icon' => 'fa-car', 'url' => '/', 'buttonText' => 'V'],
+        ]);
+
+        $this->assertStringContainsString("class='row", $html);
+    }
+
+    public function testRenderDocumentCardGridAppliesDefaultColClass(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCardGrid([
+            ['title' => 'T', 'icon' => 'fa-car', 'url' => '/', 'buttonText' => 'V'],
+        ]);
+
+        $this->assertStringContainsString('col-lg-4', $html);
+    }
+
+    public function testRenderDocumentCardGridAppliesCustomColClass(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCardGrid(
+            [['title' => 'T', 'icon' => 'fa-car', 'url' => '/', 'buttonText' => 'V']],
+            'col-md-6'
+        );
+
+        $this->assertStringContainsString('col-md-6', $html);
+    }
+
+    public function testRenderDocumentCardGridPerCardColClassOverride(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCardGrid([
+            ['title' => 'T', 'icon' => 'fa-car', 'url' => '/', 'buttonText' => 'V', 'colClass' => 'col-lg-6'],
+        ]);
+
+        $this->assertStringContainsString('col-lg-6', $html);
+        $this->assertStringNotContainsString('col-lg-4', $html);
+    }
+
+    public function testRenderDocumentCardGridReturnsEmptyStringForEmptyArray(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCardGrid([]);
+
+        $this->assertSame('', $html);
+    }
+
+    // ============================================================
+    // renderSectionHeading TESTS
+    // ============================================================
+
+    public function testRenderSectionHeadingContainsTitle(): void
+    {
+        $html = DocumentPortalTemplate::renderSectionHeading('fa-code', 'Developer Tools');
+
+        $this->assertStringContainsString('Developer Tools', $html);
+    }
+
+    public function testRenderSectionHeadingContainsIcon(): void
+    {
+        $html = DocumentPortalTemplate::renderSectionHeading('fa-code', 'Title');
+
+        $this->assertStringContainsString('fas fa-code', $html);
+    }
+
+    public function testRenderSectionHeadingAppliesColorClass(): void
+    {
+        $html = DocumentPortalTemplate::renderSectionHeading('fa-code', 'Title', 'text-danger');
+
+        $this->assertStringContainsString('fas fa-code text-danger', $html);
+    }
+
+    public function testRenderSectionHeadingOmitsColorClassWhenEmpty(): void
+    {
+        $html = DocumentPortalTemplate::renderSectionHeading('fa-code', 'Title');
+
+        $this->assertStringContainsString("class='fas fa-code'", $html);
+        $this->assertStringNotContainsString('text-danger', $html);
+    }
+
+    public function testRenderSectionHeadingEscapesTitle(): void
+    {
+        $html = DocumentPortalTemplate::renderSectionHeading('fa-code', '<script>xss</script>');
+
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
+    // ============================================================
+    // renderNavFooter TESTS
+    // ============================================================
+
+    public function testRenderNavFooterRendersLinks(): void
+    {
+        $html = DocumentPortalTemplate::renderNavFooter([
+            ['label' => 'Home', 'url' => '/'],
+            ['label' => 'Docs', 'url' => '/docs'],
+        ]);
+
+        $this->assertStringContainsString('Home', $html);
+        $this->assertStringContainsString('Docs', $html);
+        $this->assertStringContainsString("href='/'", $html);
+        $this->assertStringContainsString("href='/docs'", $html);
+    }
+
+    public function testRenderNavFooterRendersIcon(): void
+    {
+        $html = DocumentPortalTemplate::renderNavFooter([
+            ['label' => 'Home', 'url' => '/', 'icon' => 'fa-home'],
+        ]);
+
+        $this->assertStringContainsString('fas fa-home', $html);
+    }
+
+    public function testRenderNavFooterOmitsIconWhenAbsent(): void
+    {
+        $html = DocumentPortalTemplate::renderNavFooter([
+            ['label' => 'Home', 'url' => '/'],
+        ]);
+
+        $this->assertStringNotContainsString('fas', $html);
+    }
+
+    public function testRenderNavFooterAppliesBtnClass(): void
+    {
+        $html = DocumentPortalTemplate::renderNavFooter([
+            ['label' => 'Home', 'url' => '/', 'btnClass' => 'btn-success'],
+        ]);
+
+        $this->assertStringContainsString('btn btn-success', $html);
+    }
+
+    public function testRenderNavFooterReturnsEmptyStringForEmptyArray(): void
+    {
+        $html = DocumentPortalTemplate::renderNavFooter([]);
+
+        $this->assertSame('', $html);
+    }
+
+    public function testRenderNavFooterThrowsOnMissingLabel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DocumentPortalTemplate::renderNavFooter([
+            ['url' => '/'],
+        ]);
+    }
+
+    public function testRenderNavFooterThrowsOnMissingUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DocumentPortalTemplate::renderNavFooter([
+            ['label' => 'Home'],
+        ]);
+    }
+}

--- a/tests/unit/classes/DocumentPortalTemplateTest.php
+++ b/tests/unit/classes/DocumentPortalTemplateTest.php
@@ -118,6 +118,18 @@ final class DocumentPortalTemplateTest extends TestCase
         $this->assertStringNotContainsString("<i class='fas", $html);
     }
 
+    public function testRenderPortalHeaderEscapesLeadText(): void
+    {
+        $html = DocumentPortalTemplate::renderPortalHeader([
+            'title'       => 'Title',
+            'description' => 'Desc',
+            'leadText'    => '<script>xss</script>',
+        ]);
+
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
     public function testRenderPortalHeaderThrowsOnMissingTitle(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -365,14 +377,75 @@ final class DocumentPortalTemplateTest extends TestCase
         $this->assertStringNotContainsString('<script>', $html);
     }
 
+    public function testRenderDocumentCardEscapesDescription(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title'       => 'Title',
+            'icon'        => 'fa-car',
+            'url'         => '/test',
+            'buttonText'  => 'View',
+            'description' => '<script>xss</script>',
+        ]);
+
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
+    public function testRenderDocumentCardEscapesMetadata(): void
+    {
+        $html = DocumentPortalTemplate::renderDocumentCard([
+            'title'      => 'Title',
+            'icon'       => 'fa-car',
+            'url'        => '/test',
+            'buttonText' => 'View',
+            'metadata'   => '<b onmouseover="evil()">metadata</b>',
+        ]);
+
+        $this->assertStringNotContainsString('<b ', $html);
+        $this->assertStringContainsString('&lt;b ', $html);
+    }
+
     public function testRenderDocumentCardThrowsOnMissingTitle(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         DocumentPortalTemplate::renderDocumentCard([
-            'icon' => 'fa-car',
-            'url' => '/test',
+            'icon'       => 'fa-car',
+            'url'        => '/test',
             'buttonText' => 'View',
+        ]);
+    }
+
+    public function testRenderDocumentCardThrowsOnMissingIcon(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DocumentPortalTemplate::renderDocumentCard([
+            'title'      => 'Title',
+            'url'        => '/test',
+            'buttonText' => 'View',
+        ]);
+    }
+
+    public function testRenderDocumentCardThrowsOnMissingUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DocumentPortalTemplate::renderDocumentCard([
+            'title'      => 'Title',
+            'icon'       => 'fa-car',
+            'buttonText' => 'View',
+        ]);
+    }
+
+    public function testRenderDocumentCardThrowsOnMissingButtonText(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        DocumentPortalTemplate::renderDocumentCard([
+            'title' => 'Title',
+            'icon'  => 'fa-car',
+            'url'   => '/test',
         ]);
     }
 

--- a/usersc/classes/DocumentPortalTemplate.php
+++ b/usersc/classes/DocumentPortalTemplate.php
@@ -98,7 +98,8 @@ class DocumentPortalTemplate
      *     listItems?: list<array{icon: string, text: string}>,
      *     buttonIcon?: string,
      *     headerStyle?: string,
-     *     buttonStyle?: string
+     *     buttonStyle?: string,
+     *     colClass?: string
      * } $card
      * @throws \InvalidArgumentException if required keys are missing
      */
@@ -133,7 +134,8 @@ class DocumentPortalTemplate
 
         if (!empty($card['listItems'])) {
             $html .= "<ul class='list-unstyled'>";
-            foreach ($card['listItems'] as $item) {
+            foreach ($card['listItems'] as $index => $item) {
+                self::requireKeys($item, ['icon', 'text'], "renderDocumentCard listItems[{$index}]");
                 $itemText  = htmlspecialchars($item['text'], ENT_QUOTES, 'UTF-8');
                 $html     .= "<li>" . self::renderIcon($item['icon']) . "{$itemText}</li>";
             }

--- a/usersc/classes/DocumentPortalTemplate.php
+++ b/usersc/classes/DocumentPortalTemplate.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Documentation Portal Template
+ *
+ * Static rendering utilities for documentation portal pages.
+ * Eliminates duplicated Bootstrap card/grid HTML across portal index pages.
+ *
+ * @package ElanRegistry\Documentation
+ */
+
+namespace ElanRegistry\Documentation;
+
+class DocumentPortalTemplate
+{
+    /** @var list<string> */
+    private const REQUIRED_HEADER_KEYS = ['title', 'description'];
+
+    /** @var list<string> */
+    private const REQUIRED_CARD_KEYS = ['title', 'icon', 'url', 'buttonText'];
+
+    /** @var list<string> */
+    private const REQUIRED_LINK_KEYS = ['label', 'url'];
+
+    private const DEFAULT_CARD_CLASS   = 'registry-card h-100';
+    private const DEFAULT_HEADER_CLASS = 'bg-primary text-white';
+    private const DEFAULT_BUTTON_CLASS = 'btn-primary btn-sm';
+    private const DEFAULT_BTN_CLASS    = 'btn-outline-primary';
+    private const DEFAULT_COL_CLASS    = 'col-lg-4';
+
+    /**
+     * Render the portal heading card (page title + description).
+     *
+     * @param array{
+     *     title: string,
+     *     description: string,
+     *     titleIcon?: string,
+     *     headerClass?: string,
+     *     leadText?: string,
+     *     isAdmin?: bool
+     * } $config
+     * @throws \InvalidArgumentException if required keys are missing
+     */
+    public static function renderPortalHeader(array $config): string
+    {
+        self::requireKeys($config, self::REQUIRED_HEADER_KEYS, 'renderPortalHeader');
+
+        $title       = htmlspecialchars($config['title'], ENT_QUOTES, 'UTF-8');
+        $description = htmlspecialchars($config['description'], ENT_QUOTES, 'UTF-8');
+        $headerClass = isset($config['headerClass'])
+            ? ' ' . htmlspecialchars($config['headerClass'], ENT_QUOTES, 'UTF-8')
+            : '';
+
+        $html  = "<div class='row'>";
+        $html .= "<div class='col-12'>";
+        $html .= "<div class='card registry-card'>";
+        $html .= "<div class='card-header{$headerClass}'>";
+        $html .= "<h1 class='mb-0'>" . self::renderIcon($config['titleIcon'] ?? '') . "{$title}</h1>";
+        $html .= "<p class='text-muted mb-0'>{$description}</p>";
+        $html .= "</div>";
+        $html .= "<div class='card-body'>";
+
+        if (isset($config['leadText']) && $config['leadText'] !== '') {
+            $leadText = htmlspecialchars($config['leadText'], ENT_QUOTES, 'UTF-8');
+            $html    .= "<p class='lead'>{$leadText}</p>";
+        }
+
+        if (!empty($config['isAdmin'])) {
+            $html .= "<div class='alert alert-warning'>";
+            $html .= "<i class='fas fa-exclamation-triangle'></i> <strong>Administrator Access Required</strong><br>";
+            $html .= "This documentation is intended for registry administrators and technical staff only.";
+            $html .= "</div>";
+        }
+
+        $html .= "</div>";
+        $html .= "</div>";
+        $html .= "</div>";
+        $html .= "</div>";
+
+        return $html;
+    }
+
+    /**
+     * Render a single document registry-card.
+     *
+     * @param array{
+     *     title: string,
+     *     icon: string,
+     *     url: string,
+     *     buttonText: string,
+     *     headerClass?: string,
+     *     buttonClass?: string,
+     *     cardClass?: string,
+     *     description?: string,
+     *     metadata?: string,
+     *     listItems?: list<array{icon: string, text: string}>,
+     *     buttonIcon?: string,
+     *     headerStyle?: string,
+     *     buttonStyle?: string
+     * } $card
+     * @throws \InvalidArgumentException if required keys are missing
+     */
+    public static function renderDocumentCard(array $card): string
+    {
+        self::requireKeys($card, self::REQUIRED_CARD_KEYS, 'renderDocumentCard');
+
+        $title       = htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8');
+        $icon        = htmlspecialchars($card['icon'], ENT_QUOTES, 'UTF-8');
+        $url         = htmlspecialchars($card['url'], ENT_QUOTES, 'UTF-8');
+        $buttonText  = htmlspecialchars($card['buttonText'], ENT_QUOTES, 'UTF-8');
+        $cardClass   = isset($card['cardClass'])   ? htmlspecialchars($card['cardClass'],   ENT_QUOTES, 'UTF-8') : self::DEFAULT_CARD_CLASS;
+        $headerClass = isset($card['headerClass']) ? htmlspecialchars($card['headerClass'], ENT_QUOTES, 'UTF-8') : self::DEFAULT_HEADER_CLASS;
+        $buttonClass = isset($card['buttonClass']) ? htmlspecialchars($card['buttonClass'], ENT_QUOTES, 'UTF-8') : self::DEFAULT_BUTTON_CLASS;
+
+        $headerStyleAttr = self::renderStyleAttr($card['headerStyle'] ?? '');
+        $buttonStyleAttr = self::renderStyleAttr($card['buttonStyle'] ?? '');
+
+        $html  = "<div class='card {$cardClass}'>";
+        $html .= "<div class='card-header {$headerClass}'{$headerStyleAttr}>";
+        $html .= "<h5 class='mb-0'><i class='fas {$icon}'></i> {$title}</h5>";
+        $html .= "</div>";
+        $html .= "<div class='card-body d-flex flex-column'>";
+
+        if (isset($card['description']) && $card['description'] !== '') {
+            $html .= "<p class='card-text'>" . htmlspecialchars($card['description'], ENT_QUOTES, 'UTF-8') . "</p>";
+        }
+
+        if (isset($card['metadata']) && $card['metadata'] !== '') {
+            $html .= "<p class='small text-muted'>" . htmlspecialchars($card['metadata'], ENT_QUOTES, 'UTF-8') . "</p>";
+        }
+
+        if (!empty($card['listItems'])) {
+            $html .= "<ul class='list-unstyled'>";
+            foreach ($card['listItems'] as $item) {
+                $itemText  = htmlspecialchars($item['text'], ENT_QUOTES, 'UTF-8');
+                $html     .= "<li>" . self::renderIcon($item['icon']) . "{$itemText}</li>";
+            }
+            $html .= "</ul>";
+        }
+
+        $html .= "<div class='mt-auto'>";
+        $html .= "<a href='{$url}' class='btn {$buttonClass}'{$buttonStyleAttr}>" . self::renderIcon($card['buttonIcon'] ?? '') . "{$buttonText}</a>";
+        $html .= "</div>";
+        $html .= "</div>";
+        $html .= "</div>";
+
+        return $html;
+    }
+
+    /**
+     * Render a Bootstrap row of document cards.
+     *
+     * The default column class is col-lg-4. Individual cards may override via
+     * $card['colClass'].
+     *
+     * @param list<array<string, mixed>> $cards
+     */
+    public static function renderDocumentCardGrid(array $cards, string $colClass = self::DEFAULT_COL_CLASS): string
+    {
+        if ($cards === []) {
+            return '';
+        }
+
+        $escapedDefaultCol = htmlspecialchars($colClass, ENT_QUOTES, 'UTF-8');
+        $html              = "<div class='row mt-4'>";
+
+        foreach ($cards as $card) {
+            $col   = isset($card['colClass'])
+                ? htmlspecialchars((string) $card['colClass'], ENT_QUOTES, 'UTF-8')
+                : $escapedDefaultCol;
+            $html .= "<div class='{$col} mb-4'>";
+            $html .= self::renderDocumentCard($card);
+            $html .= "</div>";
+        }
+
+        $html .= "</div>";
+
+        return $html;
+    }
+
+    /**
+     * Render an h2 section heading row.
+     *
+     * @param string $icon       Font Awesome icon class without 'fas ' prefix (e.g. 'fa-code')
+     * @param string $title      Section heading text
+     * @param string $colorClass Optional Bootstrap text color class (e.g. 'text-danger')
+     */
+    public static function renderSectionHeading(string $icon, string $title, string $colorClass = ''): string
+    {
+        $escapedIcon  = htmlspecialchars($icon, ENT_QUOTES, 'UTF-8');
+        $escapedTitle = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+        $iconClasses  = 'fas ' . $escapedIcon . ($colorClass !== '' ? ' ' . htmlspecialchars($colorClass, ENT_QUOTES, 'UTF-8') : '');
+
+        $html  = "<div class='row mt-4'>";
+        $html .= "<div class='col-12'>";
+        $html .= "<h2><i class='{$iconClasses}'></i> {$escapedTitle}</h2>";
+        $html .= "</div>";
+        $html .= "</div>";
+
+        return $html;
+    }
+
+    /**
+     * Render the navigation footer row.
+     *
+     * @param list<array{label: string, url: string, icon?: string, btnClass?: string}> $links
+     * @throws \InvalidArgumentException if any link is missing required keys
+     */
+    public static function renderNavFooter(array $links): string
+    {
+        if ($links === []) {
+            return '';
+        }
+
+        $lastIndex = count($links) - 1;
+
+        $html  = "<div class='row mt-4 mb-4'>";
+        $html .= "<div class='col-12 text-center'>";
+
+        foreach ($links as $index => $link) {
+            self::requireKeys($link, self::REQUIRED_LINK_KEYS, 'renderNavFooter');
+
+            $label    = htmlspecialchars($link['label'], ENT_QUOTES, 'UTF-8');
+            $url      = htmlspecialchars($link['url'], ENT_QUOTES, 'UTF-8');
+            $btnClass = isset($link['btnClass'])
+                ? htmlspecialchars($link['btnClass'], ENT_QUOTES, 'UTF-8')
+                : self::DEFAULT_BTN_CLASS;
+            $classes  = 'btn ' . $btnClass . ($index < $lastIndex ? ' mr-2' : '');
+
+            $html .= "<a href='{$url}' class='{$classes}'>" . self::renderIcon($link['icon'] ?? '') . "{$label}</a>";
+        }
+
+        $html .= "</div>";
+        $html .= "</div>";
+
+        return $html;
+    }
+
+    /**
+     * Render a Font Awesome icon element, or empty string if no icon class given.
+     *
+     * Returns "<i class='fas {escapedClass}'></i> " when $iconClass is non-empty,
+     * so callers can concatenate directly without an extra space check.
+     */
+    private static function renderIcon(string $iconClass): string
+    {
+        if ($iconClass === '') {
+            return '';
+        }
+
+        return "<i class='fas " . htmlspecialchars($iconClass, ENT_QUOTES, 'UTF-8') . "'></i> ";
+    }
+
+    /**
+     * Render an inline style attribute string, or empty string if no value given.
+     */
+    private static function renderStyleAttr(string $style): string
+    {
+        if ($style === '') {
+            return '';
+        }
+
+        return " style='" . htmlspecialchars($style, ENT_QUOTES, 'UTF-8') . "'";
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param list<string> $keys
+     * @throws \InvalidArgumentException
+     */
+    private static function requireKeys(array $data, array $keys, string $context): void
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $data)) {
+                throw new \InvalidArgumentException(
+                    "DocumentPortalTemplate::{$context}: missing required key '{$key}'"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `DocumentPortalTemplate` static class (`usersc/classes/`) with five render methods: `renderPortalHeader`, `renderDocumentCard`, `renderDocumentCardGrid`, `renderSectionHeading`, `renderNavFooter`
- Replaces ~390 lines of duplicated Bootstrap card/grid HTML across `docs/faq/index.php`, `docs/faq/admin/index.php`, and `docs/index.php` with data arrays + template calls
- Adds 46 PHPUnit unit tests in `DocumentPortalTemplateTest.php` covering all methods, XSS escaping, validation, and optional parameters

## Test plan

- [ ] `composer test:quick` passes (810 tests, only 2 pre-existing `LogCategoriesUsageTest` failures)
- [ ] `vendor/bin/phpstan analyse usersc/classes/DocumentPortalTemplate.php` — no errors
- [ ] Browse `docs/faq/index.php` on local dev — 7 cards render correctly, nav links conditional on login state
- [ ] Browse `docs/faq/admin/index.php` — 3 sections with headings, admin warning banner present, purple Paint Colors card not present (that's on the FAQ page)
- [ ] Browse `docs/index.php` — Reference Library and Car Stories inner cards render with `border-primary`/`border-success` styling

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)