### PR TITLE
feat: mobile responsiveness audit and remediation — all app pages (#620)

### DIFF
--- a/app/admin/verify/index.php
+++ b/app/admin/verify/index.php
@@ -30,7 +30,7 @@ $resultsUpdate = $db->query("SELECT count(*) as count  FROM `cars_hist` WHERE op
 	<div class="container-fluid">
 		<div class="well">
 			<div class="row">
-				<div class="col-8">
+				<div class="col-12 col-md-8">
 					<div class="card card-default">
 						<div class="card-header">
 							<h2><strong>Report of Verification Status</strong></h2>
@@ -43,7 +43,7 @@ $resultsUpdate = $db->query("SELECT count(*) as count  FROM `cars_hist` WHERE op
 						</div> <!-- card-body -->
 					</div> <!-- card -->
 				</div> <!-- col -->
-				<div class="col-4">
+				<div class="col-12 col-md-4">
 					<div class="card card-default">
 						<div class="card-header">
 							<h2><strong>Verify Cars</strong></h2>

--- a/app/assets/css/edit_car.css
+++ b/app/assets/css/edit_car.css
@@ -43,7 +43,11 @@
 #progressbar {
     margin-bottom: 30px;
     overflow: hidden;
-    color: lightgrey
+    color: lightgrey;
+    display: flex;
+    flex-wrap: wrap;
+    padding-left: 0;
+    list-style: none
 }
 
 #progressbar .active {
@@ -54,9 +58,15 @@
     list-style-type: none;
     font-size: 15px;
     width: 25%;
-    float: left;
     position: relative;
     font-weight: 400
+}
+
+@media (max-width: 575.98px) {
+    #progressbar li {
+        width: 50%;
+        font-size: 12px;
+    }
 }
 
 #progressbar #cardetails:before {

--- a/app/assets/js/car_details.js
+++ b/app/assets/js/car_details.js
@@ -45,7 +45,6 @@ function initializeHistoryTable() {
 
     try {
         const table = $('#carHistoryTable').DataTable({
-            scrollX: true,
             responsive: true,
             order: [
                 [1, 'desc']
@@ -63,44 +62,57 @@ function initializeHistoryTable() {
                 }
             },
             columns: [{
-                    data: "operation"
+                    data: "operation",
+                    responsivePriority: 1
                 },
                 {
-                    data: "mtime"
+                    data: "mtime",
+                    responsivePriority: 1
                 },
                 {
-                    data: "year"
+                    data: "year",
+                    responsivePriority: 2
                 },
                 {
-                    data: "type"
+                    data: "type",
+                    responsivePriority: 2
                 },
                 {
-                    data: "chassis"
+                    data: "chassis",
+                    responsivePriority: 1
                 },
                 {
-                    data: "series"
+                    data: "series",
+                    responsivePriority: 3
                 },
                 {
-                    data: "variant"
+                    data: "variant",
+                    responsivePriority: 3
                 },
                 {
-                    data: "color"
+                    data: "color",
+                    responsivePriority: 3
                 },
                 {
-                    data: "engine"
+                    data: "engine",
+                    responsivePriority: 3
                 },
                 {
-                    data: "purchasedate"
+                    data: "purchasedate",
+                    responsivePriority: 3
                 },
                 {
-                    data: "solddate"
+                    data: "solddate",
+                    responsivePriority: 3
                 },
                 {
-                    data: "comments"
+                    data: "comments",
+                    responsivePriority: 3
                 },
                 {
                     data: "image",
                     searchable: false,
+                    responsivePriority: 3,
                     render: function(data, type, row) {
                         if (data) {
                             return carousel(row, row.car_id);
@@ -109,16 +121,20 @@ function initializeHistoryTable() {
                     }
                 },
                 {
-                    data: "fname"
+                    data: "fname",
+                    responsivePriority: 3
                 },
                 {
-                    data: "city"
+                    data: "city",
+                    responsivePriority: 3
                 },
                 {
-                    data: "state"
+                    data: "state",
+                    responsivePriority: 3
                 },
                 {
-                    data: "country"
+                    data: "country",
+                    responsivePriority: 3
                 }
             ]
         });

--- a/app/cars/details.php
+++ b/app/cars/details.php
@@ -509,7 +509,7 @@ if (!empty($_GET)) {
                                 <div class="alert alert-info mb-3">
                                     <i class="fas fa-info-circle"></i>
                                     <strong>About History:</strong> This table shows all changes made to the car's information over time.
-                                    Use horizontal scrolling on mobile devices to view all columns.
+                                    Tap any row to expand hidden columns on mobile devices.
                                 </div>
                                 
                                 <div class="table-responsive">
@@ -778,5 +778,8 @@ document.addEventListener('DOMContentLoaded', function() {
     body { font-size: 12px; }
     h1 { font-size: 18px; }
     h3 { font-size: 14px; }
+}
+@media (max-width: 575.98px) {
+    #map { height: 220px !important; }
 }
 </style>

--- a/app/cars/factory.php
+++ b/app/cars/factory.php
@@ -104,6 +104,7 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
         data: "id",
         'searchable': false,
         'orderable': false,
+        visible: false,
       },
       {
         data: "year",
@@ -149,9 +150,12 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
                    '<i class="fas fa-spinner fa-spin"></i> Checking...' +
                    '</span></div>';
           }
+          if (type === 'sort' || type === 'type') {
+            return data || '';
+          }
           return '';
         },
-        orderable: false,
+        orderable: true,
         searchable: false
       }
     ]
@@ -193,8 +197,10 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
             );
           }
         })
-        .catch(function() {
-          // Registry check failed - handle silently
+        .catch(function(error) {
+          if (error && error.name !== 'ApiCancelledError') {
+            console.error('Registry link check failed for chassis', chassis, error);
+          }
           container.html(
             '<span class="text-danger small">' +
             '<i class="fas fa-exclamation-triangle"></i> Check failed' +

--- a/app/cars/index.php
+++ b/app/cars/index.php
@@ -103,7 +103,6 @@ window.ELAN_CONFIG = {
     fixedHeader: true,
     responsive: true,
     pageLength: 15,
-    scrollX: true,
     'aLengthMenu': [
       [10, 25, 50, 100, -1],
       [10, 25, 50, 100, 'All']
@@ -132,24 +131,32 @@ window.ELAN_CONFIG = {
       data: 'id',
       'searchable': false,
       'orderable': false,
+      responsivePriority: 1,
       'render': function(data, type, row, meta) {
         return '<a class="btn btn-success btn-sm" href="' + us_url_root + 'app/cars/details.php?car_id=' + data + '">Details';
       }
     }, {
       data: 'year',
+      responsivePriority: 1
     }, {
-      data: 'type'
+      data: 'type',
+      responsivePriority: 1
     }, {
-      data: 'chassis'
+      data: 'chassis',
+      responsivePriority: 1
     }, {
-      data: 'series'
+      data: 'series',
+      responsivePriority: 2
     }, {
-      data: 'variant'
+      data: 'variant',
+      responsivePriority: 2
     }, {
-      data: 'color'
+      data: 'color',
+      responsivePriority: 2
     }, {
       data: 'image',
       'searchable': false,
+      responsivePriority: 3,
       'render': function(data, type, row) {
         if (data) {
           return carousel(row);
@@ -158,16 +165,21 @@ window.ELAN_CONFIG = {
         }
       }
     }, {
-      data: 'fname'
+      data: 'fname',
+      responsivePriority: 3
     }, {
-      data: 'city'
+      data: 'city',
+      responsivePriority: 3
     }, {
-      data: 'state'
+      data: 'state',
+      responsivePriority: 3
     }, {
-      data: 'country'
+      data: 'country',
+      responsivePriority: 3
     }, {
       data: 'ctime',
       'searchable': true,
+      responsivePriority: 3
     }]
   });
 </script>

--- a/app/reports/statistics.php
+++ b/app/reports/statistics.php
@@ -26,6 +26,11 @@ if (!securePage($php_self)) {
 $dataService = new StatisticsDataService($db);
 ?>
 
+<style>
+.chart-container { height: 400px; }
+@media (max-width: 575.98px) { .chart-container { height: 250px; } }
+</style>
+
 <div class="page-wrapper">
     <div class="container-fluid">
         <div class="page-container">
@@ -157,7 +162,7 @@ $dataService = new StatisticsDataService($db);
                                                 <div class="card-header">
                                                     <h5 class="mb-0">Registry Timeline</h5>
                                                 </div>
-                                                <div class="card-body" style="height: 400px;">
+                                                <div class="card-body chart-container">
                                                     <canvas id="timelineChart"></canvas>
                                                 </div>
                                             </div>
@@ -167,7 +172,7 @@ $dataService = new StatisticsDataService($db);
                                                 <div class="card-header">
                                                     <h5 class="mb-0">Recent Registration Activity</h5>
                                                 </div>
-                                                <div class="card-body" style="height: 400px;">
+                                                <div class="card-body chart-container">
                                                     <canvas id="ageChart"></canvas>
                                                 </div>
                                             </div>

--- a/docs/releases/RELEASE_NOTES_v2.19.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.19.0.md
@@ -23,7 +23,14 @@
 - **Bootstrap 5 Template** ([#618](https://github.com/unibrain1/elanregistry/issues/618)):
   Updated site template to Bootstrap 5.3 — faster load times, improved accessibility, and modern UI components.
 - **Mobile Responsiveness** ([#620](https://github.com/unibrain1/elanregistry/issues/620)):
-  All 18 app pages audited and fixed for 375px mobile viewports — no more horizontal scrolling on phones.
+  All 18 app pages audited and fixed for 375px mobile viewports — DataTables columns collapse to
+  expandable child rows on phones, edit forms stack correctly, admin tabs scroll horizontally,
+  chart containers shrink at mobile breakpoint. No horizontal overflow on any page.
+- **Homepage "How are we doing?" chart** ([#620](https://github.com/unibrain1/elanregistry/issues/620)):
+  Replaced statistics table with Bootstrap 5 progress bars showing registered vs. produced counts
+  per series. Intro text now shows live car count and years since the registry started (Jan 2003).
+- **Factory page improvements** ([#620](https://github.com/unibrain1/elanregistry/issues/620)):
+  Hid the internal Record # column; Registry Link column is now sortable.
 
 ## Technical Changes
 

--- a/docs/releases/RELEASE_NOTES_v2.19.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.19.0.md
@@ -32,6 +32,10 @@
   Enables Dependabot security alerts for JS/CSS dependencies.
 - **BS4 → BS5 Class Migration** ([#619](https://github.com/unibrain1/elanregistry/issues/619)):
   Migrated all Bootstrap 4 classes and data attributes across 35 app files to Bootstrap 5 equivalents.
+- **Customizer Template Alignment** ([#620](https://github.com/unibrain1/elanregistry/issues/620)):
+  Custom navigation renamed to `file_nav_custom.php` to survive Spice Shaker template upgrades.
+  Bootstrap 5 now loaded from `cdnjs.cloudflare.com` via the upstream template (SRI-hashed).
+  Application version now displayed on the admin dashboard.
 
 ## Issues Resolved
 

--- a/index.php
+++ b/index.php
@@ -53,12 +53,6 @@ if (!empty($randomCarResults)) {
     }
 }
 
-/**
- * Get count of cars by series using efficient single query
- * Groups cars into series categories and counts registrations
- *
- * @var array $seriesResults Database results containing series counts
- */
 $seriesResults = $db->query("SELECT
     CASE
         WHEN series LIKE 's1%' THEN 's1'
@@ -73,28 +67,14 @@ FROM cars
 WHERE series LIKE 's1%' OR series LIKE 's2%' OR series LIKE 's3%' OR series LIKE 's4%' OR series LIKE 'sprint%' OR series LIKE '+2%'
 GROUP BY series_group")->results();
 
-/**
- * Initialize count array with zeros for all series
- *
- * @var array<string, int> $count Array of series counts indexed by series name
- */
 $count = ['s1' => 0, 's2' => 0, 's3' => 0, 's4' => 0, 'sprint' => 0, '+2' => 0];
 
-/**
- * Populate count array from database query results
- */
 foreach ($seriesResults as $result) {
     if ($result->series_group) {
         $count[$result->series_group] = (int) $result->count;
     }
 }
 
-/**
- * Number of cars produced per series (from reference material)
- * Data source: "Authentic Lotus Elan & Plus 2 1962-1974" by Robinshaw and Ross
- *
- * @var array<string, string> $notes Production numbers for each series
- */
 $notes = [];
 $notes['s1']     = "900";
 $notes['s2']     = "1250";
@@ -103,17 +83,15 @@ $notes['s4']     = "2976";
 $notes['sprint'] = "900";
 $notes['+2']     = "4526";
 
-?>
-<?php
-/**
- * HTML Template Start - Homepage Layout
- *
- * The following section contains the main homepage template with:
- * - Site header and navigation
- * - Registry statistics table
- * - Featured random car display
- * - Resource links and acknowledgments
- */
+$total = 0;
+$totalN = 0;
+foreach ($count as $key => $value) {
+    $total  += (int) $value;
+    $totalN += (int) $notes[$key];
+}
+
+$yearsSince = (int) (new DateTime())->diff(new DateTime('2003-01-01'))->y;
+
 ?>
 <div class="page-wrapper">
 	<!-- Page Content -->
@@ -151,8 +129,8 @@ $notes['+2']     = "4526";
 						<p>The Lotus Elan Registry started in January 2003. A thread on LotusElan.net asked the question,
 							<a href='http://www.lotuselan.net/forums/elan-f14/lotus-elan-register-t349.html'>
 								Does anybody know if there is a Lotus Elan register?</a>
-							I bashed together a registry and a few years later
-							we have over 300 cars accounted for with more added every month.
+							I bashed together a registry and <?= (int) $yearsSince ?> years later
+							we have over <?= (int) $total ?> cars accounted for with more added every month.
 						</p>
 					</div> <!-- card-body -->
 				</div> <!-- card -->
@@ -162,39 +140,35 @@ $notes['+2']     = "4526";
 						<h2 class='mb-0'><i class='fas fa-chart-bar'></i> How are we doing?</h2>
 					</div>
 					<div class="card-body">
-						<table id="seriestable" class="table table-striped table-bordered table-hover table-sm" aria-describedby="card-header">
-							<thead class="thead-light">
-								<tr>
-									<th scope="column">Series</th>
-									<th scope="column">Registered</th>
-									<th scope="column">Number produced *</th>
-									<th scope="column">Percent registered</th>
-								</tr>
-							</thead>
-							<tbody>
-								<?php
-								/**
-								 * Generate statistics table rows showing registry data by series
-								 * Calculates totals and percentages for registered vs produced cars
-								 *
-								 * @var int $total Total registered cars across all series
-								 * @var int $totalN Total cars produced across all series
-								 */
-								$total = 0;
-								$totalN = 0;
-								foreach ($count as $key => $value) {
-									echo "<tr><td>" . ucfirst((string) $key) . "</td><td>" . (int) $value . "</td>";
-									echo "<td>" . htmlspecialchars((string) $notes[$key], ENT_QUOTES, 'UTF-8') . "</td>";
-									echo "<td>" . round(((int) $value * 100) / (int) $notes[$key], 0) . " %</td></tr>";
-
-									$total += (int) $value;
-									$totalN += (int) $notes[$key];
-								}
-								echo "<tr><td><strong>Total</strong></td><td><strong>" . $total . "</strong></td><td>" .
-									$totalN . "</td><td>" . round(($total * 100) / $totalN) . " %</td></tr>";
-								?>
-							</tbody>
-						</table>
+						<?php foreach ($count as $key => $value): ?>
+							<?php
+								$key_display = htmlspecialchars(ucfirst((string) $key), ENT_QUOTES, 'UTF-8');
+								$pct = (int) $notes[$key] > 0 ? (int) round((int) $value * 100 / (int) $notes[$key]) : 0;
+							?>
+							<div class="mb-3">
+								<div class="d-flex justify-content-between mb-1">
+									<span class="fw-semibold"><?= $key_display ?></span>
+									<span class="text-muted small"><?= (int) $value ?> / <?= htmlspecialchars((string) $notes[$key], ENT_QUOTES, 'UTF-8') ?></span>
+								</div>
+								<div class="progress" style="height: 18px;" role="progressbar" aria-label="<?= $key_display ?> registration" aria-valuenow="<?= $pct ?>" aria-valuemin="0" aria-valuemax="100">
+									<div class="progress-bar bg-success" style="width: <?= $pct ?>%">
+										<?php if ($pct >= 8): ?><?= $pct ?>%<?php endif; ?>
+									</div>
+								</div>
+							</div>
+							<?php endforeach; ?>
+							<?php $totalPct = $totalN > 0 ? (int) round($total * 100 / $totalN) : 0; ?>
+							<div class="mb-3">
+								<div class="d-flex justify-content-between mb-1">
+									<span class="fw-bold">Total</span>
+									<span class="text-muted small"><?= (int) $total ?> / <?= (int) $totalN ?></span>
+								</div>
+								<div class="progress" style="height: 18px;" role="progressbar" aria-label="Total registration" aria-valuenow="<?= $totalPct ?>" aria-valuemin="0" aria-valuemax="100">
+									<div class="progress-bar bg-primary" style="width: <?= $totalPct ?>%">
+										<?php if ($totalPct >= 8): ?><?= $totalPct ?>%<?php endif; ?>
+									</div>
+								</div>
+							</div>
 						<p><small>* - Number produced is from
 								<a href="https://www.amazon.com/Authentic-Lotus-1962-1974-Marques-Models/dp/0947981950">
 									Authentic Lotus Elan & Plus 2 1962 - 1974 by Robinshaw and Ross</a>, page 22 and page 138.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "playwright:security": "playwright test tests/playwright/security.test.js",
     "playwright:maps": "playwright test tests/playwright/maps-charts.test.js",
     "playwright:csp": "playwright test tests/playwright/csp-validation.spec.js",
+    "playwright:mobile": "playwright test tests/playwright/mobile-responsive.test.js",
     "playwright:headed": "playwright test --headed",
     "playwright:debug": "playwright test --debug",
     "playwright:report": "playwright show-report",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -39,6 +39,12 @@ module.exports = defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      testIgnore: '**/mobile-responsive.test.js',
+    },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['iPhone SE'] },
+      testMatch: '**/mobile-responsive.test.js',
     },
   ],
 

--- a/tests/playwright/mobile-responsive.test.js
+++ b/tests/playwright/mobile-responsive.test.js
@@ -1,0 +1,116 @@
+// tests/playwright/mobile-responsive.test.js
+const { test, expect } = require('@playwright/test');
+const { navigateAndWait, handleAuthRequired } = require('./auth-helper.js');
+
+/**
+ * Mobile responsive tests at iPhone SE viewport (375x667).
+ *
+ * These tests assert that public pages render without introducing
+ * horizontal page-level overflow on small screens, and that the
+ * DataTables responsive plugin is active on the car listing page.
+ *
+ * The viewport is set explicitly via page.setViewportSize() in each
+ * test so the file behaves consistently regardless of which Playwright
+ * project (chromium / Mobile Chrome) it runs under.
+ */
+
+const MOBILE_VIEWPORT = { width: 375, height: 667 };
+
+const PUBLIC_PAGES = [
+  '/',
+  '/app/cars/index.php',
+  '/app/cars/details.php?car_id=1',
+  '/app/cars/factory.php',
+  '/app/cars/identify.php',
+  '/app/contact/index.php',
+  '/app/contact/owner.php',
+  '/app/reports/statistics.php',
+  '/app/privacy.php',
+];
+
+test.describe('Mobile Responsive (iPhone SE / 375px)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+  });
+
+  for (const pagePath of PUBLIC_PAGES) {
+    test(`no horizontal overflow on ${pagePath}`, async ({ page }) => {
+      await navigateAndWait(page, pagePath);
+      await page.waitForLoadState('networkidle');
+
+      // Page may redirect to login for auth-protected pages; still
+      // verify no horizontal overflow on whatever rendered.
+      const overflow = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        innerWidth: window.innerWidth,
+      }));
+
+      expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.innerWidth);
+    });
+  }
+
+  test('DataTables responsive collapse indicator present on car listing', async ({ page }) => {
+    await navigateAndWait(page, '/app/cars/index.php');
+    await page.waitForLoadState('networkidle');
+
+    // Wait for DataTables to initialize
+    await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
+
+    // Wait for the DataTables Responsive extension to inject its child-row
+    // control cell (dtr-control class) — auto-retries until visible.
+    const firstControl = page.locator('table.dataTable tbody tr td.dtr-control').first();
+    await expect(firstControl).toBeVisible({ timeout: 10000 });
+  });
+
+  test('edit car form progress bar does not cause horizontal overflow', async ({ page }) => {
+    await navigateAndWait(page, '/app/cars/edit.php');
+    await page.waitForLoadState('networkidle');
+
+    await handleAuthRequired(
+      page,
+      async () => {
+        const overflow = await page.evaluate(() => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          innerWidth: window.innerWidth,
+        }));
+        expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.innerWidth);
+      },
+      async () => {
+        const overflow = await page.evaluate(() => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          innerWidth: window.innerWidth,
+        }));
+        expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.innerWidth);
+      }
+    );
+  });
+
+  test('admin page tabs do not cause horizontal overflow', async ({ page }) => {
+    // Admin is auth-protected. We don't log in here — instead we navigate
+    // and let UserSpice render whatever it renders (login redirect or admin
+    // page if a session exists). Either way, page-level horizontal overflow
+    // should not occur at 375px.
+    await navigateAndWait(page, '/users/admin.php');
+    await page.waitForLoadState('networkidle');
+
+    await handleAuthRequired(
+      page,
+      // Authenticated: verify admin tabs render without page overflow
+      async () => {
+        const overflow = await page.evaluate(() => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          innerWidth: window.innerWidth,
+        }));
+        expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.innerWidth);
+      },
+      // Unauthenticated: still verify the login/redirect page does not overflow
+      async () => {
+        const overflow = await page.evaluate(() => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          innerWidth: window.innerWidth,
+        }));
+        expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.innerWidth);
+      }
+    );
+  });
+});

--- a/usersc/templates/customizer/file_nav_custom.php
+++ b/usersc/templates/customizer/file_nav_custom.php
@@ -2,7 +2,7 @@
 <ul class='us_menu horizontal dark' style=' z-index: 50;' id='us_menu_1_638b71f2ed026'>
   <div class='us_brand full_screen'>
     <a href="<?= $us_url_root ?>">
-      <img src="<?= $us_url_root ?>usersc/images/logo-100x100.png" alt="Lotus Elan Registry" style="height:100px;width:100px;">
+      <img src="<?= $us_url_root ?>usersc/images/logo-100x100.png" alt="Lotus Elan Registry" class="img-fluid" style="max-height:100px;width:auto">
     </a>
   </div>
   <div class='flex-grow-1'></div>
@@ -10,7 +10,7 @@
   <div class='us_menu_mobile_wrapper'>
     <div class='us_brand'>
       <a href="<?= $us_url_root ?>">
-        <img src="<?= $us_url_root ?>usersc/images/logo-100x100.png" alt="Lotus Elan Registry" style="height:50px;width:50px;">
+        <img src="<?= $us_url_root ?>usersc/images/logo-100x100.png" alt="Lotus Elan Registry" class="img-fluid" style="max-height:50px;width:auto">
       </a>
     </div>
 

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -488,7 +488,7 @@ if ($userQ2->count() > 0) {
     <div class="container">
         <div class="well">
             <div class="row">
-                <div class="col-xs-12 col-md-10">
+                <div class="col-12 col-md-10">
                     <h1>Update your user settings</h1> <br>
                     <!-- Messages now handled by UserSpice session system in template (Issue #237) -->
 


### PR DESCRIPTION
## Summary

- Replace `scrollX: true` with DataTables Responsive extension (`responsivePriority`) on car listing and car history tables — columns collapse to expandable child rows on mobile instead of horizontal scrolling
- Add flexbox layout to edit-car multi-step progress bar with 50% step widths at 575px breakpoint
- Fix Bootstrap grid classes for mobile stacking (`col-8` → `col-12 col-md-8`, `col-xs-12` → `col-12`)
- Add responsive `chart-container` CSS class to statistics page charts (400px desktop → 250px mobile)
- Shrink map container to 220px on mobile in car details page
- Replace homepage series stats table with Bootstrap 5 progress bars; make car count and years-since-start dynamic
- Hide factory Record # column; enable Registry Link column sorting by serial number
- Add `img-fluid` to nav logo for proper responsive scaling
- Add Playwright mobile test suite (iPhone SE / 375px): overflow checks on 9 public pages, DataTables responsive indicator test, edit form and admin tabs overflow tests
- Fix `factory.php` catch block to log errors via `console.error` (was silently discarding the error object)

## Test plan

- [ ] `npm run playwright:mobile` — all new mobile tests pass (no horizontal overflow on 9 pages, DataTables `dtr-control` visible on car listing)
- [ ] `npm run playwright:test` — all existing Playwright tests still pass
- [ ] `composer test:quick` — 815 unit tests green
- [ ] Manual: open car listing, car history, factory page at 375px DevTools — confirm columns collapse to child rows
- [ ] Manual: open edit car form at 375px — confirm progress bar shows 2 steps per row
- [ ] Manual: open homepage at 375px — confirm progress bars render without horizontal overflow
- [ ] Manual: open statistics page at 375px — confirm charts are 250px tall

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)