### PR TITLE
chore: upgrade PHPUnit 11 → 12 (#629)

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql
           coverage: none
           tools: composer:v2

--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -871,7 +871,6 @@ function getMimeType(string $file): string
     if (function_exists('finfo_open')) {
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mimeType = finfo_file($finfo, $file);
-        finfo_close($finfo);
     } elseif (function_exists('mime_content_type')) {
         $mimeType = mime_content_type($file);
     } else {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^12.0",
         "phpstan/phpstan": "^2.1"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea3653da81bb20f0c8b21ddbb37ffebd",
+    "content-hash": "cbf6227a5959c8ab5708d419ab29bfbb",
     "packages": [],
     "packages-dev": [
         {
@@ -298,16 +298,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.12",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
@@ -315,18 +315,16 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
-                "php": ">=8.2",
-                "phpunit/php-file-iterator": "^5.1.0",
-                "phpunit/php-text-template": "^4.0.1",
-                "sebastian/code-unit-reverse-lookup": "^4.0.1",
-                "sebastian/complexity": "^4.0.1",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/lines-of-code": "^3.0.1",
-                "sebastian/version": "^5.0.2",
-                "theseer/tokenizer": "^1.3.1"
+                "php": ">=8.3",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/lines-of-code": "^4.0",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.46"
+                "phpunit/phpunit": "^12.5.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -335,7 +333,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0.x-dev"
+                    "dev-main": "12.5.x-dev"
                 }
             },
             "autoload": {
@@ -364,7 +362,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
@@ -384,32 +382,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:01:01+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.1",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -437,7 +435,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -457,28 +455,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T13:52:54+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "5.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -486,7 +484,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -513,7 +511,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
                 "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
             },
             "funding": [
                 {
@@ -521,32 +519,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:07:44+00:00"
+            "time": "2025-02-07T04:58:58+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -573,7 +571,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
             },
             "funding": [
                 {
@@ -581,32 +579,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:08:43+00:00"
+            "time": "2025-02-07T04:59:16+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "7.0.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -633,7 +631,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
                 "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
             },
             "funding": [
                 {
@@ -641,20 +639,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:09:35+00:00"
+            "time": "2025-02-07T04:59:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.55",
+            "version": "12.5.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
+                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
                 "shasum": ""
             },
             "require": {
@@ -667,27 +665,23 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.1",
-                "phpunit/php-invoker": "^5.0.1",
-                "phpunit/php-text-template": "^4.0.1",
-                "phpunit/php-timer": "^7.0.1",
-                "sebastian/cli-parser": "^3.0.2",
-                "sebastian/code-unit": "^3.0.3",
-                "sebastian/comparator": "^6.3.3",
-                "sebastian/diff": "^6.0.2",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/exporter": "^6.3.2",
-                "sebastian/global-state": "^7.0.2",
-                "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/recursion-context": "^6.0.3",
-                "sebastian/type": "^5.1.3",
-                "sebastian/version": "^5.0.2",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-file-iterator": "^6.0.1",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.0",
+                "sebastian/comparator": "^7.1.6",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.1.0",
+                "sebastian/exporter": "^7.0.2",
+                "sebastian/global-state": "^8.0.2",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
+                "sebastian/type": "^6.0.3",
+                "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -695,7 +689,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.5-dev"
+                    "dev-main": "12.5-dev"
                 }
             },
             "autoload": {
@@ -727,56 +721,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.23"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-02-18T12:37:06+00:00"
+            "time": "2026-04-18T06:12:49+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "3.0.2",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -800,152 +778,51 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:41:36+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-19T07:56:08+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "4.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:45:54+00:00"
+            "time": "2025-09-14T09:36:45+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.3",
+            "version": "7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/diff": "^6.0",
-                "sebastian/exporter": "^6.0"
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.4"
+                "phpunit/phpunit": "^12.2"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -953,7 +830,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -993,7 +870,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
             },
             "funding": [
                 {
@@ -1013,33 +890,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:26:40+00:00"
+            "time": "2026-04-14T08:23:15+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1063,7 +940,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
             },
             "funding": [
                 {
@@ -1071,33 +948,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:49:50+00:00"
+            "time": "2025-02-07T04:55:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.2",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1130,7 +1007,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
             },
             "funding": [
                 {
@@ -1138,27 +1015,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:53:05+00:00"
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "7.2.1",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1166,7 +1043,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.2-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -1194,7 +1071,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
             },
             "funding": [
                 {
@@ -1214,34 +1091,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T11:55:47+00:00"
+            "time": "2026-04-15T12:13:01+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "6.3.2",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1284,7 +1161,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
             },
             "funding": [
                 {
@@ -1304,35 +1181,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:12:51+00:00"
+            "time": "2025-09-24T06:16:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "7.0.2",
+            "version": "8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -1358,41 +1235,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:57:36+00:00"
+            "time": "2025-08-29T11:29:25+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "3.0.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1416,7 +1305,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1424,34 +1313,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:58:38+00:00"
+            "time": "2025-02-07T04:57:28+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "6.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1474,7 +1363,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
                 "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -1482,32 +1371,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:00:13+00:00"
+            "time": "2025-02-07T04:57:48+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1530,7 +1419,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
                 "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
             },
             "funding": [
                 {
@@ -1538,32 +1427,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:01:32+00:00"
+            "time": "2025-02-07T04:58:17+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "6.0.3",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1594,7 +1483,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
@@ -1614,32 +1503,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T04:42:22+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "5.1.3",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1663,7 +1552,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
             },
             "funding": [
                 {
@@ -1683,29 +1572,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:55:48+00:00"
+            "time": "2025-08-09T06:57:12+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "5.0.2",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1729,7 +1618,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
                 "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1737,7 +1626,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T05:16:32+00:00"
+            "time": "2025-02-07T05:00:38+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -1793,23 +1682,23 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.3.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -1831,7 +1720,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1839,7 +1728,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-17T20:03:58+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
         }
     ],
     "aliases": [],

--- a/docs/releases/RELEASE_NOTES_v2.19.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.19.0.md
@@ -20,8 +20,8 @@ None — this milestone is entirely internal testing infrastructure.
   Add `elan_feedback_email` to `processSettingsAutoCreation()` so the regression test
   accurately verifies fresh-install seeding.
 - **Upgrade PHPUnit 11 → 12** ([#629](https://github.com/unibrain1/elanregistry/issues/629)):
-  Resolve Dependabot advisory GHSA-qrr6-mg7r-m243; update composer constraint and fix
-  API compatibility issues.
+  Resolve Dependabot advisory GHSA-qrr6-mg7r-m243; convert 310 docblock annotations to
+  PHP 8 attributes; fix `finfo_close()` and `imagedestroy()` PHP 8.5 deprecations.
 - **Refactor GetDataTables tests** ([#606](https://github.com/unibrain1/elanregistry/issues/606)):
   Replace source-inspection anti-pattern assertions with behavior-based tests covering
   valid, malformed, oversized, unauthenticated, and CSRF scenarios.

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
          bootstrap="tests/bootstrap-integration.php"
          colors="true"
          processIsolation="false"

--- a/phpunit-unit.xml
+++ b/phpunit-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
          bootstrap="tests/bootstrap-unit.php"
          colors="true"
          processIsolation="false"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
          processIsolation="false"

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -714,7 +714,8 @@ if (!function_exists('getMimeType')) {
         
         $allowedMimes = [
             'image/jpeg',
-            'image/png', 
+            'image/jpg',
+            'image/png',
             'image/gif',
             'image/webp'
         ];

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -711,7 +711,6 @@ if (!function_exists('getMimeType')) {
         
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mimeType = finfo_file($finfo, $filepath);
-        finfo_close($finfo);
         
         $allowedMimes = [
             'image/jpeg',

--- a/tests/integration/CarActionsHistoryAndValidationTest.php
+++ b/tests/integration/CarActionsHistoryAndValidationTest.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Integration tests for Car Actions endpoints: history.php and validateChassis.php
  *
  * Tests the ApiResponse pattern implementation for:
  * - Car history retrieval (history.php)
  * - Chassis validation (validateChassis.php)
- *
- * @group integration
- * @group car-actions
  */
+#[Group('integration')]
+#[Group('car-actions')]
 final class CarActionsHistoryAndValidationTest extends IntegrationTestCase
 {
     /**

--- a/tests/integration/CarActionsTest.php
+++ b/tests/integration/CarActionsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Integration tests for car action endpoints
  *
@@ -12,10 +14,9 @@ require_once __DIR__ . '/IntegrationTestCase.php';
  * - Car updates (updateCar)
  * - Image fetching (fetchImages)
  * - Image removal (removeImages)
- *
- * @group integration
- * @group car-actions
  */
+#[Group('integration')]
+#[Group('car-actions')]
 final class CarActionsTest extends IntegrationTestCase
 {
     /**

--- a/tests/integration/CarDataTablesTest.php
+++ b/tests/integration/CarDataTablesTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test cases for Car DataTables functionality
  *
  * Tests cover server-side DataTables data processing including searching,
  * sorting, pagination, and security validation.
- *
- * @group integration
  */
+#[Group('integration')]
 final class CarDataTablesTest extends IntegrationTestCase
 {
     protected $db;
@@ -31,9 +32,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData for cars table
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataForCarsTable(): void
     {
         $car = new Car();
@@ -62,9 +62,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData for factory table
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataForFactoryTable(): void
     {
         $car = new Car();
@@ -89,9 +88,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData with search filter
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataWithSearch(): void
     {
         $car = new Car();
@@ -118,9 +116,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData with sorting
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataWithSorting(): void
     {
         $car = new Car();
@@ -151,9 +148,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData with pagination
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataWithPagination(): void
     {
         $car = new Car();
@@ -179,9 +175,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData validates column names
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataValidatesColumnNames(): void
     {
         $car = new Car();
@@ -211,9 +206,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData prevents SQL injection
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataPreventsInjection(): void
     {
         $car = new Car();
@@ -239,9 +233,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData fails with invalid table
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataFailsWithInvalidTable(): void
     {
         $this->expectException(Exception::class);
@@ -264,9 +257,8 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * Test getDataTablesData returns correct record counts
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetDataTablesDataReturnsCorrectRecordCounts(): void
     {
         $car = new Car();

--- a/tests/integration/CarDeletionTest.php
+++ b/tests/integration/CarDeletionTest.php
@@ -7,14 +7,15 @@ require_once __DIR__ . '/IntegrationTestCase.php';
 use ElanRegistry\Exceptions\CarDeletionException;
 use ElanRegistry\Exceptions\CarNotFoundException;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test cases for Car deletion functionality
  *
  * Tests cover car deletion operations with CSRF protection, transaction handling,
  * audit trail creation, and error scenarios.
- *
- * @group integration
  */
+#[Group('integration')]
 final class CarDeletionTest extends IntegrationTestCase
 {
     private $testCarId;
@@ -65,9 +66,8 @@ final class CarDeletionTest extends IntegrationTestCase
 
     /**
      * Test successful car deletion with valid CSRF token
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDeleteCarSuccessWithValidToken(): void
     {
         $car = new Car($this->testCarId);
@@ -82,9 +82,8 @@ final class CarDeletionTest extends IntegrationTestCase
 
     /**
      * Test car deletion fails with invalid CSRF token
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDeleteCarFailsWithInvalidToken(): void
     {
         $this->expectException(CarDeletionException::class);
@@ -95,9 +94,8 @@ final class CarDeletionTest extends IntegrationTestCase
 
     /**
      * Test car deletion fails when car does not exist
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDeleteCarFailsWhenCarNotExists(): void
     {
         $this->expectException(CarNotFoundException::class);
@@ -108,9 +106,8 @@ final class CarDeletionTest extends IntegrationTestCase
 
     /**
      * Test car deletion creates audit trail in history table
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDeleteCarCreatesAuditTrail(): void
     {
         $car = new Car($this->testCarId);
@@ -131,9 +128,8 @@ final class CarDeletionTest extends IntegrationTestCase
 
     /**
      * Test car deletion removes car-user relationships
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDeleteCarRemovesCarUserRelationships(): void
     {
         $car = new Car($this->testCarId);
@@ -155,9 +151,8 @@ final class CarDeletionTest extends IntegrationTestCase
 
     /**
      * Test car deletion transaction rollback on failure
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDeleteTransactionRollbackOnFailure(): void
     {
         // This test verifies that if any step fails, the transaction rolls back
@@ -186,9 +181,8 @@ final class CarDeletionTest extends IntegrationTestCase
 
     /**
      * Test car deletion requires authenticated user
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDeleteRequiresAuthenticatedUser(): void
     {
         $this->expectException(CarDeletionException::class);
@@ -212,9 +206,8 @@ final class CarDeletionTest extends IntegrationTestCase
 
     /**
      * Test car deletion with optional token parameter
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDeleteCarWithOptionalToken(): void
     {
         $car = new Car($this->testCarId);

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -6,14 +6,15 @@ require_once __DIR__ . '/IntegrationTestCase.php';
 
 use ElanRegistry\Exceptions\CarPermissionException;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test cases for Car merge functionality
  *
  * Tests cover car merging operations with history transfer, deletion,
  * transaction handling, and validation.
- *
- * @group integration
  */
+#[Group('integration')]
 final class CarMergeTest extends IntegrationTestCase
 {
     private $testCarId;
@@ -71,9 +72,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test successful car merge with valid source car
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeCarSuccessWithValidOldCar(): void
     {
         $car = new Car($this->testCarId);
@@ -84,9 +84,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge fails when target car does not exist
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeCarFailsWhenTargetNotExists(): void
     {
         $this->expectException(Exception::class);
@@ -97,9 +96,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge fails when source car does not exist
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeCarFailsWhenSourceNotExists(): void
     {
         $this->expectException(Exception::class);
@@ -110,9 +108,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge fails when merging car with itself
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeCarFailsWhenMergingSelf(): void
     {
         $this->expectException(Exception::class);
@@ -123,9 +120,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge transfers history records
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeTransfersHistoryRecords(): void
     {
         $car = new Car($this->testCarId);
@@ -143,9 +139,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge deletes old car
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeDeletesOldCar(): void
     {
         $oldCarId = $this->testMergeCarId;
@@ -162,9 +157,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge creates audit trail
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeCreatesAuditTrail(): void
     {
         $car = new Car($this->testCarId);
@@ -182,9 +176,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge transaction rollback on failure
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeTransactionRollbackOnFailure(): void
     {
         $this->expectException(Exception::class);
@@ -204,9 +197,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge removes old car relationships
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeRemovesOldCarRelationships(): void
     {
         $oldCarId = $this->testMergeCarId;
@@ -223,9 +215,8 @@ final class CarMergeTest extends IntegrationTestCase
 
     /**
      * Test car merge requires authenticated user
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMergeRequiresAuthenticatedUser(): void
     {
         $this->expectException(CarPermissionException::class);

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -6,14 +6,15 @@ require_once __DIR__ . '/IntegrationTestCase.php';
 
 use ElanRegistry\Exceptions\CarPermissionException;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test cases for Car transfer functionality
  *
  * Tests cover car ownership transfer operations with user validation,
  * transaction handling, relationship updates, and profile data copying.
- *
- * @group integration
  */
+#[Group('integration')]
 final class CarTransferTest extends IntegrationTestCase
 {
     private $testCarId;
@@ -66,9 +67,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test successful car transfer to valid user
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferCarSuccessWithValidUser(): void
     {
         $car = new Car($this->testCarId);
@@ -84,9 +84,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer fails with invalid user ID
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferCarFailsWithInvalidUser(): void
     {
         $this->expectException(Exception::class);
@@ -97,9 +96,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer fails when car does not exist
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferCarFailsWhenCarNotExists(): void
     {
         $this->expectException(Exception::class);
@@ -110,9 +108,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer updates car_user relationship table
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferUpdatesCarUserRelationship(): void
     {
         $car = new Car($this->testCarId);
@@ -139,9 +136,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer creates history record
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferCreatesHistoryRecord(): void
     {
         $car = new Car($this->testCarId);
@@ -161,9 +157,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer copies user profile data
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferCopiesUserProfileData(): void
     {
         $car = new Car($this->testCarId);
@@ -185,9 +180,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer transaction rollback on failure
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferTransactionRollbackOnFailure(): void
     {
         // Test that invalid user causes transfer to fail completely
@@ -208,9 +202,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer requires authenticated user
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferRequiresAuthenticatedUser(): void
     {
         $this->expectException(CarPermissionException::class);
@@ -234,9 +227,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer with TRANSFER operation type
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferCarWithTransferOperationType(): void
     {
         $car = new Car($this->testCarId);
@@ -256,9 +248,8 @@ final class CarTransferTest extends IntegrationTestCase
 
     /**
      * Test car transfer updates location data if available
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testTransferUpdatesLocationData(): void
     {
         $car = new Car($this->testCarId);

--- a/tests/integration/CarVerificationTest.php
+++ b/tests/integration/CarVerificationTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test cases for Car verification functionality
  *
  * Tests cover verification code management, verification status tracking,
  * and sold status marking with date validation.
- *
- * @group integration
  */
+#[Group('integration')]
 final class CarVerificationTest extends IntegrationTestCase
 {
     private $testCarId;
@@ -41,9 +42,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test set verification code success
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testSetVerificationCodeSuccess(): void
     {
         $car = new Car($this->testCarId);
@@ -60,9 +60,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test set verification code fails with short code
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testSetVerificationCodeFailsWithShortCode(): void
     {
         $this->expectException(Exception::class);
@@ -73,9 +72,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test set verification code fails when car does not exist
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testSetVerificationCodeFailsWhenCarNotExists(): void
     {
         $this->expectException(Exception::class);
@@ -86,9 +84,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test mark verified success
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMarkVerifiedSuccess(): void
     {
         $car = new Car($this->testCarId);
@@ -104,9 +101,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test mark verified updates timestamp
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMarkVerifiedUpdatesTimestamp(): void
     {
         $car = new Car($this->testCarId);
@@ -129,9 +125,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test mark sold with custom date
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMarkSoldWithCustomDate(): void
     {
         $car = new Car($this->testCarId);
@@ -148,9 +143,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test mark sold with default date
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMarkSoldWithDefaultDate(): void
     {
         $car = new Car($this->testCarId);
@@ -167,9 +161,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test mark sold fails with invalid date
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMarkSoldFailsWithInvalidDate(): void
     {
         $this->expectException(Exception::class);
@@ -180,9 +173,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test find by verification code success
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testFindByVerificationCodeSuccess(): void
     {
         $car = new Car($this->testCarId);
@@ -198,9 +190,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test find by verification code returns null when not found
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testFindByVerificationCodeReturnsNullWhenNotFound(): void
     {
         $result = Car::findByVerificationCode('NONEXISTENT-CODE-12345');
@@ -210,9 +201,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test find by verification code fails with empty code
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testFindByVerificationCodeFailsWithEmptyCode(): void
     {
         // Empty code returns null, not an exception
@@ -224,9 +214,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test verification code is cleared on verification
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testVerificationCodeIsClearedAfterVerification(): void
     {
         $car = new Car($this->testCarId);
@@ -245,9 +234,8 @@ final class CarVerificationTest extends IntegrationTestCase
 
     /**
      * Test mark sold clears verification code
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMarkSoldClearsVerificationCode(): void
     {
         $car = new Car($this->testCarId);

--- a/tests/integration/DocumentationViewerTest.php
+++ b/tests/integration/DocumentationViewerTest.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/IntegrationTestCase.php';
 
 use ElanRegistry\Exceptions\DocumentationException;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * DocumentationViewerTest
  *
@@ -115,8 +117,8 @@ class DocumentationViewerTest extends IntegrationTestCase
      *
      * @param string $invalidDoc Invalid document name to test
      * @test
-     * @dataProvider invalidDocumentFormatProvider
      */
+    #[DataProvider('invalidDocumentFormatProvider')]
     public function testInvalidDocumentFormatRejected(string $invalidDoc): void
     {
         // Verify the regex pattern blocks invalid formats
@@ -280,8 +282,8 @@ class DocumentationViewerTest extends IntegrationTestCase
      * @param string $scenario The error scenario being tested
      * @param string $expectedCategory The expected log category
      * @test
-     * @dataProvider logCategoryProvider
      */
+    #[DataProvider('logCategoryProvider')]
     public function testLogCategoriesAreCorrect(string $scenario, string $expectedCategory): void
     {
         $logCategories = [

--- a/tests/integration/ErrorPageHeadersTest.php
+++ b/tests/integration/ErrorPageHeadersTest.php
@@ -3,23 +3,24 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test security headers on error pages
  *
  * Verifies that error pages (403, 404, 500) return proper
  * anti-clickjacking headers even if init.php fails to load.
- *
- * @group integration
- * @group security
- * @group error-pages
  */
+#[Group('integration')]
+#[Group('security')]
+#[Group('error-pages')]
 class ErrorPageHeadersTest extends TestCase
 {
     /**
      * Test that error page files include security header fallbacks
-     *
-     * @dataProvider errorPageProvider
      */
+    #[DataProvider('errorPageProvider')]
     public function testErrorPageIncludesSecurityHeaders(string $pageName): void
     {
         $errorPageFile = dirname(__DIR__, 2) . '/error/' . $pageName;
@@ -61,9 +62,8 @@ class ErrorPageHeadersTest extends TestCase
      *
      * Headers should be set early in the file, before any includes that
      * might fail (like init.php)
-     *
-     * @dataProvider errorPageProvider
      */
+    #[DataProvider('errorPageProvider')]
     public function testErrorPageHeadersBeforeInitPhp(string $pageName): void
     {
         $errorPageFile = dirname(__DIR__, 2) . '/error/' . $pageName;
@@ -119,9 +119,8 @@ class ErrorPageHeadersTest extends TestCase
      *
      * Error pages allow framing within same origin (more user-friendly)
      * while still protecting against cross-origin clickjacking
-     *
-     * @dataProvider errorPageProvider
      */
+    #[DataProvider('errorPageProvider')]
     public function testErrorPageUsesSameoriginPolicy(string $pageName): void
     {
         $errorPageFile = dirname(__DIR__, 2) . '/error/' . $pageName;

--- a/tests/integration/FactoryRegistryLinkIntegrationTest.php
+++ b/tests/integration/FactoryRegistryLinkIntegrationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Integration tests for Registry Link workflow in factory page
  *
@@ -19,11 +21,11 @@ require_once __DIR__ . '/IntegrationTestCase.php';
  * - HTTP method validation
  * - Response format and data types
  *
- * @group integration
- * @group factories
  * @author Elan Registry Development Team
  * @copyright 2025
  */
+#[Group('integration')]
+#[Group('factories')]
 final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
 {
     protected $db;
@@ -49,10 +51,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test findCarByChassis finds registered car by chassis number
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testFindCarByChassisWithMatchingCar(): void
     {
         // Verify test car exists in database
@@ -73,10 +75,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test findCarByChassis returns null for non-existent chassis
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testFindCarByChassisWithNonExistentChassis(): void
     {
         $nonExistentChassis = 'NONEXISTENT' . uniqid();
@@ -93,10 +95,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test query uses LIMIT 1 and returns only first match
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testFindCarByChassisLimitsBehavior(): void
     {
         // Create second car with same chassis (shouldn't happen in real scenario)
@@ -120,10 +122,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test prepared statement prevents SQL injection
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testPreparedStatementPreventsInjection(): void
     {
         // Attempt SQL injection in chassis parameter
@@ -147,10 +149,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test chassis lookup returns integer car ID, not string
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testCarIdReturnedAsCorrectType(): void
     {
         $query = $this->db->query(
@@ -168,10 +170,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test query respects case sensitivity of chassis lookup
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testChassisCaseSensitivity(): void
     {
         // MySQL is typically case-insensitive for string comparisons by default
@@ -200,10 +202,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test empty chassis parameter returns error
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testEmptyChassisParameter(): void
     {
         // Empty string should not match any cars
@@ -218,10 +220,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test special characters in chassis number are handled correctly
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testSpecialCharactersInChassis(): void
     {
         $specialChassis = 'TEST-70/1234-' . uniqid();
@@ -246,10 +248,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test performance: single chassis lookup completes quickly
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testChassisLookupPerformance(): void
     {
         $startTime = microtime(true);
@@ -278,10 +280,10 @@ final class FactoryRegistryLinkIntegrationTest extends IntegrationTestCase
     /**
      * Test database can handle concurrent lookups (without actual concurrency)
      *
-     * @group integration
-     * @group slow
      * @return void
      */
+    #[Group('integration')]
+    #[Group('slow')]
     public function testSequentialChassisLookups(): void
     {
         // Simulate sequential lookups that might happen from pagination

--- a/tests/integration/GetDataTablesEndpointTest.php
+++ b/tests/integration/GetDataTablesEndpointTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Integration tests for getDataTables.php endpoint error handling
  *
@@ -16,10 +18,10 @@ require_once __DIR__ . '/IntegrationTestCase.php';
  * - Exception handling
  * - Missing data handling
  *
- * @group integration
  * @author Elan Registry Development Team
  * @copyright 2025
  */
+#[Group('integration')]
 final class GetDataTablesEndpointTest extends IntegrationTestCase
 {
     protected $db;
@@ -38,9 +40,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test GET request returns 405 Method Not Allowed
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testGetRequestReturnsMethodNotAllowed(): void
     {
         // Set up GET request (we can't directly test $_SERVER['REQUEST_METHOD'],
@@ -65,9 +66,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test method not allowed response follows Pattern A
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMethodNotAllowedFollowsPatternA(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -90,9 +90,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test method not allowed response does not log
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testMethodNotAllowedDoesNotLog(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -119,9 +118,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test invalid CSRF token returns 403 Forbidden
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testInvalidCsrfTokenReturnsForbidden(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -144,9 +142,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test CSRF error response follows Pattern A
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testCsrfErrorFollowsPatternA(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -169,9 +166,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test CSRF error includes DataTables metadata
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testCsrfErrorIncludesDataTablesMetadata(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -214,9 +210,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test CSRF error is logged to Security category
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testCsrfErrorIsLogged(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -243,9 +238,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test exception returns 500 Server Error
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testExceptionReturnsServerError(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -268,9 +262,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test exception response follows Pattern A
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testExceptionFollowsPatternA(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -299,9 +292,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test exception response includes DataTables metadata
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testExceptionIncludesDataTablesMetadata(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -332,9 +324,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test exception handler logs errors
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testExceptionIsLogged(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -370,9 +361,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test no POST data returns 400 Bad Request
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testNoPostDataReturnsBadRequest(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -395,9 +385,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test no POST data follows Pattern A
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testNoDataFollowsPatternA(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -426,9 +415,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test no data response includes DataTables metadata
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testNoDataIncludesDataTablesMetadata(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -463,9 +451,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test file has strict types declaration
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testFileHasStrictTypesDeclaration(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -480,9 +467,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test all error responses use send() method
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testAllErrorResponsesUseSendMethod(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -508,9 +494,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test CSRF error is returned before processing
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testCsrfCheckBeforeProcessing(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -536,9 +521,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test DataTables metadata structure is consistent
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testDataTablesMetadataStructureIsConsistent(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';
@@ -580,9 +564,8 @@ final class GetDataTablesEndpointTest extends IntegrationTestCase
 
     /**
      * Test no hardcoded error responses remain
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testNoHardcodedErrorResponses(): void
     {
         $filePath = __DIR__ . '/../../app/action/getDataTables.php';

--- a/tests/integration/LocationGeocoderTest.php
+++ b/tests/integration/LocationGeocoderTest.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/IntegrationTestCase.php';
 
 use ElanRegistry\Exceptions\LocationServiceException;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * LocationGeocoderTest / LocationServiceTest
  *
@@ -21,10 +23,9 @@ use ElanRegistry\Exceptions\LocationServiceException;
  * Uses free OpenStreetMap APIs (Photon/Nominatim) instead of Google Maps.
  *
  * Tests assume user ID 1 for rate limiting and logging context.
- *
- * @group Integration
- * @group Geocoding
  */
+#[Group('Integration')]
+#[Group('Geocoding')]
 class LocationGeocoderTest extends IntegrationTestCase
 {
     protected const TEST_USER_ID = 1;

--- a/tests/integration/Reference/CarModelTest.php
+++ b/tests/integration/Reference/CarModelTest.php
@@ -7,16 +7,18 @@ namespace Tests\Integration\Reference;
 use PHPUnit\Framework\TestCase;
 use ElanRegistry\Reference\CarModel;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * CarModelTest - Unit Tests for CarModel Reference Data Class
  *
  * Tests the read-only query interface for car model reference data.
  * These tests verify correct data retrieval and filtering from the car_models table.
- *
- * @group integration
- * @group reference-data
- * @covers \ElanRegistry\Reference\CarModel
  */
+#[Group('integration')]
+#[Group('reference-data')]
+#[CoversClass(CarModel::class)]
 class CarModelTest extends TestCase
 {
     private CarModel $carModel;

--- a/tests/integration/cars/services/CarValidatorModelTest.php
+++ b/tests/integration/cars/services/CarValidatorModelTest.php
@@ -8,16 +8,17 @@ use PHPUnit\Framework\TestCase;
 use ElanRegistry\Car\CarValidator;
 use ElanRegistry\Exceptions\CarValidationException;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Integration Tests for CarValidator Model Validation
  *
  * Tests model validation that requires car_models reference data.
  * These tests verify that CarValidator correctly integrates with the
  * CarModel class to validate model combinations against the database.
- *
- * @group integration
- * @group reference-data
  */
+#[Group('integration')]
+#[Group('reference-data')]
 final class CarValidatorModelTest extends TestCase
 {
     private CarValidator $validator;

--- a/tests/integration/database/CarDatabaseOperationsTest.php
+++ b/tests/integration/database/CarDatabaseOperationsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../IntegrationTestCase.php';
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Integration tests for Car database operations
  *
@@ -12,9 +14,8 @@ require_once __DIR__ . '/../IntegrationTestCase.php';
  * works correctly with the Car class.
  *
  * Uses real database fixtures (user ID 1, car IDs 1-2).
- *
- * @group integration
  */
+#[Group('integration')]
 final class CarDatabaseOperationsTest extends IntegrationTestCase
 {
     private $testCarId;
@@ -63,9 +64,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test car creation persists to database
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testCarCreationPersistsToDatabases(): void
     {
         $carData = [
@@ -98,9 +98,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test car update persists to database
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testCarUpdatePersiststoDatabase(): void
     {
         $car = new Car($this->testCarId);
@@ -127,9 +126,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test car deletion removes from database
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testCarDeletionRemovesFromDatabase(): void
     {
         $car = new Car($this->testCarId);
@@ -144,9 +142,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test car deletion creates audit trail
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testCarDeletionCreatesAuditTrail(): void
     {
         $car = new Car($this->testCarId);
@@ -164,9 +161,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test car transfer updates relationships
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testCarTransferUpdatesRelationships(): void
     {
         $car = new Car($this->testCarId);
@@ -194,9 +190,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test car transfer creates history record
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testCarTransferCreatesHistoryRecord(): void
     {
         $car = new Car($this->testCarId);
@@ -216,9 +211,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test car merge transfers history records
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testCarMergeTransfersHistoryRecords(): void
     {
         // Create a second test car to merge from
@@ -245,9 +239,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test database trigger creates update history on car update
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testDatabaseTriggerCreatesUpdateHistory(): void
     {
         $car = new Car($this->testCarId);
@@ -284,9 +277,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test car-user relationship integrity
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testCarUserRelationshipIntegrity(): void
     {
         // Verify car has valid user relationship
@@ -305,9 +297,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test verification code is set and retrieved
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testVerificationCodeSetAndRetrieved(): void
     {
         $car = new Car($this->testCarId);
@@ -330,9 +321,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test mark sold updates database
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testMarkSoldUpdatesDatabase(): void
     {
         // Create a test car for sold marking
@@ -367,9 +357,8 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
     /**
      * Test concurrent car operations maintain integrity
-     *
-     * @group integration
      */
+    #[Group('integration')]
     public function testConcurrentCarOperationsMaintainIntegrity(): void
     {
         // Load same car twice

--- a/tests/unit/ExceptionHierarchyTest.php
+++ b/tests/unit/ExceptionHierarchyTest.php
@@ -26,15 +26,17 @@ use ElanRegistry\Exceptions\UnauthorizedException;
 use ElanRegistry\Exceptions\ValidationException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test cases for the ElanRegistry exception hierarchy
  *
  * Verifies that all exceptions properly extend ElanRegistryException
  * and implement required methods correctly.
- *
- * @group unit
- * @group exceptions
  */
+#[Group('unit')]
+#[Group('exceptions')]
 class ExceptionHierarchyTest extends TestCase
 {
     /**
@@ -80,8 +82,8 @@ class ExceptionHierarchyTest extends TestCase
      * Test that all exceptions extend ElanRegistryException
      *
      * @param string $className Exception class name to test
-     * @dataProvider exceptionClassProvider
      */
+    #[DataProvider('exceptionClassProvider')]
     public function testExceptionExtendsBase(string $className): void
     {
         $this->assertTrue(
@@ -99,8 +101,8 @@ class ExceptionHierarchyTest extends TestCase
      * Test that all exceptions have required methods
      *
      * @param string $className Exception class name to test
-     * @dataProvider exceptionClassProvider
      */
+    #[DataProvider('exceptionClassProvider')]
     public function testExceptionHasRequiredMethods(string $className): void
     {
         $exception = new $className();
@@ -125,8 +127,8 @@ class ExceptionHierarchyTest extends TestCase
      * Test that HTTP status codes are valid
      *
      * @param string $className Exception class name to test
-     * @dataProvider exceptionClassProvider
      */
+    #[DataProvider('exceptionClassProvider')]
     public function testHttpStatusCodeIsValid(string $className): void
     {
         $exception = new $className();
@@ -149,8 +151,8 @@ class ExceptionHierarchyTest extends TestCase
      * Test that user messages are non-empty and user-friendly
      *
      * @param string $className Exception class name to test
-     * @dataProvider exceptionClassProvider
      */
+    #[DataProvider('exceptionClassProvider')]
     public function testUserMessageIsUserFriendly(string $className): void
     {
         $exception = new $className();
@@ -184,9 +186,8 @@ class ExceptionHierarchyTest extends TestCase
 
     /**
      * Test that log categories match expected values
-     *
-     * @dataProvider exceptionWithCategoryProvider
      */
+    #[DataProvider('exceptionWithCategoryProvider')]
     public function testLogCategoryMatchesExpected(
         string $className,
         string $expectedCategory
@@ -202,9 +203,8 @@ class ExceptionHierarchyTest extends TestCase
 
     /**
      * Test that HTTP status codes match expected values
-     *
-     * @dataProvider exceptionWithStatusProvider
      */
+    #[DataProvider('exceptionWithStatusProvider')]
     public function testHttpStatusMatchesExpected(
         string $className,
         int $expectedStatus
@@ -222,8 +222,8 @@ class ExceptionHierarchyTest extends TestCase
      * Test backward compatibility - existing constructor signature works
      *
      * @param string $className Exception class name to test
-     * @dataProvider exceptionClassProvider
      */
+    #[DataProvider('exceptionClassProvider')]
     public function testBackwardCompatibility(string $className): void
     {
         // Test with message only
@@ -244,8 +244,8 @@ class ExceptionHierarchyTest extends TestCase
      * Test withUserMessage factory method
      *
      * @param string $className Exception class name to test
-     * @dataProvider exceptionClassProvider
      */
+    #[DataProvider('exceptionClassProvider')]
     public function testWithUserMessageFactory(string $className): void
     {
         $exception = $className::withUserMessage(
@@ -270,8 +270,8 @@ class ExceptionHierarchyTest extends TestCase
      * Test that previous exception uses Throwable type (not just Exception)
      *
      * @param string $className Exception class name to test
-     * @dataProvider exceptionClassProvider
      */
+    #[DataProvider('exceptionClassProvider')]
     public function testPreviousAcceptsThrowable(string $className): void
     {
         $error = new Error('An error');

--- a/tests/unit/admin/BackupManagerTest.php
+++ b/tests/unit/admin/BackupManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
 // BackupManager and BackupException auto-loaded via custom autoloader
 // (BackupManager now in usersc/classes/admin/, BackupException in usersc/classes/exceptions/)
 
@@ -12,11 +13,10 @@ use PHPUnit\Framework\TestCase;
  *
  * Tests backup creation, validation, statistics, and cleanup operations
  * for the database backup management system.
- *
- * @group fast
- * @group unit
- * @group admin
  */
+#[Group('fast')]
+#[Group('unit')]
+#[Group('admin')]
 final class BackupManagerTest extends TestCase
 {
     private string $testBackupDir;
@@ -64,9 +64,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test BackupManager instantiation
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testInstantiation(): void
     {
         $this->assertInstanceOf(BackupManager::class, $this->backupManager);
@@ -75,9 +75,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test createSchemaBackup creates a backup file
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testCreateSchemaBackup(): void
     {
         $backupPath = $this->backupManager->createSchemaBackup('Test Operation', ['settings']);
@@ -90,9 +90,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test createSchemaBackup uses default tables when none specified
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testCreateSchemaBackupWithDefaultTables(): void
     {
         $backupPath = $this->backupManager->createSchemaBackup('Default Tables Test');
@@ -106,9 +106,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test createManualBackup creates a backup file
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testCreateManualBackup(): void
     {
         $backupPath = $this->backupManager->createManualBackup('Pre-Migration', ['users', 'cars']);
@@ -121,9 +121,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test createManualBackup includes metadata in backup
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testCreateManualBackupWithMetadata(): void
     {
         $metadata = [
@@ -141,9 +141,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test verifyBackupIntegrity validates a good backup
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testVerifyBackupIntegrityValidBackup(): void
     {
         // Create a test backup
@@ -161,9 +161,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test verifyBackupIntegrity detects non-existent file
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testVerifyBackupIntegrityNonExistentFile(): void
     {
         $result = $this->backupManager->verifyBackupIntegrity('/nonexistent/backup.sql');
@@ -175,9 +175,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test verifyBackupIntegrity detects empty file
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testVerifyBackupIntegrityEmptyFile(): void
     {
         // Create an empty file
@@ -193,9 +193,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test getEnhancedBackupStatistics returns statistics structure
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testGetEnhancedBackupStatistics(): void
     {
         // Create some test backups
@@ -225,9 +225,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test getEnhancedBackupStatistics calculates health score
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testGetEnhancedBackupStatisticsHealthScore(): void
     {
         $this->backupManager->createSchemaBackup('Health Test', ['settings']);
@@ -242,9 +242,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test performEnhancedCleanup returns cleanup statistics
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testPerformEnhancedCleanup(): void
     {
         // Create some test backups
@@ -271,9 +271,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test performEnhancedCleanup does not delete recent backups
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testPerformEnhancedCleanupPreservesRecentBackups(): void
     {
         // Create a recent backup
@@ -289,9 +289,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test backup file naming convention
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testBackupFileNamingConvention(): void
     {
         $backupPath = $this->backupManager->createSchemaBackup('Test Naming', ['settings']);
@@ -308,9 +308,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test backup contains metadata header
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testBackupContainsMetadata(): void
     {
         $backupPath = $this->backupManager->createSchemaBackup('Metadata Test', ['settings']);
@@ -326,9 +326,9 @@ final class BackupManagerTest extends TestCase
     /**
      * Test backup contains SQL statements
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testBackupContainsSqlStatements(): void
     {
         $backupPath = $this->backupManager->createSchemaBackup('SQL Test', ['settings']);

--- a/tests/unit/api/ApiResponseTest.php
+++ b/tests/unit/api/ApiResponseTest.php
@@ -4,24 +4,25 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for ApiResponse class
  *
  * Tests all factory methods, builder methods, output methods, and edge cases
  * for the standardized API response system.
- *
- * @group fast
- * @group unit
- * @group api
  */
+#[Group('fast')]
+#[Group('unit')]
+#[Group('api')]
 final class ApiResponseTest extends TestCase
 {
     /**
      * Test success factory method with default message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testSuccessWithDefaultMessage(): void
     {
         $response = ApiResponse::success();
@@ -34,9 +35,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test success factory method with custom message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testSuccessWithCustomMessage(): void
     {
         $response = ApiResponse::success('Profile updated successfully!');
@@ -49,9 +50,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test error factory method with default message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testErrorWithDefaultMessage(): void
     {
         $response = ApiResponse::error();
@@ -64,9 +65,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test error factory method with custom message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testErrorWithCustomMessage(): void
     {
         $response = ApiResponse::error('Invalid request data');
@@ -79,9 +80,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test error factory method with custom status code
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testErrorWithCustomStatusCode(): void
     {
         $response = ApiResponse::error('Rate limit exceeded', 429);
@@ -94,9 +95,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test validationError factory method with errors
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testValidationError(): void
     {
         $errors = [
@@ -115,9 +116,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test validationError factory method with custom message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testValidationErrorWithCustomMessage(): void
     {
         $errors = ['field' => 'Error'];
@@ -130,9 +131,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test unauthorized factory method with default message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testUnauthorizedWithDefaultMessage(): void
     {
         $response = ApiResponse::unauthorized();
@@ -145,9 +146,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test unauthorized factory method with custom message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testUnauthorizedWithCustomMessage(): void
     {
         $response = ApiResponse::unauthorized('Session expired');
@@ -159,9 +160,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test forbidden factory method with default message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testForbiddenWithDefaultMessage(): void
     {
         $response = ApiResponse::forbidden();
@@ -174,9 +175,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test forbidden factory method with custom message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testForbiddenWithCustomMessage(): void
     {
         $response = ApiResponse::forbidden('Admin access required');
@@ -188,9 +189,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test notFound factory method with default message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testNotFoundWithDefaultMessage(): void
     {
         $response = ApiResponse::notFound();
@@ -203,9 +204,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test notFound factory method with custom message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testNotFoundWithCustomMessage(): void
     {
         $response = ApiResponse::notFound('Car not found');
@@ -217,9 +218,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test serverError factory method with default message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testServerErrorWithDefaultMessage(): void
     {
         $response = ApiResponse::serverError();
@@ -232,9 +233,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test serverError factory method with custom message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testServerErrorWithCustomMessage(): void
     {
         $response = ApiResponse::serverError('Database connection failed');
@@ -246,9 +247,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withData adds data to response
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithDataAddsSingleValue(): void
     {
         $response = ApiResponse::success('Done')
@@ -262,9 +263,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withData is immutable
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithDataIsImmutable(): void
     {
         $original = ApiResponse::success('Done');
@@ -278,9 +279,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withData can be chained multiple times
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithDataChaining(): void
     {
         $response = ApiResponse::success('Done')
@@ -297,9 +298,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withDataArray adds multiple values at once
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithDataArray(): void
     {
         $response = ApiResponse::success('Done')
@@ -316,9 +317,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withDataArray is immutable
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithDataArrayIsImmutable(): void
     {
         $original = ApiResponse::success('Done');
@@ -331,9 +332,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withLogging sets pending log
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithLogging(): void
     {
         $response = ApiResponse::success('Done')
@@ -349,9 +350,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withLogging is immutable
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithLoggingIsImmutable(): void
     {
         $original = ApiResponse::success('Done');
@@ -364,9 +365,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withStatusCode overrides status code
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithStatusCode(): void
     {
         $response = ApiResponse::error('Custom error')
@@ -378,9 +379,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withStatusCode is immutable
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithStatusCodeIsImmutable(): void
     {
         $original = ApiResponse::error('Error');
@@ -393,9 +394,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test toArray returns minimal response for success
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testToArrayMinimalSuccess(): void
     {
         $response = ApiResponse::success('Done');
@@ -410,9 +411,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test toArray returns minimal response for error
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testToArrayMinimalError(): void
     {
         $response = ApiResponse::error('Failed');
@@ -427,9 +428,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test toArray includes additional data
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testToArrayWithData(): void
     {
         $response = ApiResponse::success('Done')
@@ -447,9 +448,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test toArray for validation error includes errors
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testToArrayForValidationError(): void
     {
         $errors = [
@@ -468,9 +469,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test toJson returns valid JSON string
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testToJson(): void
     {
         $response = ApiResponse::success('Done');
@@ -484,9 +485,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test toJson with special characters
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testToJsonWithSpecialCharacters(): void
     {
         $response = ApiResponse::success('Updated "Lotus Elan" & saved <data>');
@@ -500,9 +501,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response with empty string message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testEmptyStringMessage(): void
     {
         $response = ApiResponse::success('');
@@ -515,9 +516,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response with null data value
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testNullDataValue(): void
     {
         $response = ApiResponse::success('Done')
@@ -531,9 +532,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response with empty array data
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testEmptyArrayData(): void
     {
         $response = ApiResponse::success('Done')
@@ -546,9 +547,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response with nested array data
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testNestedArrayData(): void
     {
         $nestedData = [
@@ -571,9 +572,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response with numeric data
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testNumericData(): void
     {
         $response = ApiResponse::success('Done')
@@ -590,9 +591,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response with boolean data
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testBooleanData(): void
     {
         $response = ApiResponse::success('Done')
@@ -607,9 +608,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test getStatusCode for all factory methods
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testStatusCodesForAllFactoryMethods(): void
     {
         $this->assertEquals(200, ApiResponse::success()->getStatusCode());
@@ -624,9 +625,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test isSuccess for all factory methods
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testIsSuccessForAllFactoryMethods(): void
     {
         $this->assertTrue(ApiResponse::success()->isSuccess());
@@ -641,9 +642,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test full builder chain maintains all values
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testFullBuilderChain(): void
     {
         $response = ApiResponse::success('Profile updated!')
@@ -668,9 +669,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test validation error with empty errors array
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testValidationErrorWithEmptyErrors(): void
     {
         $response = ApiResponse::validationError([]);
@@ -683,9 +684,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withLogging with zero user ID
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithLoggingZeroUserId(): void
     {
         $response = ApiResponse::forbidden('Access denied')
@@ -698,9 +699,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response data does not include internal state
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testToArrayDoesNotIncludePendingLog(): void
     {
         $response = ApiResponse::success('Done')
@@ -715,9 +716,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test data can overwrite values with same key
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithDataOverwritesSameKey(): void
     {
         $response = ApiResponse::success('Done')
@@ -730,9 +731,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test getMessage getter
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testGetMessage(): void
     {
         $response = ApiResponse::success('Test message');
@@ -742,9 +743,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test getData returns empty array when no data set
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testGetDataReturnsEmptyArrayByDefault(): void
     {
         $response = ApiResponse::success('Done');
@@ -754,9 +755,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test getPendingLog returns null when no log set
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testGetPendingLogReturnsNullByDefault(): void
     {
         $response = ApiResponse::success('Done');
@@ -766,9 +767,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response with Unicode characters
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testUnicodeCharacters(): void
     {
         $response = ApiResponse::success('Mise à jour réussie! 日本語 🚗');
@@ -782,9 +783,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test response with very long message
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testVeryLongMessage(): void
     {
         $longMessage = str_repeat('A', 10000);
@@ -797,9 +798,9 @@ final class ApiResponseTest extends TestCase
     /**
      * Test withDataArray merges with existing data
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testWithDataArrayMergesWithExisting(): void
     {
         $response = ApiResponse::success('Done')

--- a/tests/unit/api/GetDataTablesFindCarByChassisTest.php
+++ b/tests/unit/api/GetDataTablesFindCarByChassisTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for getDataTables.php findCarByChassis endpoint logic
  *
@@ -18,20 +20,20 @@ use PHPUnit\Framework\TestCase;
  * - Special characters handling
  * - Response format validation (Pattern A)
  *
- * @group fast
- * @group unit
- * @group api
  * @author Elan Registry Development Team
  * @copyright 2025
  */
+#[Group('fast')]
+#[Group('unit')]
+#[Group('api')]
 final class GetDataTablesFindCarByChassisTest extends TestCase
 {
     /**
      * Test missing chassis parameter returns validation error
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testMissingChassisParameterReturnsError(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -62,9 +64,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test chassis parameter is retrieved correctly
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testChassisParameterRetrieval(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -81,9 +83,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test SQL query uses prepared statement (prevents SQL injection)
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testSqlQueryUsesPreparedStatement(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -120,9 +122,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test car found response uses correct pattern
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testCarFoundResponsePattern(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -160,9 +162,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test car not found response uses correct pattern
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testCarNotFoundResponsePattern(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -193,9 +195,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test response uses ApiResponse Pattern A format
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testResponseFollowsPatternA(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -227,9 +229,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test endpoint exits after sending response
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testEndpointExitsAfterResponse(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -246,9 +248,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test chassis lookup returns integer car_id (not string)
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testCarIdIsProperType(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -269,9 +271,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test limit 1 ensures only one result is returned
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testQueryLimitsToOneResult(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -288,9 +290,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test findCarByChassis is early return before table validation
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testFindCarByChassisIsEarlyReturn(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -312,9 +314,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
     /**
      * Test chassis parameter is not logged in response
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testChassisParameterNotLoggedInResponse(): void
     {
         $filePath = __DIR__ . '/../../../app/action/getDataTables.php';
@@ -352,9 +354,9 @@ final class GetDataTablesFindCarByChassisTest extends TestCase
      * Regression test for issue #581: Missing CSRF token caused 403 Forbidden errors
      * This ensures the calling code passes the csrf parameter to prevent CSRF validation failures
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testFactoryPageIncludesCsrfTokenInRequest(): void
     {
         $filePath = __DIR__ . '/../../../app/cars/factory.php';

--- a/tests/unit/api/LocationServiceResponseTest.php
+++ b/tests/unit/api/LocationServiceResponseTest.php
@@ -4,25 +4,26 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for Location Service AJAX endpoints using ApiResponse
  *
  * Tests the refactored location-search.php and location-reverse.php endpoints
  * to verify they properly use the ApiResponse class and return standardized
  * response formats.
- *
- * @group fast
- * @group unit
- * @group api
  */
+#[Group('fast')]
+#[Group('unit')]
+#[Group('api')]
 final class LocationServiceResponseTest extends TestCase
 {
     /**
      * Test that search endpoint would return 405 for non-POST requests
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationSearchReturnsMethodNotAllowedForNonPost(): void
     {
         $response = ApiResponse::error('Method not allowed', 405);
@@ -36,9 +37,9 @@ final class LocationServiceResponseTest extends TestCase
     /**
      * Test that reverse geocode endpoint would return 405 for non-POST requests
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationReverseReturnsMethodNotAllowedForNonPost(): void
     {
         $response = ApiResponse::error('Method not allowed', 405);
@@ -50,9 +51,9 @@ final class LocationServiceResponseTest extends TestCase
     /**
      * Test that search endpoint would return 403 for invalid CSRF token
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationSearchReturnsForbiddenForInvalidCsrf(): void
     {
         $response = ApiResponse::forbidden('Invalid CSRF token');
@@ -65,9 +66,9 @@ final class LocationServiceResponseTest extends TestCase
     /**
      * Test that reverse geocode endpoint would return 403 for invalid CSRF token
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationReverseReturnsForbiddenForInvalidCsrf(): void
     {
         $response = ApiResponse::forbidden('Invalid CSRF token');
@@ -84,9 +85,9 @@ final class LocationServiceResponseTest extends TestCase
      * - Response has 'message' key (not 'error' key)
      * - HTTP status code is 400
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationSearchReturnsValidationErrorWithMessageKey(): void
     {
         $response = ApiResponse::error('Search query must be at least 2 characters', 400);
@@ -108,9 +109,9 @@ final class LocationServiceResponseTest extends TestCase
      * - HTTP status code is 400
      * - Optional logging can be attached
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationSearchReturnsBadRequestForLocationServiceException(): void
     {
         $errorMessage = 'Rate limit exceeded. Please try again in a moment.';
@@ -137,9 +138,9 @@ final class LocationServiceResponseTest extends TestCase
      * - Response includes 'results' and 'count' keys in data
      * - HTTP status code is 200
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationSearchReturnsSuccessWithResultsAndCount(): void
     {
         $mockResults = [
@@ -174,9 +175,9 @@ final class LocationServiceResponseTest extends TestCase
      * - Response has generic error message
      * - HTTP status code is 500
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationSearchReturnsServerErrorForUnexpectedException(): void
     {
         $response = ApiResponse::serverError('An error occurred while searching locations')
@@ -196,9 +197,9 @@ final class LocationServiceResponseTest extends TestCase
      * - Response has 'message' key
      * - HTTP status code is 400
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationReverseReturnsBadRequestForMissingCoordinates(): void
     {
         $response = ApiResponse::error('Latitude and longitude are required', 400);
@@ -218,9 +219,9 @@ final class LocationServiceResponseTest extends TestCase
      * - HTTP status code is 400 (always, for consistent behavior)
      * - Logging is included
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationReverseReturnsBadRequestForLocationServiceException(): void
     {
         $errorMessage = 'Invalid coordinates provided';
@@ -246,9 +247,9 @@ final class LocationServiceResponseTest extends TestCase
      * - Response includes 'location' object in data with city, state, country, lat, lon
      * - HTTP status code is 200
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationReverseReturnsSuccessWithLocation(): void
     {
         $mockLocation = [
@@ -279,9 +280,9 @@ final class LocationServiceResponseTest extends TestCase
      * - Response has generic error message
      * - HTTP status code is 500
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationReverseReturnsServerErrorForUnexpectedException(): void
     {
         $response = ApiResponse::serverError('An error occurred while reverse geocoding coordinates')
@@ -299,9 +300,9 @@ final class LocationServiceResponseTest extends TestCase
      * This verifies the frontend JavaScript can properly read the 'message' key
      * when checking if data.success is false.
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationResponsesUseMessageKeyNotErrorKey(): void
     {
         // Test error response
@@ -329,9 +330,9 @@ final class LocationServiceResponseTest extends TestCase
      * Location services are used during registration (anonymous users),
      * so logging should work with userId=0
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationResponsesWithAnonymousUserLogging(): void
     {
         $response = ApiResponse::error('Search failed', 400)
@@ -347,9 +348,9 @@ final class LocationServiceResponseTest extends TestCase
     /**
      * Test logging is included in responses with authenticated users
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationResponsesWithAuthenticatedUserLogging(): void
     {
         $userId = 42;
@@ -365,9 +366,9 @@ final class LocationServiceResponseTest extends TestCase
     /**
      * Test search response with empty results
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationSearchWithEmptyResults(): void
     {
         $response = ApiResponse::success('Search completed')
@@ -383,9 +384,9 @@ final class LocationServiceResponseTest extends TestCase
     /**
      * Test search response with multiple results
      *
-     * @group fast
      * @return void
      */
+    #[Group('fast')]
     public function testLocationSearchWithMultipleResults(): void
     {
         $mockResults = [

--- a/tests/unit/cars/CarCoreTest.php
+++ b/tests/unit/cars/CarCoreTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Core Car class tests
  *
  * Consolidated tests for Car class functionality including instantiation,
  * find operations, exists checks, basic getters, and static methods.
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarCoreTest extends TestCase
 {
     private int $testCarId = 1;

--- a/tests/unit/cars/CarCrudTest.php
+++ b/tests/unit/cars/CarCrudTest.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 use ElanRegistry\Exceptions\CarValidationException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Car CRUD operations tests
  *
  * Tests cover create, read, update, delete operations including
  * validation, security, file uploads, and image management.
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarCrudTest extends TestCase
 {
     private $testCarId;

--- a/tests/unit/cars/services/CarAdministrationServiceTest.php
+++ b/tests/unit/cars/services/CarAdministrationServiceTest.php
@@ -7,11 +7,12 @@ use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\CarValidationException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for CarAdministrationService service class
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarAdministrationServiceTest extends TestCase
 {
     private CarAdministrationService $service;

--- a/tests/unit/cars/services/CarDataTablesServiceTest.php
+++ b/tests/unit/cars/services/CarDataTablesServiceTest.php
@@ -6,11 +6,12 @@ use ElanRegistry\Car\CarDataTablesService;
 use ElanRegistry\Exceptions\CarValidationException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for CarDataTablesService service class
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarDataTablesServiceTest extends TestCase
 {
     private CarDataTablesService $service;

--- a/tests/unit/cars/services/CarImageProcessorTest.php
+++ b/tests/unit/cars/services/CarImageProcessorTest.php
@@ -6,11 +6,12 @@ use ElanRegistry\Car\CarImageProcessor;
 use ElanRegistry\Exceptions\ImageProcessingException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for CarImageProcessor service class
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarImageProcessorTest extends TestCase
 {
     private CarImageProcessor $processor;

--- a/tests/unit/cars/services/CarRepositoryTest.php
+++ b/tests/unit/cars/services/CarRepositoryTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 use ElanRegistry\Car\CarRepository;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for CarRepository service class
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarRepositoryTest extends TestCase
 {
     private CarRepository $repo;

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -7,11 +7,13 @@ use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\Exceptions\ElanRegistryException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for CarValidator service class
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarValidatorTest extends TestCase
 {
     private CarValidator $validator;
@@ -258,8 +260,8 @@ final class CarValidatorTest extends TestCase
      * (extends ElanRegistryException), never generic Exception.
      *
      * @param array<string, mixed> $fields
-     * @dataProvider invalidFieldsProvider
      */
+    #[DataProvider('invalidFieldsProvider')]
     public function testAllValidationErrorsThrowCarValidationException(array $fields, bool $requireAll): void
     {
         try {

--- a/tests/unit/cars/services/CarVerificationManagerTest.php
+++ b/tests/unit/cars/services/CarVerificationManagerTest.php
@@ -6,11 +6,12 @@ use ElanRegistry\Car\CarVerificationManager;
 use ElanRegistry\Exceptions\CarValidationException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for CarVerificationManager service class
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarVerificationManagerTest extends TestCase
 {
     private CarVerificationManager $manager;

--- a/tests/unit/cars/services/FactoryDataFormatterTest.php
+++ b/tests/unit/cars/services/FactoryDataFormatterTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 use ElanRegistry\Car\FactoryDataFormatter;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for FactoryDataFormatter service class
- *
- * @group fast
  */
+#[Group('fast')]
 final class FactoryDataFormatterTest extends TestCase
 {
     public function testSuffixToTextReturnsCorrectDescriptionForA(): void

--- a/tests/unit/classes/CarViewTest.php
+++ b/tests/unit/classes/CarViewTest.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 use ElanRegistry\Exceptions\ImageProcessingException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * CarView class tests
  *
  * Tests static utility methods for car display and image generation.
  * Focus: Input validation, exception handling, HTML structure.
- *
- * @group fast
  */
+#[Group('fast')]
 final class CarViewTest extends TestCase
 {
     // ============================================================

--- a/tests/unit/classes/DocumentConfigTest.php
+++ b/tests/unit/classes/DocumentConfigTest.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use ElanRegistry\Documentation\DocumentConfig;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * DocumentConfig class tests
  *
  * Tests document configuration, validation, and access control.
  * CRITICAL: Access control for admin-only documents.
- *
- * @group fast
- * @group security
  */
+#[Group('fast')]
+#[Group('security')]
 final class DocumentConfigTest extends TestCase
 {
     // ============================================================

--- a/tests/unit/classes/DocumentPortalTemplateTest.php
+++ b/tests/unit/classes/DocumentPortalTemplateTest.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use ElanRegistry\Documentation\DocumentPortalTemplate;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * DocumentPortalTemplate class tests
  *
  * Tests static rendering utilities for documentation portal pages.
- *
- * @group fast
- * @group documentation
  */
+#[Group('fast')]
+#[Group('documentation')]
 final class DocumentPortalTemplateTest extends TestCase
 {
     // ============================================================

--- a/tests/unit/classes/EmailTemplateTest.php
+++ b/tests/unit/classes/EmailTemplateTest.php
@@ -1103,7 +1103,6 @@ final class EmailTemplateTest extends TestCase
 
     // ============================================================
     // createMessageContent() DIRECT TESTS
-    // @group createMessageContent
     // ============================================================
 
     public function testCreateMessageContentEscapesHtml(): void

--- a/tests/unit/classes/EmailTemplateTest.php
+++ b/tests/unit/classes/EmailTemplateTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * EmailTemplate class tests
  *
  * Tests email template rendering with focus on XSS prevention
  * and proper HTML structure.
- *
- * @group fast
  */
+#[Group('fast')]
 final class EmailTemplateTest extends TestCase
 {
     private EmailTemplate $template;

--- a/tests/unit/classes/MarkdownParserTest.php
+++ b/tests/unit/classes/MarkdownParserTest.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use ElanRegistry\Documentation\MarkdownParser;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * MarkdownParser class tests
  *
  * CRITICAL SECURITY TESTS for XSS prevention in markdown conversion.
  * Focus: URL validation, script injection prevention, safe output.
- *
- * @group fast
- * @group security
  */
+#[Group('fast')]
+#[Group('security')]
 final class MarkdownParserTest extends TestCase
 {
     // ============================================================

--- a/tests/unit/exceptions/CarExceptionHierarchyTest.php
+++ b/tests/unit/exceptions/CarExceptionHierarchyTest.php
@@ -14,16 +14,18 @@ use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\Exceptions\ElanRegistryException;
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test cases for the CarException hierarchy
  *
  * Verifies that all car-related exceptions properly extend CarException,
  * which in turn extends ElanRegistryException, maintaining backward
  * compatibility with existing catch blocks.
- *
- * @group unit
- * @group exceptions
  */
+#[Group('unit')]
+#[Group('exceptions')]
 class CarExceptionHierarchyTest extends TestCase
 {
     /**
@@ -67,8 +69,8 @@ class CarExceptionHierarchyTest extends TestCase
      * Test that all car exceptions extend CarException
      *
      * @param string $className Exception class name to test
-     * @dataProvider carExceptionClassProvider
      */
+    #[DataProvider('carExceptionClassProvider')]
     public function testCarExceptionExtendsCarException(string $className): void
     {
         $this->assertTrue(
@@ -81,8 +83,8 @@ class CarExceptionHierarchyTest extends TestCase
      * Test backward compatibility - all car exceptions are still instanceof ElanRegistryException
      *
      * @param string $className Exception class name to test
-     * @dataProvider carExceptionClassProvider
      */
+    #[DataProvider('carExceptionClassProvider')]
     public function testBackwardCompatibilityWithElanRegistryException(string $className): void
     {
         $exception = new $className();
@@ -97,8 +99,8 @@ class CarExceptionHierarchyTest extends TestCase
      * Test backward compatibility - all car exceptions are instanceof CarException
      *
      * @param string $className Exception class name to test
-     * @dataProvider carExceptionClassProvider
      */
+    #[DataProvider('carExceptionClassProvider')]
     public function testAllCarExceptionsAreInstanceOfCarException(string $className): void
     {
         $exception = new $className();

--- a/tests/unit/helpers/TypeHelpersTest.php
+++ b/tests/unit/helpers/TypeHelpersTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Unit tests for type helper functions (dbInt, dbIntOrNull, currentUserId)
- *
- * @group fast
  */
+#[Group('fast')]
 final class TypeHelpersTest extends TestCase
 {
     // ============================================================

--- a/tests/unit/security/HeadTagsSecurityTest.php
+++ b/tests/unit/security/HeadTagsSecurityTest.php
@@ -3,16 +3,17 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test head_tags.php security migration
  *
  * Verifies that head_tags.php uses validated server globals
  * and properly handles invalid host scenarios.
- *
- * @group security
- * @group head-tags
- * @group server-globals
  */
+#[Group('security')]
+#[Group('head-tags')]
+#[Group('server-globals')]
 class HeadTagsSecurityTest extends TestCase
 {
     private string $headTagsFile;

--- a/tests/unit/security/SecurityFunctionsTest.php
+++ b/tests/unit/security/SecurityFunctionsTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Direct tests of security functions without full framework bootstrap
  * SECURITY: Removed eval() usage and implemented safe function definitions
- *
- * @group fast
  */
+#[Group('fast')]
 class SecurityFunctionsTest extends TestCase
 {
     private $tempDir;
@@ -114,10 +115,8 @@ class SecurityFunctionsTest extends TestCase
             }
         }
     }
-    
-    /**
-     * @group fast
-     */
+
+    #[Group('fast')]
     public function testSecureFilenameGeneration(): void
     {
         $filename1 = generateSecureFilename('jpg');
@@ -133,10 +132,8 @@ class SecurityFunctionsTest extends TestCase
         // Should be proper length (img_ + 32 hex chars + .ext)
         $this->assertEquals(40, strlen($filename1)); // img_ (4) + 32 hex + .jpg (4)
     }
-    
-    /**
-     * @group fast
-     */
+
+    #[Group('fast')]
     public function testMimeTypeValidationValid(): void
     {
         // Create test files with valid MIME types
@@ -147,10 +144,8 @@ class SecurityFunctionsTest extends TestCase
         $this->assertEquals('image/jpeg', getMimeType($jpegFile));
         $this->assertEquals('image/png', getMimeType($pngFile));
     }
-    
-    /**
-     * @group fast
-     */
+
+    #[Group('fast')]
     public function testMimeTypeValidationInvalid(): void
     {
         // Create test file with invalid MIME type  
@@ -161,10 +156,8 @@ class SecurityFunctionsTest extends TestCase
         $this->expectExceptionMessage('Invalid file type detected');
         getMimeType($phpFile);
     }
-    
-    /**
-     * @group fast
-     */
+
+    #[Group('fast')]
     public function testExtensionMappingSecurity(): void
     {
         // Valid MIME types should return correct extensions
@@ -178,10 +171,8 @@ class SecurityFunctionsTest extends TestCase
         $this->expectExceptionMessage('Unsupported file type');
         getExtension('application/x-php');
     }
-    
-    /**
-     * @group fast
-     */
+
+    #[Group('fast')]
     public function testFileUploadSizeValidation(): void
     {
         // Test file within size limit
@@ -207,9 +198,8 @@ class SecurityFunctionsTest extends TestCase
     
     /**
      * Test file upload minimum size validation
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testFileUploadMinimumSize(): void
     {
         // Test file below minimum size
@@ -226,9 +216,8 @@ class SecurityFunctionsTest extends TestCase
     
     /**
      * Test file upload error handling for various upload error codes
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testFileUploadErrorHandling(): void
     {
         // Test various upload errors
@@ -257,10 +246,8 @@ class SecurityFunctionsTest extends TestCase
             }
         }
     }
-    
-    /**
-     * @group slow
-     */
+
+    #[Group('slow')]
     public function testFilenameCollisionHandling(): void
     {
         // Generate multiple filenames - should all be unique
@@ -271,10 +258,8 @@ class SecurityFunctionsTest extends TestCase
             $filenames[] = $filename;
         }
     }
-    
-    /**
-     * @group slow
-     */
+
+    #[Group('slow')]
     public function testFilenameEntropy(): void
     {
         $filenames = [];

--- a/tests/unit/security/SecurityFunctionsTest.php
+++ b/tests/unit/security/SecurityFunctionsTest.php
@@ -80,7 +80,6 @@ class SecurityFunctionsTest extends TestCase
                 if (function_exists("finfo_open")) {
                     $finfo = finfo_open(FILEINFO_MIME_TYPE);
                     $mtype = finfo_file($finfo, $file);
-                    finfo_close($finfo);
                 } elseif (function_exists("mime_content_type")) {
                     $mtype = mime_content_type($file);
                 } else {

--- a/tests/unit/security/SecurityHeadersTest.php
+++ b/tests/unit/security/SecurityHeadersTest.php
@@ -3,16 +3,17 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test security_headers.php HTTPS detection migration
  *
  * Verifies that security_headers.php uses validated $is_https
  * global instead of raw $_SERVER proxy headers.
- *
- * @group security
- * @group security-headers
- * @group server-globals
  */
+#[Group('security')]
+#[Group('security-headers')]
+#[Group('server-globals')]
 class SecurityHeadersTest extends TestCase
 {
     private string $securityHeadersFile;

--- a/tests/unit/system/AutoloaderTest.php
+++ b/tests/unit/system/AutoloaderTest.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test custom autoloader functionality
  *
  * Verifies that the hybrid namespace-aware autoloader correctly loads
  * both namespaced (PSR-4) and non-namespaced (recursive scan) classes.
- *
- * @group system
- * @group autoloader
  */
+#[Group('system')]
+#[Group('autoloader')]
 class AutoloaderTest extends TestCase
 {
     /**

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test that car-related PHP endpoints use LogCategories constants
  * instead of hardcoded string literals in withLogging() and logger() calls.
- *
- * @group system
- * @group logging
  */
+#[Group('system')]
+#[Group('logging')]
 class LogCategoriesUsageTest extends TestCase
 {
     /**
@@ -45,9 +47,7 @@ class LogCategoriesUsageTest extends TestCase
         $this->rootDir = dirname(__DIR__, 3);
     }
 
-    /**
-     * @dataProvider carEndpointFilesProvider
-     */
+    #[DataProvider('carEndpointFilesProvider')]
     public function testNoHardcodedWithLoggingStrings(string $relativePath): void
     {
         $filePath = $this->rootDir . '/' . $relativePath;
@@ -76,9 +76,7 @@ class LogCategoriesUsageTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider carEndpointFilesProvider
-     */
+    #[DataProvider('carEndpointFilesProvider')]
     public function testNoHardcodedLoggerStrings(string $relativePath): void
     {
         $filePath = $this->rootDir . '/' . $relativePath;
@@ -106,9 +104,7 @@ class LogCategoriesUsageTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider contactEndpointFilesProvider
-     */
+    #[DataProvider('contactEndpointFilesProvider')]
     public function testNoHardcodedWithLoggingStringsInContactFiles(string $relativePath): void
     {
         $filePath = $this->rootDir . '/' . $relativePath;
@@ -137,9 +133,7 @@ class LogCategoriesUsageTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider contactEndpointFilesProvider
-     */
+    #[DataProvider('contactEndpointFilesProvider')]
     public function testNoHardcodedLoggerStringsInContactFiles(string $relativePath): void
     {
         $filePath = $this->rootDir . '/' . $relativePath;

--- a/tests/unit/system/ServerGlobalsTest.php
+++ b/tests/unit/system/ServerGlobalsTest.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test server globals initialization module
  *
  * Verifies that server_globals.php correctly initializes all global variables
  * with proper validation and safe defaults.
- *
- * @group system
- * @group server-globals
  */
+#[Group('system')]
+#[Group('server-globals')]
 class ServerGlobalsTest extends TestCase
 {
     private string $globalsFile;

--- a/tests/unit/uploads/FileUploadSecurityTest.php
+++ b/tests/unit/uploads/FileUploadSecurityTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Security-focused test cases for file upload functionality
  *
  * Tests the security enhancements added to editCar.php file upload system.
  * Validates protection against common file upload attack vectors.
- *
- * @group fast
  */
+#[Group('fast')]
 class FileUploadSecurityTest extends TestCase
 {
     private $tempDir;

--- a/tests/unit/uploads/ImageOrientationTest.php
+++ b/tests/unit/uploads/ImageOrientationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test for EXIF orientation handling in the Resize class
  *
@@ -13,7 +15,6 @@ use PHPUnit\Framework\TestCase;
  * - Privacy-preserving EXIF stripping
  * - Error handling for missing EXIF data
  */
-
 class ImageOrientationTest extends TestCase
 {
     private $testImageDir;
@@ -45,9 +46,8 @@ class ImageOrientationTest extends TestCase
 
     /**
      * Test that the Resize class exists
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testResizeClassExists(): void
     {
         $this->assertTrue(class_exists('Resize'), 'Resize class should exist');
@@ -55,9 +55,8 @@ class ImageOrientationTest extends TestCase
 
     /**
      * Test that the correctOrientation method exists in Resize class
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testCorrectOrientationMethodExists(): void
     {
         $reflection = new ReflectionClass('Resize');
@@ -69,9 +68,8 @@ class ImageOrientationTest extends TestCase
 
     /**
      * Test orientation correction with mock image data
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testOrientationCorrectionWithMockImage(): void
     {
         // Create a simple test image
@@ -85,7 +83,6 @@ class ImageOrientationTest extends TestCase
         imagefilledrectangle($testImage, 0, 0, 20, 50, $red); // Red stripe on left
         
         imagejpeg($testImage, $testFile, 90);
-        imagedestroy($testImage);
 
         $this->assertFileExists($testFile, 'Test image should be created');
 
@@ -108,9 +105,8 @@ class ImageOrientationTest extends TestCase
 
     /**
      * Test that EXIF extension is available
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testEXIFExtensionAvailable(): void
     {
         $this->assertTrue(
@@ -121,9 +117,8 @@ class ImageOrientationTest extends TestCase
 
     /**
      * Test that imagerotate function is available
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testImageRotateAvailable(): void
     {
         $this->assertTrue(
@@ -134,9 +129,8 @@ class ImageOrientationTest extends TestCase
 
     /**
      * Test that imageflip function is available
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testImageFlipAvailable(): void
     {
         // imageflip was added in PHP 5.5.0
@@ -158,7 +152,6 @@ class ImageOrientationTest extends TestCase
         
         $testFile = $this->outputDir . 'no_exif.jpg';
         imagejpeg($testImage, $testFile, 90);
-        imagedestroy($testImage);
 
         // Should not throw exception when processing image without EXIF
         try {
@@ -181,7 +174,6 @@ class ImageOrientationTest extends TestCase
         
         $testFile = $this->outputDir . 'test.png';
         imagepng($testImage, $testFile);
-        imagedestroy($testImage);
 
         // Should process PNG files normally (no EXIF orientation correction)
         try {

--- a/tests/unit/uploads/ImageOrientationTest.php
+++ b/tests/unit/uploads/ImageOrientationTest.php
@@ -143,7 +143,8 @@ class ImageOrientationTest extends TestCase
     /**
      * Test that the Resize class properly handles files without EXIF data
      */
-    public function testHandleImageWithoutEXIF()
+    #[Group('fast')]
+    public function testHandleImageWithoutEXIF(): void
     {
         // Create a simple test image without EXIF data
         $testImage = imagecreate(100, 100);
@@ -163,9 +164,10 @@ class ImageOrientationTest extends TestCase
     }
 
     /**
-     * Test that non-JPEG files are handled properly 
+     * Test that non-JPEG files are handled properly
      */
-    public function testHandleNonJPEGFiles()
+    #[Group('fast')]
+    public function testHandleNonJPEGFiles(): void
     {
         // Create a simple PNG test image
         $testImage = imagecreate(100, 100);

--- a/tests/unit/users/UserDeletionCleanupTest.php
+++ b/tests/unit/users/UserDeletionCleanupTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * User Deletion Cleanup tests (Issue #106)
  *
  * Tests the decision logic and validation for user deletion cleanup.
  * Note: Database operations are tested in integration tests, not here.
- *
- * @group fast
  */
+#[Group('fast')]
 final class UserDeletionCleanupTest extends TestCase
 {
     private $db;

--- a/tests/unit/users/VerificationWorkflowTest.php
+++ b/tests/unit/users/VerificationWorkflowTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Verification Workflow Tests
  * Tests the car verification process specific to the Lotus Elan Registry
@@ -30,9 +32,8 @@ class VerificationWorkflowTest extends TestCase
     
     /**
      * Test verification email generation
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testVerificationEmailGeneration(): void
     {
         $carData = [
@@ -55,9 +56,8 @@ class VerificationWorkflowTest extends TestCase
     
     /**
      * Test verification link generation
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testVerificationLinkGeneration(): void
     {
         $carId = 123;
@@ -71,9 +71,8 @@ class VerificationWorkflowTest extends TestCase
     
     /**
      * Test verification status transitions
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testVerificationStatusTransitions(): void
     {
         // Test valid status transitions
@@ -101,9 +100,8 @@ class VerificationWorkflowTest extends TestCase
     
     /**
      * Test verification requirements validation
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testVerificationRequirements(): void
     {
         // Test minimum requirements for verification
@@ -131,9 +129,8 @@ class VerificationWorkflowTest extends TestCase
     
     /**
      * Test verification document validation
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testVerificationDocumentValidation(): void
     {
         // Test document types accepted for verification
@@ -162,9 +159,8 @@ class VerificationWorkflowTest extends TestCase
     
     /**
      * Test chassis number uniqueness validation
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testChassisNumberUniquenessValidation(): void
     {
         $testChassis = '12345678';
@@ -182,9 +178,8 @@ class VerificationWorkflowTest extends TestCase
     
     /**
      * Test verification email throttling
-     *
-     * @group fast
      */
+    #[Group('fast')]
     public function testVerificationEmailThrottling(): void
     {
         $carId = 123;


### PR DESCRIPTION
## Summary

- Upgrades `phpunit/phpunit` from `^11.0` to `^12.0`, resolving Dependabot advisory GHSA-qrr6-mg7r-m243
- Converts 310 docblock annotations (`@group`, `@dataProvider`, `@covers`) to PHP 8 attributes across 46 test files
- Fixes PHP 8.5 deprecations: removes `finfo_close()` (auto-freed) and `imagedestroy()` (no-op since PHP 8.0) calls
- Updates all three `phpunit*.xml` schema URLs from `11.0` to `12.0`
- Syncs `getMimeType` bootstrap mock allowlist with production (`image/jpg` was missing)

## Test plan

- [ ] 818 unit tests pass with 0 failures and 0 PHPUnit/PHP deprecations
- [ ] `composer test:fast` runs tests in `fast` group (non-zero count)
- [ ] `composer test:slow` runs tests in `slow` group (non-zero count)
- [ ] PHPStan reports no errors
- [ ] PHP coding standards pass

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)