### PR TITLE
feat: apply Elan Registry branding to password reset email template (#695)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.18.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.18.0.md
@@ -53,6 +53,11 @@
   layout (matching the join flow) with Font Awesome icons, styled input groups, and a
   "Check Your Email" confirmation card showing the reset link expiry time.
 
+- **Branded password reset email** ([#695](https://github.com/unibrain1/elanregistry/issues/695)):
+  The password reset email now uses the registry's branded email template — logo header,
+  styled "Reset My Password" button, plain-text fallback link, expiry notice, and a
+  security disclaimer — matching the visual identity of all other registry transactional emails.
+
 - **Documentation reorganized by intent** ([#559](https://github.com/unibrain1/elanregistry/issues/559)):
   Documentation is now structured around owner intent — "How do I use the registry?" (Owner
   Guides) vs. "Tell me about my car" (Technical Reference) — with a simplified 5-item
@@ -90,6 +95,7 @@
 - [#684](https://github.com/unibrain1/elanregistry/issues/684) — chore: auto-update VERSION file via post-commit/post-checkout git hooks
 - [#686](https://github.com/unibrain1/elanregistry/issues/686) — chore: remove stale test artifacts and update .gitignore
 - [#694](https://github.com/unibrain1/elanregistry/issues/694) — Apply Elan Registry branding to forgot password pages
+- [#695](https://github.com/unibrain1/elanregistry/issues/695) — Apply Elan Registry branding to password reset email template
 
 ## Summary
 

--- a/usersc/views/_email_template_forgot_password.php
+++ b/usersc/views/_email_template_forgot_password.php
@@ -10,7 +10,11 @@ declare(strict_types=1);
  * via the EmailTemplate class.
  *
  * Variables available (from $email_field_whitelist):
- *   $fname, $email (rawurlencode'd), $vericode, $user_id, $reset_vericode_expiry
+ *   $fname            — user's first name (raw)
+ *   $email            — already rawurlencode'd by the caller; do NOT re-encode in this template
+ *   $vericode         — raw plaintext token (rawurlencode applied in this template)
+ *   $user_id          — user ID integer
+ *   $reset_vericode_expiry — reset link expiry in minutes
  */
 
 require_once $abs_us_root . $us_url_root . 'usersc/classes/EmailTemplate.php';

--- a/usersc/views/_email_template_forgot_password.php
+++ b/usersc/views/_email_template_forgot_password.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Forgot Password Email Template (Branded Override)
+ *
+ * Overrides the default UserSpice forgot password email
+ * (users/views/_email_template_forgot_password.php) with full registry branding
+ * via the EmailTemplate class.
+ *
+ * Variables available (from $email_field_whitelist):
+ *   $fname, $email (rawurlencode'd), $vericode, $user_id, $reset_vericode_expiry
+ */
+
+require_once $abs_us_root . $us_url_root . 'usersc/classes/EmailTemplate.php';
+
+$emailTemplate = new EmailTemplate();
+
+$resetUrl = getBaseUrl() . '/users/forgot_password_reset.php?email=' . $email . '&vericode=' . rawurlencode($vericode) . '&user_id=' . (int)$user_id . '&reset=1';
+
+$content = "
+    <p>Hello <strong>" . htmlspecialchars($fname, ENT_QUOTES, 'UTF-8') . "</strong>,</p>
+
+    <p>We received a request to reset the password for your Lotus Elan Registry account. Click the button below to choose a new password.</p>
+
+    " . $emailTemplate->createButton('Reset My Password', $resetUrl, 'primary') . "
+
+    <p>Or copy and paste this link into your browser:</p>
+    <p style=\"word-break:break-all;font-size:13px;color:#6c757d;\">" . htmlspecialchars($resetUrl, ENT_QUOTES, 'UTF-8') . "</p>
+
+    <p>This reset link expires in <strong>" . htmlspecialchars((string)$reset_vericode_expiry, ENT_QUOTES, 'UTF-8') . " minutes</strong>.</p>
+
+    <p>If you did not request a password reset, you can safely ignore this email. Your password will not be changed.</p>
+";
+
+echo $emailTemplate->render(
+    'Reset Your Password',
+    'Password Reset Request',
+    $content,
+    ['footer_text' => 'You received this email because a password reset was requested for your account. If this was not you, please ignore this message.']
+);


### PR DESCRIPTION
## Summary

- Creates `usersc/views/_email_template_forgot_password.php` to override the stock UserSpice password reset email with full Elan Registry branding
- Uses the `EmailTemplate` class (same pattern as all other branded transactional emails)
- Includes registry logo header, styled "Reset My Password" button, plain-text fallback link, expiry notice in minutes, and security disclaimer footer
- Updates v2.18.0 release notes

## Implementation Notes

- Uses `getBaseUrl()` for URL construction (not legacy DB query) — consistent with `_email_template_verify.php`
- `$email` is embedded directly (pre-encoded by caller in `forgot_password.php`)
- `$vericode` is wrapped with `rawurlencode()` for defensive consistency with the verify template
- No other files require changes — the UserSpice override mechanism (`usersc/views/` checked before `users/views/`) activates this automatically

## Test plan

- [ ] Submit forgot password form on staging (`test.elanregistry.org`) and verify branded email is delivered
- [ ] Confirm reset link in email is functional end-to-end (click → reset password → login)
- [ ] Verify plain-text fallback URL matches the button URL
- [ ] Verify expiry duration is displayed correctly in minutes
- [ ] Check email renders correctly in at least one email client (e.g., Gmail)

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)