### PR TITLE
feat(security): split admin panel and enforce role-based page permissions

### DIFF
--- a/app/admin/includes/system/backup-operations.php
+++ b/app/admin/includes/system/backup-operations.php
@@ -19,14 +19,6 @@ if (!securePage($php_self)) {
         ->send();
 }
 
-// Only administrators can perform backup operations
-if (!hasPerm([2], $user->data()->id)) {
-    ApiResponse::forbidden('Administrator access required')
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY,
-            'Non-admin attempted backup operations')
-        ->send();
-}
-
 // CSRF protection for all POST operations
 if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
     ApiResponse::forbidden('Invalid CSRF token')

--- a/app/admin/manage-consolidated.php
+++ b/app/admin/manage-consolidated.php
@@ -10,9 +10,7 @@ declare(strict_types=1);
  * TAB 1: Car/Owner Relationships - Car reassignment, deletion, and ownership transfers
  * TAB 2: Manage Cars - Individual car management and bulk operations
  * TAB 3: Manage Owners - User profile management and owner data administration
- * TAB 4: System Maintenance - Database maintenance, FIX scripts, and system utilities
- * TAB 5: Owner Cleanup - User account cleanup information and spam management overview
- * TAB 6: Settings - Complete ElanRegistry configuration (Google APIs, CDNs, media, email)
+ * TAB 4: Owner Cleanup - User account cleanup information and spam management overview
  *
  * @author Elan Registry Development Team
  * @copyright 2025
@@ -45,9 +43,7 @@ $validTabs = [
     'car-mgmt' => 'Car/Owner Relationships',
     'manage-cars' => 'Manage Cars',
     'owner-mgmt' => 'Manage Owners',
-    'cleanup' => 'Owner Cleanup',
-    'system' => 'System Maintenance',
-    'settings' => 'Settings'
+    'cleanup' => 'Owner Cleanup'
 ];
 
 $activeTab = isset($_GET['tab']) && array_key_exists($_GET['tab'], $validTabs) ? $_GET['tab'] : 'car-mgmt';
@@ -143,7 +139,7 @@ try {
     // Store separated counts
     $systemStatus['car_issues'] = $carIssues;
     $systemStatus['owner_issues'] = $ownerIssues;
-    $systemStatus['quality_issues'] = $carIssues + $ownerIssues; // Total for backwards compatibility
+    $systemStatus['quality_issues'] = $carIssues + $ownerIssues;
 
 } catch (PDOException $e) {
     // Fail silently for header stats - main functionality should still work
@@ -372,7 +368,7 @@ if (Input::exists('post')) {
                             <h1 class="h2 mb-2 text-gray-800">
                                 <i class="fas fa-cogs"></i> Registry Management
                             </h1>
-                            <p class="text-muted mb-0">Administrative tools for car registry, data quality, and system maintenance</p>
+                            <p class="text-muted mb-0">Administrative tools for car registry and ownership management</p>
                         </div>
                         <div class="text-end">
                             <div class="mb-2">
@@ -443,22 +439,6 @@ if (Input::exists('post')) {
                                     <a class="nav-link <?= $activeTab === 'cleanup' ? 'active' : '' ?>"
                                        href="?tab=cleanup" role="tab">
                                         <i class="fas fa-shield-alt"></i> Owner Cleanup
-                                    </a>
-                                </li>
-
-                                <!-- System Maintenance Tab -->
-                                <li class="nav-item">
-                                    <a class="nav-link <?= $activeTab === 'system' ? 'active' : '' ?>"
-                                       href="?tab=system" role="tab">
-                                        <i class="fas fa-tools"></i> System Maintenance
-                                    </a>
-                                </li>
-
-                                <!-- Settings Tab -->
-                                <li class="nav-item">
-                                    <a class="nav-link <?= $activeTab === 'settings' ? 'active' : '' ?>"
-                                       href="?tab=settings" role="tab">
-                                        <i class="fas fa-cog"></i> Settings
                                     </a>
                                 </li>
 
@@ -803,4 +783,3 @@ if (Input::exists('post')) {
     document.documentElement.setAttribute('data-csrf-token', '<?= $csrfToken ?>');
 </script>
 <script src="assets/manage-consolidated.min.js"></script>
-<script src="assets/backup-operations.min.js"></script>

--- a/app/admin/manage-maintenance.php
+++ b/app/admin/manage-maintenance.php
@@ -1,0 +1,186 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * manage-maintenance.php
+ * Registry Maintenance Interface
+ *
+ * Admin-only management interface focused on system maintenance and
+ * registry-wide configuration. Split out from manage-consolidated.php to
+ * separate operational maintenance from day-to-day car/owner administration.
+ *
+ * TAB 1: System Maintenance - Database maintenance, FIX scripts, backups
+ * TAB 2: Settings - ElanRegistry configuration (Google APIs, CDNs, media, email)
+ *
+ * Access control is enforced by PageManager (admin-only). All state-changing
+ * operations on this page are performed via AJAX endpoints
+ * (backup-operations.php, schema-operations.php), so this page does not
+ * process any direct form submissions.
+ *
+ * @author Elan Registry Development Team
+ * @copyright 2025
+ */
+
+require_once '../../users/init.php';
+require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
+
+// securePage() enforces access via the UserSpice permission_page_matches table.
+// This page must be registered with admin-only (permission 2) in the UserSpice
+// pages table — the restriction is a DB configuration, not a code-level hard gate.
+if (!securePage($php_self)) {
+    die();
+}
+
+$db = DB::getInstance();
+
+// securePage() handles auth/permission. This guard covers the narrow edge case
+// where the session passes securePage() but is corrupt — ensuring the audit trail
+// always records a real user ID.
+try {
+    $currentUserId = currentUserId();
+} catch (RuntimeException $e) {
+    logger(0, LogCategories::LOG_CATEGORY_SECURITY,
+        "Admin page accessed with invalid user session on $php_self");
+    Redirect::to($us_url_root . 'users/login.php');
+    die();
+}
+
+$validTabs = [
+    'system' => 'System Maintenance',
+    'settings' => 'Settings'
+];
+
+$activeTab = isset($_GET['tab']) && array_key_exists($_GET['tab'], $validTabs) ? $_GET['tab'] : 'system';
+$pageTitle = 'Registry Maintenance - ' . $validTabs[$activeTab];
+
+// Generate CSRF token for AJAX requests
+$csrfToken = Token::generate();
+
+// Get system status for header (cars + active users only — other counts not
+// relevant to maintenance/settings view)
+$systemStatus = [
+    'total_cars' => 0,
+    'total_users' => 0,
+    'last_updated' => date('Y-m-d H:i:s')
+];
+
+try {
+    $carCountStmt = $db->query("SELECT COUNT(*) as count FROM cars");
+    $carCount = $carCountStmt->first();
+    $systemStatus['total_cars'] = $carCount ? (int)$carCount->count : 0;
+
+    $userCountStmt = $db->query("SELECT COUNT(*) as count FROM users WHERE active = ?", [1]);
+    $userCount = $userCountStmt->first();
+    $systemStatus['total_users'] = $userCount ? (int)$userCount->count : 0;
+} catch (PDOException $e) {
+    // Header stats are cosmetic — a PDOException here may indicate broader DB issues
+    // affecting maintenance operations on this page.
+    logger($currentUserId ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+           "Database error getting system status: " . $e->getMessage());
+} catch (RuntimeException $e) {
+    logger($currentUserId ?? 0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR,
+           "Runtime error getting system status: " . $e->getMessage());
+}
+
+?>
+
+<div class="page-wrapper">
+    <!-- Hidden CSRF token for AJAX requests -->
+    <input type="hidden" name="csrf" value="<?= $csrfToken ?>" />
+
+    <div class="container-fluid">
+        <div class="page-container">
+
+            <!-- Page Header -->
+            <div class="row mb-4">
+                <div class="col-12">
+                    <div class="d-sm-flex align-items-center justify-content-between">
+                        <div>
+                            <h1 class="h2 mb-2 text-gray-800">
+                                <i class="fas fa-tools"></i> Registry Maintenance
+                            </h1>
+                            <p class="text-muted mb-0">System maintenance, database operations, and registry settings</p>
+                        </div>
+                        <div class="text-end">
+                            <div class="mb-2">
+                                <span class="badge text-bg-success badge-lg">
+                                    <i class="fas fa-check-circle"></i> System Operational
+                                </span>
+                            </div>
+                            <div>
+                                <small class="text-muted">
+                                    <i class="fas fa-database"></i> <?= number_format($systemStatus['total_cars']) ?> cars &nbsp;
+                                    <i class="fas fa-users"></i> <?= number_format($systemStatus['total_users']) ?> users
+                                    <br><i class="fas fa-clock"></i> Updated: <?= date('M j, Y g:i A', strtotime($systemStatus['last_updated'])) ?>
+                                    <br><i class="fas fa-code-branch"></i> <?= htmlspecialchars(ApplicationVersion::get()) ?>
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Main Interface Card -->
+            <div class="row">
+                <div class="col-12">
+                    <div class="card registry-card">
+
+                        <!-- Navigation Tabs -->
+                        <div class="card-header p-0">
+                            <ul class="nav nav-tabs card-header-tabs" id="managementTabs" role="tablist">
+
+                                <!-- System Maintenance Tab -->
+                                <li class="nav-item">
+                                    <a class="nav-link <?= $activeTab === 'system' ? 'active' : '' ?>"
+                                       href="?tab=system" role="tab">
+                                        <i class="fas fa-tools"></i> System Maintenance
+                                    </a>
+                                </li>
+
+                                <!-- Settings Tab -->
+                                <li class="nav-item">
+                                    <a class="nav-link <?= $activeTab === 'settings' ? 'active' : '' ?>"
+                                       href="?tab=settings" role="tab">
+                                        <i class="fas fa-cog"></i> Settings
+                                    </a>
+                                </li>
+
+                            </ul>
+                        </div>
+
+                        <!-- Tab Content -->
+                        <div class="card-body">
+                            <div class="tab-content" id="managementTabContent">
+
+                                <?php
+                                $tabFile = 'includes/tab-' . str_replace('-', '_', $activeTab) . '.php';
+                                $tabPath = __DIR__ . '/' . $tabFile;
+
+                                if (file_exists($tabPath)) {
+                                    include $tabPath;
+                                } else {
+                                    include 'includes/tab-placeholder.php';
+                                }
+                                ?>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>
+
+<link rel="stylesheet" href="assets/manage-consolidated.min.css">
+<script>
+    window.elanUrlRoot = '<?= $us_url_root ?>';
+    // Make CSRF token available to ElanRegistryAPI client
+    document.documentElement.setAttribute('data-csrf-token', '<?= $csrfToken ?>');
+</script>
+<script src="assets/manage-consolidated.min.js"></script>
+<script src="assets/backup-operations.min.js"></script>
+

--- a/database/3-configuration.sql
+++ b/database/3-configuration.sql
@@ -207,6 +207,8 @@ INSERT INTO `pages` (`id`, `page`, `title`, `private`, `re_auth`, `core`) VALUES
 (330, 'app/admin/verify/send_email.php', NULL, 1, 0, 0),
 (331, 'app/admin/verify/verify_car.php', NULL, 1, 0, 0),
 (337, 'app/admin/includes/system/schema-operations.php', NULL, 1, 0, 0),
+(338, 'app/admin/manage-maintenance.php', 'Admin - Registry Maintenance', 1, 0, 0),
+(339, 'app/admin/includes/system/backup-operations.php', 'Admin - Backup Operations', 1, 0, 0),
 (9001, 'docs/pdf-viewer.php',   NULL, 0, 0, 0),
 (9002, 'docs/guide-viewer.php', NULL, 0, 0, 0)
 ON DUPLICATE KEY UPDATE
@@ -226,6 +228,7 @@ INSERT IGNORE INTO `permission_page_matches` (`permission_id`, `page_id`) VALUES
 (2, 68), (2, 157), (2, 256), (2, 280), (2, 283), (2, 294), (2, 299), (2, 300),
 (2, 301), (2, 304), (2, 305), (2, 306), (2, 308), (2, 309), (2, 310), (2, 311),
 (2, 312), (2, 313), (2, 314), (2, 315), (2, 317), (2, 327), (2, 331), (2, 336),
+(2, 337), (2, 338), (2, 339),
 
 -- Editor (permission_id = 3) - Content editor access
 (3, 3), (3, 4), (3, 157), (3, 256), (3, 283), (3, 294), (3, 299), (3, 300),

--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -40,6 +40,14 @@ None.
   ([#775](https://github.com/unibrain1/elanregistry/pull/775)):
   Bumps datatables.net and datatables.net-bs4 to 1.13.11 (security fix).
 
+- **Split manage-consolidated into car management and system maintenance** ([#610](https://github.com/unibrain1/elanregistry/issues/610)):
+  `manage-consolidated.php` now handles car/owner management (Admins and Editors);
+  new `manage-maintenance.php` handles system maintenance and settings tabs (Admin only).
+- **Enforced admin-only page access via UserSpice PageManager** ([#610](https://github.com/unibrain1/elanregistry/issues/610)):
+  Removed redundant `hasPerm([2])` from `backup-operations.php`; access control now
+  centralized in UserSpice pages table with role-based permissions; operational endpoints
+  use `isRegistryAdmin()` for additional validation.
+
 ## Issues Resolved
 
 - [#571](https://github.com/unibrain1/elanregistry/issues/571) —
@@ -48,6 +56,8 @@ None.
   Convert validation alert() dialogs to app notification system
 - [#573](https://github.com/unibrain1/elanregistry/issues/573) —
   Convert remaining native dialogs and improve error messaging
+- [#610](https://github.com/unibrain1/elanregistry/issues/610) —
+  Separate system maintenance functionality from car management; enforce admin-only access via PageManager
 - [#634](https://github.com/unibrain1/elanregistry/issues/634) —
   Add path boundary guard to unlink() calls in backup operations
 - [#775](https://github.com/unibrain1/elanregistry/pull/775) —
@@ -55,6 +65,7 @@ None.
 
 ## Summary
 
-4 issues and 1 dependency update resolved; replaces all native browser dialogs across the
-admin interface with Bootstrap 5 modals and the app notification system, updates
-datatables.net to 1.13.11, and hardens file deletion with path boundary guards.
+5 issues and 1 dependency update resolved; replaces all native browser dialogs across the
+admin interface with Bootstrap 5 modals and the app notification system, refactors admin
+pages to separate system maintenance from car management with role-based access control,
+updates datatables.net to 1.13.11, and hardens file deletion with path boundary guards.

--- a/usersc/templates/customizer/file_nav_custom.php
+++ b/usersc/templates/customizer/file_nav_custom.php
@@ -107,7 +107,7 @@
       </li>
     <?php endif; ?>
 
-    <?php if (checkMenu(2, $user->data()->id)): ?>
+    <?php if (isRegistryAdmin($user->data()->id)): ?>
       <li class='dropdown'>
         <a class='sub-toggle' href='#' id='menu_1_638b71f2ed026_dropdown_admin' role='button' aria-haspopup='true' aria-expanded='false' data-target='#menu_1_638b71f2ed026_dropdown_admin'>
           <i class='fa fa-cogs'></i>
@@ -118,15 +118,24 @@
           <li class=''>
             <a class='' href='<?= $us_url_root ?>app/admin/manage-consolidated.php'>
               <i class='fa fa-car'></i>
-              <span class='labelText'>Manage Registry</span>
+              <span class='labelText'>Manage Cars/Owners</span>
             </a>
           </li>
+          <?php if (hasPerm([2], $user->data()->id)): ?>
+          <li class=''>
+            <a class='' href='<?= $us_url_root ?>app/admin/manage-maintenance.php'>
+              <i class='fa fa-tools'></i>
+              <span class='labelText'>Registry Maintenance</span>
+            </a>
+          </li>
+          <?php endif; ?>
           <li class=''>
             <a class='' href='<?= $us_url_root ?>docs/admin/index.php'>
               <i class='fa fa-question-circle'></i>
               <span class='labelText'>Admin Guide</span>
             </a>
           </li>
+          <?php if (hasPerm([2], $user->data()->id)): ?>
           <div class='dropdown-divider'></div>
           <li class=''>
             <a class='' href='<?= $us_url_root ?>users/admin.php'>
@@ -134,6 +143,7 @@
               <span class='labelText'>Admin Dashboard</span>
             </a>
           </li>
+          <?php endif; ?>
         </ul>
       </li>
     <?php endif; ?>


### PR DESCRIPTION
## Summary

- Splits `manage-consolidated.php` into two role-scoped pages: car/owner management (Admin + Editor) and new `manage-maintenance.php` for system maintenance and settings (Admin only)
- Enforces admin-only access via UserSpice PageManager (pages table) rather than redundant code-level `hasPerm()` guards
- Removes redundant `hasPerm([2])` from `backup-operations.php` — `securePage()` + PageManager is the enforcing layer
- Registers `backup-operations.php`, `schema-operations.php`, and `manage-maintenance.php` in `database/3-configuration.sql` with admin-only permissions
- Widens nav Admin dropdown to Editors (Manage Cars/Owners, Admin Guide); scopes Registry Maintenance and Admin Dashboard links to admins only
- Opens issue #780 to remove the unimplemented Owner Cleanup tab

## Permission strategy documented

| Endpoint type | Pattern | Rationale |
|---|---|---|
| System-level destructive ops (backup, schema) | `securePage()` on admin-only page | PageManager enforces; no redundant code guard needed |
| Administrative data ops (transfers, owner updates) | `isRegistryAdmin()` | Editors legitimately need these |
| Verification endpoints | `securePage()` + verification code | Access controlled by code, not role |

## Test plan

- [ ] Log in as Editor (perm 3): Admin dropdown visible with Manage Cars/Owners and Admin Guide; Registry Maintenance and Admin Dashboard not shown
- [ ] Log in as Admin (perm 2): All four Admin dropdown items visible
- [ ] Direct URL to `manage-maintenance.php` as Editor returns 403
- [ ] Direct URL to `manage-maintenance.php` as Admin loads with System Maintenance and Settings tabs
- [ ] `manage-consolidated.php` shows only Car/Owner Relationships, Manage Cars, Manage Owners, Owner Cleanup tabs
- [ ] Run `database/3-configuration.sql` on staging and verify pages 337–339 have correct permissions
- [ ] 815 unit tests pass ✅ (verified pre-commit)

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)