### PR TITLE
fix(security): add realpath() path boundary guard to all unlink() calls

### DIFF
--- a/app/admin/includes/system/backup-operations.php
+++ b/app/admin/includes/system/backup-operations.php
@@ -262,16 +262,22 @@ try {
             $types = ['automated', 'manual', 'rollback'];
 
             $realBackupDir = realpath($backupDir);
+            if ($realBackupDir === false) {
+                ApiResponse::error('Backup directory unavailable', 500)
+                    ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_ERROR,
+                        "Delete backup: realpath() failed for backup dir '{$backupDir}' — server misconfiguration")
+                    ->send();
+            }
 
             foreach ($types as $type) {
                 $filepath = $backupDir . $type . '/' . $filename;
 
                 if (file_exists($filepath)) {
                     $realpath = realpath($filepath);
-                    if ($realpath === false || $realBackupDir === false || !str_starts_with($realpath, $realBackupDir . '/')) {
+                    if ($realpath === false || !str_starts_with($realpath, $realBackupDir . '/')) {
                         ApiResponse::error('Access denied', 403)
                             ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_ERROR,
-                                "Delete backup: path outside backup directory for '{$filename}'")
+                                "Delete backup: path traversal attempt blocked for '{$filename}'")
                             ->send();
                     }
                     if (unlink($realpath)) { // nosemgrep: php.lang.security.unlink-use.unlink-use -- path verified within backup directory

--- a/app/admin/includes/system/backup-operations.php
+++ b/app/admin/includes/system/backup-operations.php
@@ -239,7 +239,7 @@ try {
             break;
 
         case 'delete_backup':
-            // Sanitize filename at assignment — basename() strips directory components to prevent path traversal
+            // basename() strips ../ traversal sequences; realpath() below provides defense-in-depth against symlinks — both are required
             $filename = basename($_POST['filename'] ?? '');
             logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_MANAGER, "Delete backup requested: {$filename}");
 
@@ -261,11 +261,20 @@ try {
             $deleted = false;
             $types = ['automated', 'manual', 'rollback'];
 
+            $realBackupDir = realpath($backupDir);
+
             foreach ($types as $type) {
                 $filepath = $backupDir . $type . '/' . $filename;
 
                 if (file_exists($filepath)) {
-                    if (unlink($filepath)) {
+                    $realpath = realpath($filepath);
+                    if ($realpath === false || $realBackupDir === false || !str_starts_with($realpath, $realBackupDir . '/')) {
+                        ApiResponse::error('Access denied', 403)
+                            ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_ERROR,
+                                "Delete backup: path outside backup directory for '{$filename}'")
+                            ->send();
+                    }
+                    if (unlink($realpath)) { // nosemgrep: php.lang.security.unlink-use.unlink-use -- path verified within backup directory
                         $deleted = true;
                         logger($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_MANAGER,
                             "Backup deleted via API: {$filename} (type: {$type})");
@@ -273,7 +282,7 @@ try {
                     } else {
                         ApiResponse::error('Failed to delete backup file', 500)
                             ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_BACKUP_ERROR,
-                                "Failed to unlink backup file: {$filepath}")
+                                "Failed to unlink backup file: {$realpath}")
                             ->send();
                     }
                 }

--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -23,6 +23,11 @@ None.
 
 ## Technical Changes
 
+- **Path boundary guard on unlink() calls** ([#634](https://github.com/unibrain1/elanregistry/issues/634)):
+  Added `realpath()` verification before all `unlink()` calls in backup and cache operations
+  to ensure deleted files are confirmed within their intended directory, resolving Semgrep
+  `php.lang.security.unlink-use.unlink-use` findings.
+
 - **confirm() → #confirmationModal** ([#571](https://github.com/unibrain1/elanregistry/issues/571)):
   Three confirm() calls in tab-manage_cars.php and tab-system.php converted to the existing
   confirmationModal pattern.
@@ -43,11 +48,13 @@ None.
   Convert validation alert() dialogs to app notification system
 - [#573](https://github.com/unibrain1/elanregistry/issues/573) —
   Convert remaining native dialogs and improve error messaging
+- [#634](https://github.com/unibrain1/elanregistry/issues/634) —
+  Add path boundary guard to unlink() calls in backup operations
 - [#775](https://github.com/unibrain1/elanregistry/pull/775) —
   chore(deps): bump datatables.net and datatables.net-bs4
 
 ## Summary
 
-3 issues and 1 dependency update resolved; replaces all native browser dialogs across the
-admin interface with Bootstrap 5 modals and the app notification system, and updates
-datatables.net to 1.13.11.
+4 issues and 1 dependency update resolved; replaces all native browser dialogs across the
+admin interface with Bootstrap 5 modals and the app notification system, updates
+datatables.net to 1.13.11, and hardens file deletion with path boundary guards.

--- a/usersc/classes/LocationService.php
+++ b/usersc/classes/LocationService.php
@@ -487,7 +487,11 @@ class LocationService
 
         $data = @json_decode(file_get_contents($cacheFile), true);
         if (!$data || !isset($data['expires']) || $data['expires'] < time()) {
-            @unlink($cacheFile);
+            $realCacheFile = realpath($cacheFile);
+            $realCacheDir = realpath($cacheDir);
+            if ($realCacheFile !== false && $realCacheDir !== false && str_starts_with($realCacheFile, $realCacheDir . '/')) {
+                @unlink($realCacheFile); // nosemgrep: php.lang.security.unlink-use.unlink-use -- path verified within cache directory; failure is non-fatal (stale cache)
+            }
             return null;
         }
 

--- a/usersc/classes/admin/BackupManager.php
+++ b/usersc/classes/admin/BackupManager.php
@@ -623,6 +623,13 @@ class BackupManager {
         ];
 
         $types = ['automated', 'manual', 'rollback'];
+        $realBackupBase = realpath($this->backupBaseDir);
+
+        if ($realBackupBase === false) {
+            ($this->logger)(1, LogCategories::LOG_CATEGORY_BACKUP_ERROR,
+                "cleanupOldBackups: realpath() failed for backup base dir '{$this->backupBaseDir}' — cleanup aborted");
+            return $cleanupSummary;
+        }
 
         foreach ($types as $type) {
             $typeDir = $this->backupBaseDir . $type . '/';
@@ -646,9 +653,23 @@ class BackupManager {
                 $cutoffTime = time() - ($fileRetentionDays * 24 * 60 * 60);
 
                 if (filemtime($file) < $cutoffTime) {
-                    if (unlink($file)) {
+                    $realpath = realpath($file);
+                    if ($realpath === false) {
+                        ($this->logger)(1, LogCategories::LOG_CATEGORY_BACKUP_MANAGER,
+                            "cleanupOldBackups: realpath() returned false for '{$file}' — skipping (possibly deleted concurrently)");
+                        continue;
+                    }
+                    if (!str_starts_with($realpath, $realBackupBase . '/')) {
+                        ($this->logger)(1, LogCategories::LOG_CATEGORY_BACKUP_ERROR,
+                            "cleanupOldBackups: path traversal blocked — '{$realpath}' is outside backup base '{$realBackupBase}'");
+                        continue;
+                    }
+                    if (unlink($realpath)) { // nosemgrep: php.lang.security.unlink-use.unlink-use -- path verified within backup directory
                         $cleanupSummary[$type]['deleted']++;
-                        $this->logBackupEvent('deleted', $filename, $type, $environment, $file);
+                        $this->logBackupEvent('deleted', $filename, $type, $environment, $realpath);
+                    } else {
+                        ($this->logger)(1, LogCategories::LOG_CATEGORY_BACKUP_ERROR,
+                            "cleanupOldBackups: unlink() failed for '{$realpath}' — check permissions");
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Resolves Semgrep `php.lang.security.unlink-use.unlink-use` findings on three `unlink()` call sites in backup and cache operations
- Adds `realpath()` + `str_starts_with()` path boundary guard to verify resolved paths stay within their intended directories before deletion
- Hardens `BackupManager::cleanupOldBackups()` with explicit logging for all previously-silent failure modes (base dir resolution failure, skipped files, traversal blocks, unlink failures)

## Test plan

- [ ] Verify Semgrep `unlink-use` findings resolve on the three flagged lines
- [ ] Test backup delete via admin UI — valid backup deletes successfully
- [ ] Confirm admin backup cleanup runs without errors in logs
- [ ] Verify expired location cache entries are cleaned up correctly

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)