### PR TITLE
feat: apply Elan Registry branding to forgot password pages

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.18.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.18.0.md
@@ -48,6 +48,11 @@
 
 ### Improvements
 
+- **Branded forgot password pages** ([#694](https://github.com/unibrain1/elanregistry/issues/694)):
+  The forgot password form and post-submission confirmation screen now use the registry card
+  layout (matching the join flow) with Font Awesome icons, styled input groups, and a
+  "Check Your Email" confirmation card showing the reset link expiry time.
+
 - **Documentation reorganized by intent** ([#559](https://github.com/unibrain1/elanregistry/issues/559)):
   Documentation is now structured around owner intent — "How do I use the registry?" (Owner
   Guides) vs. "Tell me about my car" (Technical Reference) — with a simplified 5-item
@@ -84,6 +89,7 @@
 - [#675](https://github.com/unibrain1/elanregistry/issues/675) — security: audit admin include files for unescaped echo points (XSS hardening)
 - [#684](https://github.com/unibrain1/elanregistry/issues/684) — chore: auto-update VERSION file via post-commit/post-checkout git hooks
 - [#686](https://github.com/unibrain1/elanregistry/issues/686) — chore: remove stale test artifacts and update .gitignore
+- [#694](https://github.com/unibrain1/elanregistry/issues/694) — Apply Elan Registry branding to forgot password pages
 
 ## Summary
 

--- a/tests/playwright/e2e/not-logged-in.spec.js
+++ b/tests/playwright/e2e/not-logged-in.spec.js
@@ -71,6 +71,12 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
       expectedText: 'Please Log In',
       isLoginPage: true,
     },
+    {
+      path: '/users/forgot_password.php',
+      name: 'Forgot Password',
+      selector: 'h2',
+      expectedText: 'Reset',
+    },
   ];
 
   pages.forEach(({ path, name, selector, expectedText, isRedirect, expectedRedirectPattern, isLoginPage }) => {
@@ -118,6 +124,7 @@ test.describe('Internal Links Discovery and Testing (Not Logged In)', () => {
     { path: '/docs/car-stories.php', name: 'Car Stories' },
     { path: '/docs/faq/index.php', name: 'FAQ' },
     { path: 'usersc/login.php', name: 'Log In' },
+    { path: '/users/forgot_password.php', name: 'Forgot Password' },
   ];
 
   test('find all internal links across all pages (excluding header)', async ({ page }) => {

--- a/tests/playwright/e2e/not-logged-in.spec.js
+++ b/tests/playwright/e2e/not-logged-in.spec.js
@@ -75,7 +75,7 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
       path: '/users/forgot_password.php',
       name: 'Forgot Password',
       selector: 'h2',
-      expectedText: 'Reset',
+      expectedText: 'Reset Password',
     },
   ];
 

--- a/tests/playwright/login-functionality.test.js
+++ b/tests/playwright/login-functionality.test.js
@@ -354,7 +354,7 @@ test.describe('Forgot Password Page', () => {
     await page.click(SUBMIT_BUTTON);
     await page.waitForLoadState('networkidle');
 
-    // Rate limiting or validation may keep us on the form — either way no PHP errors
+    // Only assert no PHP errors — redirect vs. stay-on-form behavior is not tested here
     const pageContent = await page.textContent('body');
     expect(pageContent).not.toMatch(/Fatal error|Parse error|Warning:/i);
   });

--- a/tests/playwright/login-functionality.test.js
+++ b/tests/playwright/login-functionality.test.js
@@ -327,3 +327,35 @@ test.describe('Login Form Responsiveness', () => {
     });
   }
 });
+
+test.describe('Forgot Password Page', () => {
+  const SUBMIT_BUTTON = 'button[name="forgotten_password"], input[name="forgotten_password"]';
+
+  test('forgot password form renders with required security elements', async ({ page }) => {
+    await page.goto('users/forgot_password.php', { waitUntil: 'networkidle' });
+
+    await expect(page.locator('input[name="email"]')).toBeVisible();
+
+    // CSRF token must survive any template restructuring
+    const csrfInput = page.locator('input[name="csrf"]');
+    await expect(csrfInput).toHaveCount(1);
+    expect((await csrfInput.inputValue()).length).toBeGreaterThan(10);
+
+    // Bot protection must be present
+    expect(await page.locator('.cf-turnstile').count()).toBeGreaterThan(0);
+
+    await expect(page.locator(SUBMIT_BUTTON)).toBeVisible();
+  });
+
+  test('forgot password confirmation page renders after submission', async ({ page }) => {
+    await page.goto('users/forgot_password.php', { waitUntil: 'networkidle' });
+
+    await page.fill('input[name="email"]', 'test@example.com');
+    await page.click(SUBMIT_BUTTON);
+    await page.waitForLoadState('networkidle');
+
+    // Rate limiting or validation may keep us on the form — either way no PHP errors
+    const pageContent = await page.textContent('body');
+    expect(pageContent).not.toMatch(/Fatal error|Parse error|Warning:/i);
+  });
+});

--- a/usersc/views/_forgot_password.php
+++ b/usersc/views/_forgot_password.php
@@ -1,42 +1,40 @@
 <?php
+declare(strict_types=1);
+
 /*
-this is a user-facing page
-UserSpice 5
-An Open Source PHP User Management System
-by the UserSpice Team at http://UserSpice.com
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Branded forgot password form for the Lotus Elan Registry.
+Overrides the stock UserSpice template with registry card layout
+matching the join flow in _join.php.
 */
 ?>
-<div class="row">
-<div class="col-12 col-sm-8 offeset-sm-1 col-md-6 offset-md-3 col-lg-4 offset-lg-4">
-		<h2><?=lang("PW_RESET");?></h2>
-		<ol>
-			<?=lang("VER_INS");?>
-		</ol>
-		<?php if ($errors != '') { display_errors($errors); } ?>
-		<form action="" method="post" class="form " id="pwReset">
-
-			<div class="form-group">
-				<label for="email"><?=lang("GEN_EMAIL");?></label>
-				<input type="text" name="email" placeholder="<?=lang("GEN_EMAIL");?>" class="form-control" autofocus autocomplete='email'>
-			</div>
-
-			<input type="hidden" name="csrf" value="<?=Token::generate();?>">
-			<?php addTurnstile(); ?>
-			<p><input type="submit" name="forgotten_password" value="<?=lang("GEN_RESET");?>" class="btn btn-primary"></p>
-		</form>
-
-	</div><!-- /.col -->
-</div><!-- /.row -->
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-6 col-lg-4">
+      <div class="card registry-card">
+        <div class="card-header">
+          <h2 class="mb-0"><i class="fas fa-key"></i> <strong><?= lang("PW_RESET"); ?></strong></h2>
+        </div>
+        <div class="card-body">
+          <?php if (!empty($errors)) { display_errors($errors); } ?>
+          <form action="" method="post" id="pwReset">
+            <div class="mb-3">
+              <label for="email" class="form-label"><?= lang("GEN_EMAIL"); ?></label>
+              <div class="input-group">
+                <span class="input-group-text"><i class="fas fa-envelope"></i></span>
+                <input type="email" name="email" id="email" class="form-control"
+                       placeholder="your.email@example.com" autofocus autocomplete="email">
+              </div>
+            </div>
+            <input type="hidden" name="csrf" value="<?= Token::generate(); ?>">
+            <?php addTurnstile(); ?>
+            <div class="mt-3 text-center">
+              <button type="submit" name="forgotten_password" value="1" class="btn btn-primary btn-lg">
+                <i class="fas fa-paper-plane mr-2"></i><?= lang("GEN_RESET"); ?>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/usersc/views/_forgot_password_sent.php
+++ b/usersc/views/_forgot_password_sent.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/*
+Branded forgot password confirmation page for the Lotus Elan Registry.
+Overrides the stock UserSpice template (users/views/_forgot_password_sent.php).
+The controller at users/forgot_password.php checks for this override file first.
+*/
+?>
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-6 col-lg-4">
+      <div class="card registry-card text-center">
+        <div class="card-body py-5">
+          <div class="mb-3">
+            <i class="fas fa-envelope-open-text fa-3x text-success"></i>
+          </div>
+          <h2 class="h4 mb-3">Check Your Email</h2>
+          <p class="text-muted mb-3">
+            We've sent password reset instructions to your email address.
+          </p>
+          <?php $expiry = (int) $settings->reset_vericode_expiry; ?>
+          <?php if ($expiry > 0): ?>
+            <p class="text-muted mb-4">
+              The reset link will expire in
+              <strong><?= $expiry ?> <?= lang("T_MINUTES"); ?></strong>.
+            </p>
+          <?php endif; ?>
+          <a href="<?= htmlspecialchars($us_url_root, ENT_QUOTES, 'UTF-8') ?>users/login.php" class="btn btn-outline-primary">
+            <i class="fas fa-arrow-left mr-2"></i>Back to Login
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/usersc/views/_forgot_password_sent.php
+++ b/usersc/views/_forgot_password_sent.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 /*
 Branded forgot password confirmation page for the Lotus Elan Registry.
 Overrides the stock UserSpice template (users/views/_forgot_password_sent.php).
-The controller at users/forgot_password.php checks for this override file first.
+The controller users/forgot_password.php checks for this file via file_exists()
+and requires it instead of the stock template when the reset email has been sent.
 */
 ?>
 <div class="container mt-4">


### PR DESCRIPTION
## Summary

- Replace bare UserSpice forgot password form (`usersc/views/_forgot_password.php`) with branded registry card layout matching the join flow — `registry-card` class, Font Awesome key icon, input-group email field, centered submit button
- Create `usersc/views/_forgot_password_sent.php` to override the stock confirmation screen — success icon, "Check Your Email" heading, expiry time from `$settings->reset_vericode_expiry`, and a Back to Login link
- Add Playwright smoke test guarding CSRF token, Turnstile widget, and form field names against future template regressions
- Add forgot password page to e2e reachability suite

Closes #694

## Test plan

- [ ] Visit `/users/forgot_password.php` — card renders centred with top spacing, key icon, email input-group, Turnstile widget visible
- [ ] Submit a valid email — confirmation card appears with success icon, expiry time, and Back to Login link
- [ ] Submit an invalid email — validation error displays within the card
- [ ] Verify at 320px viewport — card is full-width and readable
- [ ] `npm run playwright:test` — new smoke tests pass on localhost:9999

🤖 Generated with [Claude Code](https://claude.com/claude-code)