### PR TITLE
fix: add elan_feedback_email to processSettingsAutoCreation() defaults

### DIFF
--- a/app/admin/includes/tab-settings.php
+++ b/app/admin/includes/tab-settings.php
@@ -30,7 +30,8 @@ if (!function_exists('processSettingsAutoCreation')) {
 
         // Email & Communication settings
         $emailSettingsFields = [
-            'elan_admin_emails' => ['type' => 'TEXT', 'default' => 'registrar@elanregistry.org', 'description' => 'Comma-separated admin email addresses for system notifications and administrative alerts']
+            'elan_admin_emails'   => ['type' => 'TEXT', 'default' => 'registrar@elanregistry.org', 'description' => 'Comma-separated admin email addresses for system notifications and administrative alerts'],
+            'elan_feedback_email' => ['type' => 'VARCHAR(255)', 'default' => 'registrar@elanregistry.org', 'description' => 'Email address for receiving user feedback form submissions'],
         ];
 
         // System Maintenance settings

--- a/docs/releases/RELEASE_NOTES_v2.19.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.19.0.md
@@ -1,0 +1,46 @@
+# Elan Registry v2.19.0 Release Notes
+
+**Release Date:** [DATE]
+**Type:** Minor Release - Testing Infrastructure
+
+## Required Actions After Deployment
+
+None for most issues. #574 (schema validation) may require:
+
+1. Run database migrations to add missing indexes and FK constraints (see issue for SQL)
+2. Verify `EnhancedSchemaManager::validateSchema()` passes on staging before production
+
+## User-Facing Changes
+
+None — this milestone is entirely internal testing infrastructure.
+
+## Technical Changes
+
+- **Fix failing test assertion** ([#689](https://github.com/unibrain1/elanregistry/issues/689)):
+  Add `elan_feedback_email` to `processSettingsAutoCreation()` so the regression test
+  accurately verifies fresh-install seeding.
+- **Upgrade PHPUnit 11 → 12** ([#629](https://github.com/unibrain1/elanregistry/issues/629)):
+  Resolve Dependabot advisory GHSA-qrr6-mg7r-m243; update composer constraint and fix
+  API compatibility issues.
+- **Refactor GetDataTables tests** ([#606](https://github.com/unibrain1/elanregistry/issues/606)):
+  Replace source-inspection anti-pattern assertions with behavior-based tests covering
+  valid, malformed, oversized, unauthenticated, and CSRF scenarios.
+- **Schema validation enhancements** ([#574](https://github.com/unibrain1/elanregistry/issues/574)):
+  Add 4 missing performance indexes, 4 FK constraints, and expand `EnhancedSchemaManager`
+  validation to cover custom tables and column requirements.
+- **CI coverage reporting and baseline** ([#611](https://github.com/unibrain1/elanregistry/issues/611)):
+  Add coverage reporting to GitHub Actions, establish baseline coverage percentage,
+  document coverage gate policy.
+
+## Issues Resolved
+
+- [#574](https://github.com/unibrain1/elanregistry/issues/574) — Enhance schema validation checks for performance and data integrity
+- [#606](https://github.com/unibrain1/elanregistry/issues/606) — test: refactor GetDataTables tests from source-inspection to behavior-based testing
+- [#611](https://github.com/unibrain1/elanregistry/issues/611) — test: add CI coverage reporting and baseline tracking
+- [#629](https://github.com/unibrain1/elanregistry/issues/629) — Upgrade PHPUnit from 11.x to 12.x
+- [#689](https://github.com/unibrain1/elanregistry/issues/689) — fix: tighten testFeedbackEmailSettingIsAutoCreated assertion to verify PHP defaults array
+
+## Summary
+
+5 issues resolved across testing infrastructure: PHPUnit upgrade, test quality refactoring,
+CI coverage reporting, schema validation enhancements, and a pre-existing test failure fix.


### PR DESCRIPTION
## Summary

- Adds `elan_feedback_email` to the `$emailSettingsFields` array in `processSettingsAutoCreation()` so fresh installs seed the setting into the database
- Uses `VARCHAR(255)` (correct for a single email address; also enables a proper MySQL column `DEFAULT`, unlike `TEXT`)
- Default value `registrar@elanregistry.org` matches the HTML form placeholder already in the file

## Test plan

- [x] `composer test:quick` — 818 tests, 0 failures (previously 1 failure in `LogCategoriesUsageTest::testFeedbackEmailSettingIsAutoCreated`)
- [x] `composer check:php` — no new PHPStan errors or coding standards violations
- [x] Pre-commit hooks passed (coding standards, markdownlint, PHPStan, unit tests)

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)