### PR TITLE
fix: remove try/catch anti-pattern from StatisticsApiTest (#740)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.19.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.19.0.md
@@ -67,6 +67,10 @@
   Client-side image resize (to `elan_image_display_max_size`) before upload.
   Fixed XSS vulnerability in edit car form validation error display (escapeHtml applied to server error messages).
   Added `basename()` normalization to server-side `removeImages` file parameter.
+- **StatisticsApiTest integration tests** ([#740](https://github.com/unibrain1/elanregistry/issues/740)):
+  Removed `try/catch (Throwable)` anti-pattern that was converting assertion failures into silent
+  skips; corrected asserted strings to match the actual `LogCategories` constants and `error.message`
+  JS pattern used in the source files.
 
 ## Issues Resolved
 
@@ -78,9 +82,10 @@
 - [#741](https://github.com/unibrain1/elanregistry/issues/741) — Migrate photo upload from Dropzone to FilePond with improved UX and security fixes
 - [#743](https://github.com/unibrain1/elanregistry/issues/743) — Fix Step 3 photo upload layout for mobile
 - [#744](https://github.com/unibrain1/elanregistry/issues/744) — Fix mobile CSS regressions in add/edit car form
+- [#740](https://github.com/unibrain1/elanregistry/issues/740) — Fix silently-skipping integration tests in StatisticsApiTest
 
 ## Summary
 
-8 issues resolved: full Bootstrap 5 migration (self-hosted libraries, template rebase, class migration,
+9 issues resolved: full Bootstrap 5 migration (self-hosted libraries, template rebase, class migration,
 mobile responsiveness), first-party JS/CSS minification with esbuild, FilePond image upload library migration
-with mobile layout fix, and add/edit car form mobile CSS regressions.
+with mobile layout fix, add/edit car form mobile CSS regressions, and StatisticsApiTest integration test fixes.

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -322,7 +322,7 @@ class StatisticsApiTest extends IntegrationTestCase
     /**
      * Test that validateChassis.php is reference implementation
      */
-    public function testValidateChassisChassisPatterCompliance(): void
+    public function testValidateChassisPatternCompliance(): void
     {
         $filePath = __DIR__ . '/../../app/cars/actions/validateChassis.php';
         if (!file_exists($filePath)) {

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -358,13 +358,9 @@ class StatisticsApiTest extends IntegrationTestCase
             $this->markTestSkipped('Statistics API file not found');
         }
 
-        try {
-            $content = file_get_contents($filePath);
-            $this->assertIsString($content, "File should be readable");
-            $this->assertStringContainsString('SecurityError', $content, "Should log security errors");
-        } catch (Throwable $e) {
-            $this->markTestSkipped("Could not read statistics API file: " . $e->getMessage());
-        }
+        $content = file_get_contents($filePath);
+        $this->assertIsString($content, "File should be readable");
+        $this->assertStringContainsString('LOG_CATEGORY_SECURITY', $content, "Should log security errors via LogCategories");
     }
 
     /**
@@ -377,13 +373,9 @@ class StatisticsApiTest extends IntegrationTestCase
             $this->markTestSkipped('Statistics API file not found');
         }
 
-        try {
-            $content = file_get_contents($filePath);
-            $this->assertIsString($content, "File should be readable");
-            $this->assertStringContainsString('ValidationError', $content, "Should log validation errors");
-        } catch (Throwable $e) {
-            $this->markTestSkipped("Could not read statistics API file: " . $e->getMessage());
-        }
+        $content = file_get_contents($filePath);
+        $this->assertIsString($content, "File should be readable");
+        $this->assertStringContainsString('LOG_CATEGORY_VALIDATION_ERROR', $content, "Should log validation errors via LogCategories");
     }
 
     /**
@@ -396,13 +388,9 @@ class StatisticsApiTest extends IntegrationTestCase
             $this->markTestSkipped('Statistics API file not found');
         }
 
-        try {
-            $content = file_get_contents($filePath);
-            $this->assertIsString($content, "File should be readable");
-            $this->assertStringContainsString('DatabaseError', $content, "Should log database errors");
-        } catch (Throwable $e) {
-            $this->markTestSkipped("Could not read statistics API file: " . $e->getMessage());
-        }
+        $content = file_get_contents($filePath);
+        $this->assertIsString($content, "File should be readable");
+        $this->assertStringContainsString('LOG_CATEGORY_DATABASE_ERROR', $content, "Should log database errors via LogCategories");
     }
 
     // =========================================================================
@@ -410,7 +398,7 @@ class StatisticsApiTest extends IntegrationTestCase
     // =========================================================================
 
     /**
-     * Test that statistics.js uses response.message for errors
+     * Test that statistics.js uses error.message for API error handling
      */
     public function testStatisticsJsErrorHandling(): void
     {
@@ -419,15 +407,9 @@ class StatisticsApiTest extends IntegrationTestCase
             $this->markTestSkipped('Statistics.js file not found');
         }
 
-        try {
-            $content = file_get_contents($filePath);
-            $this->assertIsString($content, "File should be readable");
-            $this->assertStringContainsString('response.message', $content, "Should use response.message for error handling");
-            // Verify the old pattern is gone
-            $this->assertStringNotContainsString('response.error', $content, "Should not use response.error");
-        } catch (Throwable $e) {
-            $this->markTestSkipped("Could not read statistics.js file: " . $e->getMessage());
-        }
+        $content = file_get_contents($filePath);
+        $this->assertIsString($content, "File should be readable");
+        $this->assertStringContainsString('error.message', $content, "Should use error.message in catch handlers");
     }
 
     /**

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -313,14 +313,10 @@ class StatisticsApiTest extends IntegrationTestCase
             $this->markTestSkipped('Statistics API file not found');
         }
 
-        try {
-            $content = file_get_contents($filePath);
-            $this->assertIsString($content, "File should be readable");
-            $this->assertStringContainsString('securePage', $content, "Should have securePage security check");
-            $this->assertStringContainsString('ApiResponse', $content, "Should use ApiResponse pattern");
-        } catch (Throwable $e) {
-            $this->markTestSkipped("Could not read statistics API file: " . $e->getMessage());
-        }
+        $content = file_get_contents($filePath);
+        $this->assertIsString($content, "File should be readable");
+        $this->assertStringContainsString('securePage', $content, "Should have securePage security check");
+        $this->assertStringContainsString('ApiResponse', $content, "Should use ApiResponse pattern");
     }
 
     /**
@@ -333,15 +329,11 @@ class StatisticsApiTest extends IntegrationTestCase
             $this->markTestSkipped('ValidateChassis file not found');
         }
 
-        try {
-            $content = file_get_contents($filePath);
-            $this->assertIsString($content, "File should be readable");
-            $this->assertStringContainsString('declare(strict_types=1)', $content, "Should have strict types");
-            $this->assertStringContainsString('ApiResponse', $content, "Should use ApiResponse pattern");
-            $this->assertStringContainsString('withLogging', $content, "Should include logging");
-        } catch (Throwable $e) {
-            $this->markTestSkipped("Could not read validateChassis file: " . $e->getMessage());
-        }
+        $content = file_get_contents($filePath);
+        $this->assertIsString($content, "File should be readable");
+        $this->assertStringContainsString('declare(strict_types=1)', $content, "Should have strict types");
+        $this->assertStringContainsString('ApiResponse', $content, "Should use ApiResponse pattern");
+        $this->assertStringContainsString('withLogging', $content, "Should include logging");
     }
 
     // =========================================================================
@@ -418,13 +410,9 @@ class StatisticsApiTest extends IntegrationTestCase
     public function testStatisticsDataServiceExists(): void
     {
         $filePath = __DIR__ . '/../../usersc/classes/StatisticsDataService.php';
-        try {
-            if (!file_exists($filePath)) {
-                $this->markTestSkipped('StatisticsDataService file not found');
-            }
-            $this->assertFileExists($filePath, "StatisticsDataService should exist");
-        } catch (Throwable $e) {
-            $this->markTestSkipped("Could not verify StatisticsDataService file: " . $e->getMessage());
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('StatisticsDataService file not found');
         }
+        $this->assertFileExists($filePath, "StatisticsDataService should exist");
     }
 }


### PR DESCRIPTION
## Summary

- Removed `try/catch (Throwable)` wrapper in four test methods that was intercepting `AssertionFailedError` and converting failures into silent test skips
- Corrected four asserted strings to match actual source: `LOG_CATEGORY_SECURITY`, `LOG_CATEGORY_VALIDATION_ERROR`, `LOG_CATEGORY_DATABASE_ERROR`, and `error.message`
- Removed a meaningless `assertStringNotContainsString('response.error')` check that was testing a string that never appears in any source file

## Bug Escape Analysis

**Root cause:** `AssertionFailedError` extends `Error` extends `Throwable`. The try/catch blocks caught assertion failures and called `markTestSkipped()`, so tests always "passed" as skips.

**Testing gap:** No CI gate detected that 23/23 integration tests were skipping. The tests appeared green when they were effectively not running.

**Preventive:** Tests now fail loudly when assertions are wrong. The four corrected tests were verified to pass against the MAMP database (4 tests, 8 assertions, all green).

## Test plan

- [x] Ran `./vendor/bin/phpunit -c phpunit-integration.xml tests/integration/StatisticsApiTest.php --filter "testSecurityViolationLogging|testValidationErrorLogging|testDatabaseErrorLogging|testStatisticsJsErrorHandling"` — 4 tests, 8 assertions, OK
- [x] Pre-commit: 815 unit tests pass, PHPStan clean

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)