### PR TITLE
fix(admin): show estimated badge when backup health score is a fallback placeholder (#785)

### DIFF
--- a/app/admin/includes/tab-health.php
+++ b/app/admin/includes/tab-health.php
@@ -51,6 +51,8 @@ if (!empty($fixScripts)) {
 
 $pendingMigrations = count(array_filter($scriptRunStatus, fn($s) => !$s['has_run']));
 
+$backupStatsFallback = false;
+
 try {
     $backupStats = $backupManager->getEnhancedBackupStatistics();
     $oldBackupsCount = 0;
@@ -64,6 +66,7 @@ try {
     $showCleanupPrompt = $oldBackupsCount > 0;
 } catch (BackupException $e) {
     logger($user->data()->id, $e->getLogCategory(), 'Enhanced backup stats failed: ' . $e->getMessage());
+    $backupStatsFallback = true;
     try {
         $backupStats = getBackupStatistics();
         $backupStats['health_score'] = 85;
@@ -148,6 +151,9 @@ try {
                     <?= ($backupStats['automated']['count'] + $backupStats['manual']['count'] + $backupStats['rollback']['count']) ?> total files
                     <?php if (isset($backupStats['health_score'])): ?>
                         | Score: <?= $backupStats['health_score'] ?>/100
+                        <?php if ($backupStatsFallback): ?>
+                            <span class="badge text-bg-warning ms-1" title="Enhanced stats unavailable; this score is an estimate">estimated</span>
+                        <?php endif; ?>
                     <?php endif; ?>
                 </small>
             </div>

--- a/app/admin/includes/tab-maintenance.php
+++ b/app/admin/includes/tab-maintenance.php
@@ -61,6 +61,8 @@ foreach ($allMaintenanceItems as $item) {
 
 sort($maintenanceScripts, SORT_NATURAL);
 
+$backupStatsFallback = false;
+
 try {
     $backupStats = $backupManager->getEnhancedBackupStatistics();
     $oldBackupsCount = 0;
@@ -74,6 +76,7 @@ try {
     $showCleanupPrompt = $oldBackupsCount > 0;
 } catch (BackupException $e) {
     logger($user->data()->id, $e->getLogCategory(), 'Enhanced backup stats failed: ' . $e->getMessage());
+    $backupStatsFallback = true;
     try {
         $backupStats = getBackupStatistics();
         $backupStats['health_score'] = 85;

--- a/docs/development/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/development/RELEASE_NOTES_TEMPLATE.md
@@ -11,6 +11,8 @@ or script execution. Use numbered steps with commands.]
 
 ## User-Facing Changes
 
+Changes visible to public registry visitors (car listings, owner pages, search, etc.).
+
 ### New Features
 
 - **[Feature Name]** ([#NNN](https://github.com/unibrain1/elanregistry/issues/NNN)): One-line description of the feature and its benefit to users.
@@ -19,22 +21,17 @@ or script execution. Use numbered steps with commands.]
 
 - **[Improvement Name]** ([#NNN](https://github.com/unibrain1/elanregistry/issues/NNN)): One-line description of the improvement and its benefit.
 
-### Bug Fixes
+## Admin-Facing Changes
 
-- **[Fix Name]** ([#NNN](https://github.com/unibrain1/elanregistry/issues/NNN)): One-line description of what was fixed.
+Changes visible only to administrators (admin dashboard, maintenance tools, settings, etc.).
+Uses the same subsections (New Features, Improvements) as User-Facing Changes above.
 
-## Technical Changes
-
-- **[Change Name]** ([#NNN](https://github.com/unibrain1/elanregistry/issues/NNN)): One-line description of the technical change.
+- **[Change Name]** ([#NNN](https://github.com/unibrain1/elanregistry/issues/NNN)): One-line description.
 
 ## Issues Resolved
 
-- [#NNN](https://github.com/unibrain1/elanregistry/issues/NNN) — Issue title
-- [#NNN](https://github.com/unibrain1/elanregistry/issues/NNN) — Issue title
-
-## Summary
-
-[One to two sentences: total issues resolved, PRs merged, key themes.]
+- [#NNN](https://github.com/unibrain1/elanregistry/issues/NNN) — GitHub issue title (verbatim)
+- [#NNN](https://github.com/unibrain1/elanregistry/issues/NNN) — GitHub issue title (verbatim)
 
 ---
 
@@ -55,30 +52,29 @@ When generating release notes:
 
 1. **Gather all changes** from the milestone: closed issues, merged PRs, and
    commits since the last release tag.
-2. **User-Facing Changes** should focus on the benefit to the user, not
-   implementation details. Each item is one line. Remove subsections (New
-   Features, Improvements, Bug Fixes) if they have no entries.
-3. **Technical Changes** are one line each with an issue/PR link. These cover
-   code quality, refactoring, CI/CD, test infrastructure, and internal
-   improvements that don't directly affect users.
-4. **Issues Resolved** lists every closed issue in the milestone, sorted by
-   issue number. Use the format `- [#NNN](URL) — Title`.
-5. **Required Actions** should only appear when there are actual post-deployment
+2. **User-Facing Changes** are changes visible to public registry visitors
+   (car listings, owner pages, search, etc.). **Admin-Facing Changes** are
+   changes visible only to administrators (admin dashboard, maintenance tools,
+   settings). Keep these sections separate. Each item is one line, benefit-focused.
+   Remove a section or subsection entirely if it has no entries.
+3. **Issues Resolved** lists every closed issue in the milestone, sorted by
+   issue number. Use the exact GitHub issue/PR title verbatim.
+   Format: `- [#NNN](URL) — GitHub issue title`
+4. **Required Actions** should only appear when there are actual post-deployment
    steps (SQL migrations, config changes, dependency installs). Otherwise state
    "None".
-6. **Be concise.** No multi-line descriptions. No verbose explanations. Link to
-   the issue/PR for details.
-7. **No emoji** in section headers.
+5. **Be concise.** No multi-line descriptions. One line per entry. The Issues
+   Resolved list carries the narrative — link to the issue/PR for details.
+6. **No emoji** in section headers.
 
 ### Section Guidelines
 
 | Section | Purpose | Style |
 | ------- | ------- | ----- |
 | Required Actions | Post-deploy manual steps | Numbered steps with commands |
-| User-Facing Changes | What users will notice | Benefit-focused, one line each |
-| Technical Changes | Internal improvements | Brief, one line each with link |
-| Issues Resolved | Complete closure list | Sorted by issue number |
-| Summary | Quick overview | 1–2 sentences |
+| User-Facing Changes | What public visitors will notice | Benefit-focused, one line each; subsections New Features and Improvements only |
+| Admin-Facing Changes | What administrators will notice | Same format; keep separate from user-facing |
+| Issues Resolved | Complete closure list | Sorted by issue number, verbatim GH title |
 
 ### Release Requirements
 

--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -7,94 +7,27 @@
 
 None.
 
-## User-Facing Changes
+## Admin-Facing Changes
 
 ### Improvements
 
 - **Styled Confirmation Dialogs** ([#571](https://github.com/unibrain1/elanregistry/issues/571)):
-  Destructive admin actions (car merge, FIX scripts, schema maintenance) now use consistent
-  Bootstrap 5 confirmation modals instead of native browser confirm() dialogs.
+  Native browser `confirm()` dialogs replaced with Bootstrap 5 modals for destructive admin actions.
 - **Inline Validation Feedback** ([#572](https://github.com/unibrain1/elanregistry/issues/572)):
-  Admin form validation messages (car merge, API key, email settings, owner management) now
-  display as styled notifications instead of blocking browser alerts.
+  Admin validation messages now use styled notifications instead of blocking `alert()` dialogs.
 - **Consistent Error and Status Messaging** ([#573](https://github.com/unibrain1/elanregistry/issues/573)):
-  Remaining native browser dialogs replaced with application notification system; feature stubs
-  and error messages use consistent UI patterns.
-
-## Technical Changes
-
-- **Path boundary guard on unlink() calls** ([#634](https://github.com/unibrain1/elanregistry/issues/634)):
-  Added `realpath()` verification before all `unlink()` calls in backup and cache operations
-  to ensure deleted files are confirmed within their intended directory, resolving Semgrep
-  `php.lang.security.unlink-use.unlink-use` findings.
-
-- **confirm() → #confirmationModal** ([#571](https://github.com/unibrain1/elanregistry/issues/571)):
-  Car merge and schema maintenance confirm() calls converted to the shared Bootstrap
-  confirmationModal. `showConfirmDialog()` added to manage-consolidated.js (textContent-only,
-  XSS-safe). Modal HTML added to both admin pages; duplicate definition removed from
-  tab-system.php. Schema maintenance button now passes `this` explicitly instead of relying
-  on the global event object.
-- **alert() → showNotification()** ([#572](https://github.com/unibrain1/elanregistry/issues/572)):
-  Six alert() calls in admin tabs converted to showNotification() from manage-consolidated.js;
-  showNotification() hardened against XSS by escaping message before HTML interpolation.
-- **Remaining dialog cleanup** ([#573](https://github.com/unibrain1/elanregistry/issues/573)):
-  Three feature stub `alert()` calls in owner sidebar converted to `showNotification(..., 'info')`.
-  Native `prompt()` for backup reason replaced with a Bootstrap 5 input modal; `showInputDialog()`
-  helper added to `manage-consolidated.js` mirroring the `showConfirmDialog()` pattern.
-  `input-modal.php` created and included in `manage-maintenance.php`. Pre-existing stored XSS
-  risks in admin JS (car/owner data interpolated into `innerHTML` without escaping) resolved by
-  applying `escapeHtml()` consistently across `manage-consolidated.js` and `backup-operations.js`.
-  Backup button now passes `this` explicitly instead of relying on the implicit `event` global.
-  Three follow-up issues filed for unimplemented owner sidebar features (#786, #787, #788).
-- **Dependency update: datatables.net 1.10.23 → 1.13.11**
-  ([#775](https://github.com/unibrain1/elanregistry/pull/775)):
-  Bumps datatables.net and datatables.net-bs4 to 1.13.11 (security fix).
-
-- **Admin script infrastructure: fix/ and maintenance/ directories** ([#595](https://github.com/unibrain1/elanregistry/issues/595)):
-  Replaced the developer-facing `/FIX/` directory with `app/admin/scripts/fix/` (one-time
-  migrations) and `app/admin/scripts/maintenance/` (repeatable admin utilities). Both
-  directories are registered in `z_us_root.php`, protected by `.htaccess`, and surfaced in
-  `manage-maintenance.php` with a three-tab UI (Health, Maintenance, Configuration) featuring
-  risk-based color coding, batch script-run status queries, and hidden-by-default completed
-  migrations. Scripts 21 (Fix Page Permissions) and 24 (Regenerate Thumbnails) promoted to
-  the maintenance directory with CSRF protection and security hardening.
-
-- **Split manage-consolidated into car management and system maintenance** ([#610](https://github.com/unibrain1/elanregistry/issues/610)):
-  `manage-consolidated.php` now handles car/owner management (Admins and Editors);
-  new `manage-maintenance.php` handles system maintenance and settings tabs (Admin only).
-- **Enforced admin-only page access via UserSpice PageManager** ([#610](https://github.com/unibrain1/elanregistry/issues/610)):
-  Removed redundant `hasPerm([2])` from `backup-operations.php`; access control now
-  centralized in UserSpice pages table with role-based permissions; operational endpoints
-  use `isRegistryAdmin()` for additional validation.
-- **Log warning when getBaseUrl() falls back to hardcoded production URL** ([#641](https://github.com/unibrain1/elanregistry/issues/641)):
-  `getBaseUrl()` now logs an `EmailSettings` entry when `verify_url` is not configured
-  in email settings, making environment misconfiguration visible instead of silently
-  sending staging emails with production links.
+  Remaining native browser dialogs replaced with the app notification system.
+- **Backup health score caveat** ([#785](https://github.com/unibrain1/elanregistry/issues/785)):
+  "Estimated" badge shown next to backup health score when enhanced stats are unavailable.
 
 ## Issues Resolved
 
-- [#571](https://github.com/unibrain1/elanregistry/issues/571) —
-  Convert native confirm() dialogs to app modal for destructive actions
-- [#572](https://github.com/unibrain1/elanregistry/issues/572) —
-  Convert validation alert() dialogs to app notification system
-- [#573](https://github.com/unibrain1/elanregistry/issues/573) —
-  Convert remaining native dialogs and improve error messaging
-- [#595](https://github.com/unibrain1/elanregistry/issues/595) —
-  Promote FIX scripts to admin management tools; restructure into fix/ and maintenance/ directories
-- [#610](https://github.com/unibrain1/elanregistry/issues/610) —
-  Separate system maintenance functionality from car management; enforce admin-only access via PageManager
-- [#634](https://github.com/unibrain1/elanregistry/issues/634) —
-  Add path boundary guard to unlink() calls in backup operations
-- [#641](https://github.com/unibrain1/elanregistry/issues/641) —
-  Log warning when getBaseUrl() falls back to hardcoded production URL
-- [#775](https://github.com/unibrain1/elanregistry/pull/775) —
-  chore(deps): bump datatables.net and datatables.net-bs4
-
-## Summary
-
-7 issues and 1 dependency update resolved; replaces all native browser dialogs across the
-admin interface with Bootstrap 5 modals and the app notification system, refactors admin
-pages to separate system maintenance from car management with role-based access control,
-restructures developer FIX scripts into a proper admin maintenance UI, updates datatables.net
-to 1.13.11, hardens file deletion with path boundary guards, and improves environment
-misconfiguration visibility in email URL generation.
+- [#571](https://github.com/unibrain1/elanregistry/issues/571) — Convert native confirm() dialogs to app modal for destructive actions
+- [#572](https://github.com/unibrain1/elanregistry/issues/572) — Convert validation alert() dialogs to app notification system
+- [#573](https://github.com/unibrain1/elanregistry/issues/573) — Convert remaining native dialogs and improve error messaging
+- [#595](https://github.com/unibrain1/elanregistry/issues/595) — Promote active FIX scripts to admin management tools
+- [#610](https://github.com/unibrain1/elanregistry/issues/610) — security: audit admin endpoint permission checks for consistency
+- [#634](https://github.com/unibrain1/elanregistry/issues/634) — Add path boundary guard to unlink() calls in backup operations
+- [#641](https://github.com/unibrain1/elanregistry/issues/641) — improvement: getBaseUrl() silently falls back to production URL on database failure without logging
+- [#775](https://github.com/unibrain1/elanregistry/pull/775) — chore(deps): bump datatables.net and datatables.net-bs4
+- [#785](https://github.com/unibrain1/elanregistry/issues/785) — bug(admin): fabricated backup health score shown without caveat when enhanced stats fail


### PR DESCRIPTION
## Summary

- Adds `$backupStatsFallback` flag (initialized `false`, set `true` in catch block) to `tab-health.php` and `tab-maintenance.php`
- Renders a `text-bg-warning` "estimated" badge next to the backup health score in `tab-health.php` when the flag is true
- Updates release notes template: removes Technical Changes and Bug Fixes sections, adds Admin-Facing Changes section distinct from User-Facing Changes

## Test plan

- [ ] Verify happy path: health tab shows score with no badge when enhanced stats succeed
- [ ] Verify fallback path: "estimated" badge appears next to score when enhanced stats fail
- [ ] Confirm no PHP errors or warnings introduced

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)