### PR TITLE
test: add Playwright regression tests for BS5 JS API migration (#732)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.19.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.19.0.md
@@ -67,6 +67,11 @@
   Client-side image resize (to `elan_image_display_max_size`) before upload.
   Fixed XSS vulnerability in edit car form validation error display (escapeHtml applied to server error messages).
   Added `basename()` normalization to server-side `removeImages` file parameter.
+- **Playwright regression tests for Bootstrap 5 JS API** ([#732](https://github.com/unibrain1/elanregistry/issues/732)):
+  Added `tests/playwright/bs5-migration.test.js` covering Flatpickr date picker initialization
+  on the edit car form, Statistics page `ElanRegistryAPI` availability and tab AJAX lazy-loading,
+  and the navigation dropdown `firstChild` patch in `footer.php` (no TypeError on outside-click).
+  New `npm run playwright:bs5` script for targeted execution.
 - **StatisticsApiTest integration tests** ([#740](https://github.com/unibrain1/elanregistry/issues/740)):
   Removed `try/catch (Throwable)` anti-pattern that was converting assertion failures into silent
   skips; corrected asserted strings to match the actual `LogCategories` constants and `error.message`
@@ -82,10 +87,12 @@
 - [#741](https://github.com/unibrain1/elanregistry/issues/741) — Migrate photo upload from Dropzone to FilePond with improved UX and security fixes
 - [#743](https://github.com/unibrain1/elanregistry/issues/743) — Fix Step 3 photo upload layout for mobile
 - [#744](https://github.com/unibrain1/elanregistry/issues/744) — Fix mobile CSS regressions in add/edit car form
+- [#732](https://github.com/unibrain1/elanregistry/issues/732) — Add Playwright regression tests for Bootstrap 5 JS API migration critical paths
 - [#740](https://github.com/unibrain1/elanregistry/issues/740) — Fix silently-skipping integration tests in StatisticsApiTest
 
 ## Summary
 
-9 issues resolved: full Bootstrap 5 migration (self-hosted libraries, template rebase, class migration,
-mobile responsiveness), first-party JS/CSS minification with esbuild, FilePond image upload library migration
-with mobile layout fix, add/edit car form mobile CSS regressions, and StatisticsApiTest integration test fixes.
+10 issues resolved: full Bootstrap 5 migration (self-hosted libraries, template rebase, class migration,
+mobile responsiveness), Playwright regression tests for BS5 JS API patterns, first-party JS/CSS minification
+with esbuild, FilePond image upload library migration with mobile layout fix, add/edit car form mobile CSS
+regressions, and StatisticsApiTest integration test fixes.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo '\n📋 Available Tests:\n\n  PHP Unit Tests (128 tests):\n    composer test:quick\n\n  E2E Tests - Production (24 tests):\n    npm run test:e2e              # All E2E tests on elanregistry.org\n    npm run test:e2e:not-logged-in  # Public pages only\n    npm run test:e2e:logged-in      # Authenticated user tests\n\n  E2E Tests - Test Environment (24 tests):\n    npm run test:e2e:test         # All E2E tests on test.elanregistry.org\n    npm run test:e2e:test:not-logged-in  # Public pages only\n    npm run test:e2e:test:logged-in      # Authenticated user tests\n\n  Local Playwright Tests - Localhost (16 tests, requires MAMP):\n    npm run playwright:test       # All local tests\n    npm run playwright:security   # Security tests (2)\n    npm run playwright:maps       # Maps & charts (8)\n    npm run playwright:csp        # CSP validation (6)\n\n  Note: Local tests require web server at http://localhost:9999/elan_registry\n'",
+    "test": "echo '\n📋 Available Tests:\n\n  PHP Unit Tests (128 tests):\n    composer test:quick\n\n  E2E Tests - Production (24 tests):\n    npm run test:e2e              # All E2E tests on elanregistry.org\n    npm run test:e2e:not-logged-in  # Public pages only\n    npm run test:e2e:logged-in      # Authenticated user tests\n\n  E2E Tests - Test Environment (24 tests):\n    npm run test:e2e:test         # All E2E tests on test.elanregistry.org\n    npm run test:e2e:test:not-logged-in  # Public pages only\n    npm run test:e2e:test:logged-in      # Authenticated user tests\n\n  Local Playwright Tests - Localhost (16 tests, requires MAMP):\n    npm run playwright:test       # All local tests\n    npm run playwright:security   # Security tests (2)\n    npm run playwright:maps       # Maps & charts (8)\n    npm run playwright:csp        # CSP validation (6)\n    npm run playwright:bs5        # BS5 migration regression (8)\n\n  Note: Local tests require web server at http://localhost:9999/elan_registry\n'",
     "test:quick": "npm run playwright:security",
     "test:smoke": "npm run playwright:test",
     "playwright:install": "npx playwright install",
@@ -16,6 +16,7 @@
     "playwright:security": "playwright test tests/playwright/security.test.js",
     "playwright:maps": "playwright test tests/playwright/maps-charts.test.js",
     "playwright:csp": "playwright test tests/playwright/csp-validation.spec.js",
+    "playwright:bs5": "playwright test tests/playwright/bs5-migration.test.js",
     "playwright:mobile": "playwright test tests/playwright/mobile-responsive.test.js",
     "playwright:headed": "playwright test --headed",
     "playwright:debug": "playwright test --debug",

--- a/tests/playwright/bs5-migration.test.js
+++ b/tests/playwright/bs5-migration.test.js
@@ -1,0 +1,157 @@
+// tests/playwright/bs5-migration.test.js
+//
+// Behavioral regression tests for Bootstrap 5 JS API migration (PR #730).
+// Covers: Flatpickr date pickers, Statistics page ElanRegistryAPI availability,
+// and the nav dropdown firstChild patch in footer.php.
+//
+// Requires local MAMP at http://localhost:9999/elan_registry
+
+const { test, expect } = require('@playwright/test');
+const { ensureLoggedIn, navigateAndWait } = require('./auth-helper.js');
+
+// ---------------------------------------------------------------------------
+// Area 1: Flatpickr date pickers (app/cars/edit.php, step 2)
+// ---------------------------------------------------------------------------
+
+test.describe('BS5 Migration — Flatpickr date pickers', () => {
+  test.beforeEach(async ({ page }) => {
+    await ensureLoggedIn(page);
+    await page.goto('/app/cars/edit.php', { waitUntil: 'networkidle' });
+
+    // Reveal step-2 fieldset (Additional Info) directly rather than driving
+    // step-1 validation (requires model + chassis AJAX, not relevant here)
+    await page.evaluate(() => {
+      const fieldsets = document.querySelectorAll('fieldset');
+      if (fieldsets[0]) fieldsets[0].style.display = 'none';
+      if (fieldsets[1]) fieldsets[1].style.display = '';
+    });
+
+    await expect(page.locator('fieldset').nth(1)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('purchase date field opens flatpickr calendar', async ({ page }) => {
+    await page.locator('#purchasedate').click();
+    await expect(page.locator('.flatpickr-calendar')).toBeVisible();
+  });
+
+  test('purchase date stores value in YYYY-MM-DD format', async ({ page }) => {
+    await page.locator('#purchasedate').fill('2000-06-15');
+    await page.locator('#purchasedate').blur();
+    await expect(page.locator('#purchasedate')).toHaveValue('2000-06-15');
+  });
+
+  test('sold date accepts manual keyboard entry in YYYY-MM-DD format', async ({ page }) => {
+    await page.locator('#solddate').fill('2010-03-22');
+    await page.locator('#solddate').blur();
+    await expect(page.locator('#solddate')).toHaveValue('2010-03-22');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Area 2: Statistics page — ElanRegistryAPI availability & tab lazy-loading
+// Regression for the missing html_footer.php bug fixed in #619.
+// ---------------------------------------------------------------------------
+
+test.describe('BS5 Migration — Statistics page', () => {
+  test('page loads without JS errors', async ({ page }) => {
+    await ensureLoggedIn(page);
+
+    // Attach listener after login so login-page errors don't pollute the array
+    const pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await page.goto('/app/reports/statistics.php');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    expect(pageErrors, `Unexpected JS errors: ${pageErrors.join('\n')}`).toHaveLength(0);
+  });
+
+  test('ElanRegistryAPI is defined on statistics page', async ({ page }) => {
+    await ensureLoggedIn(page);
+    await page.goto('/app/reports/statistics.php');
+    await page.waitForLoadState('networkidle');
+
+    const isDefined = await page.evaluate(() => typeof window.ElanRegistryAPI !== 'undefined');
+    expect(isDefined, 'ElanRegistryAPI should be defined — html_footer.php must be included').toBe(true);
+  });
+
+  test('geographic tab triggers AJAX lazy load successfully', async ({ page }) => {
+    await ensureLoggedIn(page);
+    await page.goto('/app/reports/statistics.php');
+    await page.waitForLoadState('networkidle');
+
+    // Set up response listener before clicking to avoid race condition
+    const responsePromise = page.waitForResponse(
+      (r) => r.url().includes('statistics-data.php') && r.url().includes('tab=geographic'),
+      { timeout: 15000 }
+    );
+
+    await page.locator('#geographic-tab').click();
+    const response = await responsePromise;
+
+    expect(response.status()).toBe(200);
+
+    // Content must be rendered with data, not an error alert
+    await expect(page.locator('#geographic-content')).not.toBeEmpty();
+    await expect(page.locator('#geographic-content .alert-danger')).toHaveCount(0);
+  });
+
+  test('production tab triggers AJAX lazy load successfully', async ({ page }) => {
+    await ensureLoggedIn(page);
+    await page.goto('/app/reports/statistics.php');
+    await page.waitForLoadState('networkidle');
+
+    const responsePromise = page.waitForResponse(
+      (r) => r.url().includes('statistics-data.php') && r.url().includes('tab=production'),
+      { timeout: 15000 }
+    );
+
+    await page.locator('#production-tab').click();
+    const response = await responsePromise;
+
+    expect(response.status()).toBe(200);
+
+    await expect(page.locator('#production-content')).not.toBeEmpty();
+    await expect(page.locator('#production-content .alert-danger')).toHaveCount(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Area 3: Navigation dropdown close-on-outside-click
+// Regression for the users/js/menu.js firstChild patch in footer.php (#729).
+// Without the patch, clicking outside throws: "TypeError: Cannot read properties
+// of undefined (reading 'click')" via open.firstChild.click().
+// ---------------------------------------------------------------------------
+
+test.describe('BS5 Migration — Navigation dropdown', () => {
+  test('clicking outside an open dropdown closes it without TypeError', async ({ page }) => {
+    const typeErrors = [];
+    page.on('pageerror', (err) => {
+      if (err.message.includes('TypeError')) {
+        typeErrors.push(err.message);
+      }
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Confirm a dropdown trigger is present before interacting
+    // (nav uses .sub-toggle, not Bootstrap's .dropdown-toggle)
+    const dropdownToggle = page.locator('.us_menu .sub-toggle').first();
+    await expect(dropdownToggle).toBeVisible({ timeout: 5000 });
+
+    await dropdownToggle.click();
+    await expect(page.locator('.us_sub-menu.show')).toBeVisible({ timeout: 3000 });
+
+    // Click far outside the menu to trigger the outside-click handler
+    await page.mouse.click(10, 10);
+    await page.waitForTimeout(500);
+
+    // Dropdown should be closed — .open class removed by footer.php patch
+    await expect(page.locator('.us_menu .dropdown.open')).toHaveCount(0);
+
+    // No TypeError from menu.js firstChild.click() on a text node
+    expect(typeErrors, `TypeErrors thrown: ${typeErrors.join('\n')}`).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tests/playwright/bs5-migration.test.js` with 8 behavioral regression tests for the Bootstrap 5 vanilla JS API patterns introduced in PR #730
- Adds `npm run playwright:bs5` script for targeted execution
- Updates v2.19.0 release notes

## Coverage

| Area | Tests | What's verified |
|------|-------|-----------------|
| Flatpickr date pickers (`edit.php`) | 3 | Calendar opens on click; purchase and sold date inputs accept and store `YYYY-MM-DD` format |
| Statistics page (`statistics.php`) | 4 | No JS errors on load; `ElanRegistryAPI` defined (regression for #619 footer include bug); geographic and production tabs fire AJAX and render data without error alerts |
| Nav dropdown outside-click | 1 | `firstChild` patch in `footer.php` prevents `TypeError` from `menu.js` on outside-click |

## Bug Escape Analysis

Admin modal flows (`manage-consolidated.php`) are out of scope — no admin test credentials are available in the local environment. The three areas above are fully covered with regular-user auth.

## Test plan

- [ ] `npm run playwright:bs5` — all 8 new tests pass
- [ ] `npm run playwright:test` — no regressions in existing suite

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)