### PR TITLE
feat: log warning when getBaseUrl() falls back to hardcoded production URL (#641)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -47,6 +47,10 @@ None.
   Removed redundant `hasPerm([2])` from `backup-operations.php`; access control now
   centralized in UserSpice pages table with role-based permissions; operational endpoints
   use `isRegistryAdmin()` for additional validation.
+- **Log warning when getBaseUrl() falls back to hardcoded production URL** ([#641](https://github.com/unibrain1/elanregistry/issues/641)):
+  `getBaseUrl()` now logs an `EmailSettings` entry when `verify_url` is not configured
+  in email settings, making environment misconfiguration visible instead of silently
+  sending staging emails with production links.
 
 ## Issues Resolved
 
@@ -60,12 +64,15 @@ None.
   Separate system maintenance functionality from car management; enforce admin-only access via PageManager
 - [#634](https://github.com/unibrain1/elanregistry/issues/634) —
   Add path boundary guard to unlink() calls in backup operations
+- [#641](https://github.com/unibrain1/elanregistry/issues/641) —
+  Log warning when getBaseUrl() falls back to hardcoded production URL
 - [#775](https://github.com/unibrain1/elanregistry/pull/775) —
   chore(deps): bump datatables.net and datatables.net-bs4
 
 ## Summary
 
-5 issues and 1 dependency update resolved; replaces all native browser dialogs across the
+6 issues and 1 dependency update resolved; replaces all native browser dialogs across the
 admin interface with Bootstrap 5 modals and the app notification system, refactors admin
 pages to separate system maintenance from car management with role-based access control,
-updates datatables.net to 1.13.11, and hardens file deletion with path boundary guards.
+updates datatables.net to 1.13.11, hardens file deletion with path boundary guards, and
+improves environment misconfiguration visibility in email URL generation.

--- a/usersc/includes/custom_functions.php
+++ b/usersc/includes/custom_functions.php
@@ -124,9 +124,11 @@ function getBaseUrl(): string {
     }
 
     // Fallback for CLI or early-boot contexts where server globals are not set
+    global $user;
     static $baseUrl = null;
     if ($baseUrl === null) {
         $defaultUrl = 'https://elanregistry.org';
+        $logUserId = (isset($user) && $user->isLoggedIn()) ? (int) $user->data()->id : 0;
         $dbError = false;
         try {
             $db = DB::getInstance();
@@ -140,7 +142,7 @@ function getBaseUrl(): string {
             $category = $dbError ? LogCategories::LOG_CATEGORY_SYSTEM_ERROR : LogCategories::LOG_CATEGORY_EMAIL_SETTINGS;
             $reason = $dbError ? 'database unavailable' : 'verify_url not configured in email settings';
             try {
-                logger(0, $category,
+                logger($logUserId, $category,
                     "getBaseUrl() falling back to hardcoded production URL — $reason; emails from this environment will link to $defaultUrl");
             } catch (\Throwable $e) {
                 // logger unavailable; proceed with fallback silently

--- a/usersc/includes/custom_functions.php
+++ b/usersc/includes/custom_functions.php
@@ -128,7 +128,7 @@ function getBaseUrl(): string {
     static $baseUrl = null;
     if ($baseUrl === null) {
         $defaultUrl = 'https://elanregistry.org';
-        $logUserId = (isset($user) && $user->isLoggedIn()) ? (int) $user->data()->id : 0;
+        $logUserId = (isset($user) && $user->isLoggedIn() && $user->data()) ? (int) $user->data()->id : 0;
         $dbError = false;
         try {
             $db = DB::getInstance();

--- a/usersc/includes/custom_functions.php
+++ b/usersc/includes/custom_functions.php
@@ -126,13 +126,25 @@ function getBaseUrl(): string {
     // Fallback for CLI or early-boot contexts where server globals are not set
     static $baseUrl = null;
     if ($baseUrl === null) {
-        $db = DB::getInstance();
-        $result = $db->query("SELECT verify_url FROM email")->first();
-        $baseUrl = $result->verify_url ?? null;
+        $defaultUrl = 'https://elanregistry.org';
+        $dbError = false;
+        try {
+            $db = DB::getInstance();
+            $result = $db->query("SELECT verify_url FROM email")->first();
+            $baseUrl = $result->verify_url ?? null;
+        } catch (\PDOException $e) {
+            $baseUrl = null;
+            $dbError = true;
+        }
         if ($baseUrl === null) {
-            $defaultUrl = 'https://elanregistry.org';
-            logger(0, LogCategories::LOG_CATEGORY_EMAIL_SETTINGS,
-                "getBaseUrl() falling back to hardcoded production URL — verify_url not configured in email settings; emails from this environment will link to $defaultUrl");
+            $category = $dbError ? LogCategories::LOG_CATEGORY_SYSTEM_ERROR : LogCategories::LOG_CATEGORY_EMAIL_SETTINGS;
+            $reason = $dbError ? 'database unavailable' : 'verify_url not configured in email settings';
+            try {
+                logger(0, $category,
+                    "getBaseUrl() falling back to hardcoded production URL — $reason; emails from this environment will link to $defaultUrl");
+            } catch (\Throwable $e) {
+                // logger unavailable; proceed with fallback silently
+            }
             $baseUrl = $defaultUrl;
         }
     }

--- a/usersc/includes/custom_functions.php
+++ b/usersc/includes/custom_functions.php
@@ -128,7 +128,13 @@ function getBaseUrl(): string {
     if ($baseUrl === null) {
         $db = DB::getInstance();
         $result = $db->query("SELECT verify_url FROM email")->first();
-        $baseUrl = $result->verify_url ?? 'https://elanregistry.org';
+        $baseUrl = $result->verify_url ?? null;
+        if ($baseUrl === null) {
+            $defaultUrl = 'https://elanregistry.org';
+            logger(0, LogCategories::LOG_CATEGORY_EMAIL_SETTINGS,
+                "getBaseUrl() falling back to hardcoded production URL — verify_url not configured in email settings; emails from this environment will link to $defaultUrl");
+            $baseUrl = $defaultUrl;
+        }
     }
 
     return rtrim($baseUrl, '/');


### PR DESCRIPTION
## Summary

- `getBaseUrl()` now detects when `verify_url` is not configured in email settings and logs an `EmailSettings` warning entry instead of silently falling back to the hardcoded production URL
- Hardcoded fallback URL extracted to a named variable to eliminate duplication between the log message and the fallback value
- Release notes updated for v2.20.0

## Test plan

- [ ] Verify `getBaseUrl()` returns correct URL in web context (server globals populated)
- [ ] Verify `getBaseUrl()` returns `verify_url` from DB when server globals absent (CLI context)
- [ ] Verify a log entry with category `EmailSettings` is written when `verify_url` is null/missing
- [ ] Confirm no log entry is written on subsequent calls (static cache prevents repeated logging)

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)