### PR TITLE
chore(admin): remove unimplemented stub buttons from owner sidebar

### DIFF
--- a/app/admin/includes/load-owner-info.php
+++ b/app/admin/includes/load-owner-info.php
@@ -159,11 +159,6 @@ try {
                     <?php endif; ?>
                 </div>
 
-                <div class="mt-2">
-                    <button class="btn btn-sm btn-outline-info" onclick="viewOwnerCars(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag.taint-unsafe-echo-tag ?>)">
-                        <i class="fas fa-eye"></i> View All Cars
-                    </button>
-                </div>
             <?php else: ?>
                 <div class="text-muted text-center">
                     <i class="fas fa-car fa-2x mb-2"></i>
@@ -241,11 +236,6 @@ try {
 
     <script>
     // Quick action functions
-    function viewOwnerCars(ownerId) {
-        // See #786 — implement switchToOwnerManagementTab with car-mgmt filter
-        showNotification('Car management view will be available soon', 'info');
-    }
-
     function viewOwnerHistory(ownerId) {
         // See #787 — implement owner history view
         showNotification('Detailed history view will be available in a future update', 'info');

--- a/app/admin/includes/load-owner-info.php
+++ b/app/admin/includes/load-owner-info.php
@@ -199,13 +199,6 @@ try {
                     <?php endforeach; ?>
                 </div>
 
-                <?php if ($historyCount > 3): ?>
-                    <div class="mt-2">
-                        <button class="btn btn-sm btn-outline-secondary" onclick="viewOwnerHistory(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag.taint-unsafe-echo-tag ?>)">
-                            <i class="fas fa-history"></i> View Full History
-                        </button>
-                    </div>
-                <?php endif; ?>
             </div>
         </div>
     <?php endif; ?>
@@ -219,9 +212,6 @@ try {
         </div>
         <div class="card-body">
             <div class="d-grid gap-2">
-                <button class="btn btn-sm btn-outline-primary" onclick="contactOwner(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag.taint-unsafe-echo-tag ?>)">
-                    <i class="fas fa-envelope"></i> Send Email
-                </button>
                 <?php if ($carCount > 0): ?>
                     <button class="btn btn-sm btn-outline-success" onclick="syncLocationToCars(<?= $ownerId // nosemgrep: php.lang.security.taint-unsafe-echo-tag.taint-unsafe-echo-tag ?>)">
                         <i class="fas fa-sync"></i> Sync Location to Cars
@@ -234,18 +224,6 @@ try {
         </div>
     </div>
 
-    <script>
-    // Quick action functions
-    function viewOwnerHistory(ownerId) {
-        // See #787 — implement owner history view
-        showNotification('Detailed history view will be available in a future update', 'info');
-    }
-
-    function contactOwner(ownerId) {
-        // See #788 — wire to openAdminContactModal() with owner context
-        showNotification('Owner contact functionality will be integrated with the existing contact system', 'info');
-    }
-    </script>
 
     <?php
 

--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -21,8 +21,12 @@ None.
   "Estimated" badge shown next to backup health score when enhanced stats are unavailable.
 - **Removed unimplemented Owner Cleanup tab** ([#780](https://github.com/unibrain1/elanregistry/issues/780)):
   The Owner Cleanup tab has been removed from the Registry Management admin panel as it was never fully implemented.
-- **Removed stub 'View All Cars' button from owner sidebar** ([#786](https://github.com/unibrain1/elanregistry/issues/786)):
-  The 'View All Cars' button in the owner sidebar has been removed as the feature was not needed.
+- **Removed stub buttons from owner sidebar**
+  ([#786](https://github.com/unibrain1/elanregistry/issues/786),
+  [#787](https://github.com/unibrain1/elanregistry/issues/787),
+  [#788](https://github.com/unibrain1/elanregistry/issues/788)):
+  The unimplemented 'View All Cars', 'View Full History', and 'Send Email' buttons have been
+  removed from the owner sidebar.
 
 ## Issues Resolved
 
@@ -37,3 +41,5 @@ None.
 - [#785](https://github.com/unibrain1/elanregistry/issues/785) — bug(admin): fabricated backup health score shown without caveat when enhanced stats fail
 - [#780](https://github.com/unibrain1/elanregistry/issues/780) — tech-debt: remove unimplemented Owner Cleanup tab from admin panel
 - [#786](https://github.com/unibrain1/elanregistry/issues/786) — Remove stub 'View All Cars' button from owner sidebar
+- [#787](https://github.com/unibrain1/elanregistry/issues/787) — Remove stub 'View Full History' button from owner sidebar
+- [#788](https://github.com/unibrain1/elanregistry/issues/788) — Remove stub 'Send Email' button from owner sidebar

--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -21,6 +21,8 @@ None.
   "Estimated" badge shown next to backup health score when enhanced stats are unavailable.
 - **Removed unimplemented Owner Cleanup tab** ([#780](https://github.com/unibrain1/elanregistry/issues/780)):
   The Owner Cleanup tab has been removed from the Registry Management admin panel as it was never fully implemented.
+- **Removed stub 'View All Cars' button from owner sidebar** ([#786](https://github.com/unibrain1/elanregistry/issues/786)):
+  The 'View All Cars' button in the owner sidebar has been removed as the feature was not needed.
 
 ## Issues Resolved
 
@@ -34,3 +36,4 @@ None.
 - [#775](https://github.com/unibrain1/elanregistry/pull/775) — chore(deps): bump datatables.net and datatables.net-bs4
 - [#785](https://github.com/unibrain1/elanregistry/issues/785) — bug(admin): fabricated backup health score shown without caveat when enhanced stats fail
 - [#780](https://github.com/unibrain1/elanregistry/issues/780) — tech-debt: remove unimplemented Owner Cleanup tab from admin panel
+- [#786](https://github.com/unibrain1/elanregistry/issues/786) — Remove stub 'View All Cars' button from owner sidebar


### PR DESCRIPTION
## Summary

- Removes stub 'View All Cars' button and `viewOwnerCars()` function from owner sidebar
- Removes stub 'View Full History' button and `viewOwnerHistory()` function from owner sidebar
- Removes stub 'Send Email' button and `contactOwner()` function from owner sidebar
- Quick Actions card retains the two working buttons: Sync Location to Cars and UserSpice Admin

All three features were decided to be not needed; issues closed as "not planned".

## Issues

Closes #786
Closes #787
Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)