### PR TITLE
fix(permissions): fix user_settings.php classification and add admin-only tier

### DIFF
--- a/app/admin/scripts/maintenance/21-Fix-Page-Permissions.php
+++ b/app/admin/scripts/maintenance/21-Fix-Page-Permissions.php
@@ -10,13 +10,20 @@ declare(strict_types=1);
  *
  * PERMISSION ARCHITECTURE:
  * - PUBLIC pages (private = 0): No permission entries required, accessible to all users
- * - PRIVATE-ADMIN pages (private = 1): Must have Administrator (ID=2) and Editor (ID=3) permissions
+ * - PRIVATE-ADMIN-ONLY pages (private = 1): Must have Administrator (ID=2) permission only
+ * - PRIVATE-ADMIN+EDITOR pages (private = 1): Must have Administrator (ID=2) and Editor (ID=3) permissions
  * - PRIVATE-OWNER pages (private = 1): Must have User (ID=1) permission
  * - SPECIAL PRIVATE pages: PRIVATE with NO permissions (listed below)
  *
- * ADMIN-ONLY PAGES (will be set to private=1 with Admin+Editor permissions):
- * - app/admin/scripts/* - All admin maintenance scripts
- * - *admin* - Any path containing "admin" (includes app/admin/*, docs/admin/*, etc.)
+ * ADMIN-ONLY PAGES (will be set to private=1 with Administrator permission only):
+ * - app/admin/scripts/* - All admin maintenance & fix scripts
+ * - app/admin/manage-maintenance.php - Maintenance portal page
+ * - app/admin/includes/tab-health.php - Health tab include
+ * - app/admin/includes/tab-maintenance.php - Maintenance tab include
+ *
+ * ADMIN+EDITOR PAGES (will be set to private=1 with Admin+Editor permissions):
+ * - app/admin/* - All other admin pages (not in admin-only list above)
+ * - *admin* - Any other path containing "admin" (includes docs/admin/*, etc.)
  * - docs/*admin* - Admin documentation pages
  *
  * OWNER/USER PRIVATE PAGES (will be set to private=1 with User permission):
@@ -28,7 +35,6 @@ declare(strict_types=1);
  * SPECIAL CASE PRIVATE PAGES (will be set to private=1 with NO permissions):
  * - usersc/join.php - Registration page (public access, no permissions needed)
  * - usersc/login.php - Login page (public access, no permissions needed)
- * - usersc/user_settings.php - User settings page (no permissions set)
  *
  * PUBLIC PAGES (will be set to private=0 with no permissions):
  * - Everything else in app/* that doesn't match PRIVATE patterns
@@ -73,25 +79,26 @@ define('PERM_EDITOR', 3);
 /**
  * Check if a page should be PRIVATE with NO permissions (special case)
  */
-function shouldBePrivateNoPermissions($pagePath): bool {
+function shouldBePrivateNoPermissions(string $pagePath): bool {
     $specialPages = [
         'usersc/join.php',
-        'usersc/login.php',
-        'usersc/user_settings.php'
+        'usersc/login.php'
     ];
     return in_array($pagePath, $specialPages);
 }
 
 /**
- * Check if a page is ADMIN-ONLY (should have Admin+Editor permissions)
+ * Check if a page is an ADMIN page (should have at least Admin permission)
+ *
+ * Returns true for any page that should be restricted to admin-tier roles.
+ * Use shouldBeAdminOnly() to further distinguish between admin-only and
+ * admin+editor tiers.
  */
-function shouldHaveAdminPermissions($pagePath): bool {
-    // Admin scripts are admin-only
+function shouldHaveAdminPermissions(string $pagePath): bool {
     if (strpos($pagePath, 'app/admin/scripts/') === 0) {
         return true;
     }
 
-    // Any page containing "admin" is admin-only (includes docs/admin/*)
     if (strpos($pagePath, 'admin') !== false) {
         return true;
     }
@@ -100,9 +107,29 @@ function shouldHaveAdminPermissions($pagePath): bool {
 }
 
 /**
+ * Check if an admin page should be ADMIN-ONLY (Administrator permission only,
+ * no Editor permission). All other admin pages get Admin+Editor.
+ *
+ * @param  string $pagePath The page path to check
+ * @return bool   True if the page should be admin-only, false if admin+editor
+ */
+function shouldBeAdminOnly(string $pagePath): bool {
+    if (strpos($pagePath, 'app/admin/scripts/') === 0) {
+        return true;
+    }
+
+    $adminOnlyPages = [
+        'app/admin/manage-maintenance.php',
+        'app/admin/includes/tab-health.php',
+        'app/admin/includes/tab-maintenance.php',
+    ];
+    return in_array($pagePath, $adminOnlyPages);
+}
+
+/**
  * Determine if a page should be PRIVATE based on pattern matching
  */
-function shouldBePrivate($pagePath): bool {
+function shouldBePrivate(string $pagePath): bool {
     // Error pages (404.php, 403.php, etc.) in root should be PUBLIC
     if (preg_match('#^40\d\.php$#', $pagePath)) {
         return false;
@@ -144,11 +171,12 @@ function shouldBePrivate($pagePath): bool {
 function analyzePermissions($db): array {
     $issues = [
         'set_public' => [],                    // Pages that should be public but are private
-        'set_private_admin' => [],             // Pages that should be private-admin but are public
+        'set_private_admin' => [],             // Pages that should be private admin+editor but are public
         'set_private_user' => [],              // Pages that should be private-user but are public
         'set_private_no_perms' => [],          // Pages that should be private with NO permissions
         'remove_perms' => [],                  // Public pages that have permissions
-        'add_perms_admin' => [],               // Private-admin pages missing Admin+Editor permissions
+        'add_perms_admin' => [],               // Private admin+editor pages missing Admin+Editor permissions
+        'fix_admin_only_perms' => [],          // Admin-only pages with wrong perms (missing Admin or has Editor)
         'add_perms_user' => [],                // Private-user pages missing User permission
     ];
 
@@ -188,6 +216,14 @@ function analyzePermissions($db): array {
 
         $pageTitle = '';
 
+        // Guard: a page cannot be both special-no-perms and an admin page — that would
+        // strip the Administrator permission that protects it. Log and skip if this occurs.
+        if ($shouldBePrivateNoPermsFlag && $isAdminPage) {
+            logger($user->data()->id, LogCategories::LOG_CATEGORY_PERMISSION_FIX,
+                "CONFLICT: page is both special-no-perms and admin-tier — skipping: {$page->page}");
+            continue;
+        }
+
         // Handle special case: pages that should be PRIVATE with NO permissions
         if ($shouldBePrivateNoPermsFlag) {
             if ($page->private == 0 || $hasPerms) {
@@ -202,10 +238,21 @@ function analyzePermissions($db): array {
                 ];
             }
         } elseif ($shouldBePrivateFlag) {
-            if ($isAdminPage) {
-                // Page SHOULD be PRIVATE with Admin+Editor permissions
+            if ($isAdminPage && shouldBeAdminOnly($page->page)) {
+                // Must be private=1, Administrator only, no Editor
+                if (($page->private != 1) || !$hasAdmin || $hasEditor) {
+                    $issues['fix_admin_only_perms'][] = [
+                        'id' => $page->id,
+                        'page' => $page->page,
+                        'title' => $pageTitle,
+                        'current' => $page->private == 0 ? 'PUBLIC' : 'PRIVATE (' . ($page->perm_names ?: 'no permissions') . ')',
+                        'required' => 'PRIVATE with Administrator only',
+                        'action' => 'SET TO PRIVATE, ADD Administrator, REMOVE Editor'
+                    ];
+                }
+            } elseif ($isAdminPage) {
+                // Must be private=1 with Admin+Editor
                 if ($page->private == 0) {
-                    // Currently public, but should be private
                     $issues['set_private_admin'][] = [
                         'id' => $page->id,
                         'page' => $page->page,
@@ -215,7 +262,6 @@ function analyzePermissions($db): array {
                         'action' => 'SET TO PRIVATE, ADD Administrator, Editor'
                     ];
                 } elseif (!$hasAdmin || !$hasEditor) {
-                    // Already private, but missing permissions
                     $issues['add_perms_admin'][] = [
                         'id' => $page->id,
                         'page' => $page->page,
@@ -306,7 +352,7 @@ if ($method === 'POST' && isset($_POST['action'])) {
             $totalIssues = count($issues['set_public']) + count($issues['set_private_admin']) +
                           count($issues['set_private_user']) + count($issues['set_private_no_perms']) +
                           count($issues['remove_perms']) + count($issues['add_perms_admin']) +
-                          count($issues['add_perms_user']);
+                          count($issues['add_perms_user']) + count($issues['fix_admin_only_perms']);
 
             logger($user->data()->id, LogCategories::LOG_CATEGORY_PERMISSION_FIX, "Analysis completed, found {$totalIssues} issues");
 
@@ -320,7 +366,8 @@ if ($method === 'POST' && isset($_POST['action'])) {
                     'set_private_no_perms' => count($issues['set_private_no_perms']),
                     'remove_perms' => count($issues['remove_perms']),
                     'add_perms_admin' => count($issues['add_perms_admin']),
-                    'add_perms_user' => count($issues['add_perms_user'])
+                    'add_perms_user' => count($issues['add_perms_user']),
+                    'fix_admin_only_perms' => count($issues['fix_admin_only_perms'])
                 ],
                 'issues' => $issues
             ]);
@@ -436,22 +483,37 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                                 <ul class="mb-0">
                                     <li>Sets pages as PUBLIC (private=0) by default with no permissions</li>
                                     <li>Marks pages as PRIVATE (private=1) based on pattern matching</li>
-                                    <li>Ensures PRIVATE pages have Administrator and Editor permissions</li>
+                                    <li>Assigns role-based permissions to PRIVATE pages (admin-only, admin+editor, or owner)</li>
                                     <li>Removes all permissions from PUBLIC pages</li>
                                     <li>Creates automatic backup before making any changes</li>
                                 </ul>
                             </div>
 
                             <div class="alert alert-warning">
-                                <h5><i class="fa fa-exclamation-triangle"></i> PRIVATE Page Patterns (will be private=1 with Admin+Editor):</h5>
-                                <ul class="mb-0">
-                                    <li><strong>app/admin/scripts/*</strong> - All admin maintenance scripts</li>
-                                    <li><strong>app/admin/*</strong> - All admin pages</li>
-                                    <li><strong>*admin*</strong> - Any path containing "admin"</li>
+                                <h5><i class="fa fa-exclamation-triangle"></i> PRIVATE Page Patterns:</h5>
+                                <p class="mb-2"><strong>Admin-Only (private=1, Administrator permission only):</strong></p>
+                                <ul>
+                                    <li><strong>app/admin/scripts/*</strong> - All admin fix &amp; maintenance scripts</li>
+                                    <li><strong>app/admin/manage-maintenance.php</strong> - Maintenance portal</li>
+                                    <li><strong>app/admin/includes/tab-health.php</strong> - Health tab include</li>
+                                    <li><strong>app/admin/includes/tab-maintenance.php</strong> - Maintenance tab include</li>
+                                </ul>
+                                <p class="mb-2"><strong>Admin + Editor (private=1, Administrator + Editor permissions):</strong></p>
+                                <ul>
+                                    <li><strong>app/admin/*</strong> - All other admin pages</li>
+                                    <li><strong>*admin*</strong> - Any other path containing "admin"</li>
+                                </ul>
+                                <p class="mb-2"><strong>Owner (private=1, User permission):</strong></p>
+                                <ul>
                                     <li><strong>app/cars/actions*</strong> - All car action endpoints</li>
                                     <li><strong>app/contact/*</strong> - All contact form pages</li>
                                     <li><strong>*edit*</strong> - Any path containing "edit"</li>
                                     <li><strong>usersc/*</strong> - All UserSpice customization pages</li>
+                                </ul>
+                                <p class="mb-2"><strong>Special Case (private=1, no permissions):</strong></p>
+                                <ul class="mb-0">
+                                    <li><strong>usersc/join.php</strong> - Registration page</li>
+                                    <li><strong>usersc/login.php</strong> - Login page</li>
                                 </ul>
                             </div>
 
@@ -699,11 +761,12 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                                     <p>Found <strong>${data.totalIssues}</strong> permission issues that need to be fixed:</p>
                                     <ul>
                                         ${data.counts.set_public > 0 ? `<li>${data.counts.set_public} pages are PRIVATE but should be PUBLIC</li>` : ''}
-                                        ${data.counts.set_private_admin > 0 ? `<li>${data.counts.set_private_admin} pages are PUBLIC but should be PRIVATE (admin)</li>` : ''}
+                                        ${data.counts.set_private_admin > 0 ? `<li>${data.counts.set_private_admin} pages are PUBLIC but should be PRIVATE (admin+editor)</li>` : ''}
                                         ${data.counts.set_private_user > 0 ? `<li>${data.counts.set_private_user} pages are PUBLIC but should be PRIVATE (owner)</li>` : ''}
                                         ${data.counts.set_private_no_perms > 0 ? `<li>${data.counts.set_private_no_perms} pages should be PRIVATE with no permissions</li>` : ''}
                                         ${data.counts.remove_perms > 0 ? `<li>${data.counts.remove_perms} PUBLIC pages have permissions to remove</li>` : ''}
-                                        ${data.counts.add_perms_admin > 0 ? `<li>${data.counts.add_perms_admin} PRIVATE (admin) pages need Administrator + Editor permissions</li>` : ''}
+                                        ${data.counts.add_perms_admin > 0 ? `<li>${data.counts.add_perms_admin} PRIVATE (admin+editor) pages need Administrator + Editor permissions</li>` : ''}
+                                        ${data.counts.fix_admin_only_perms > 0 ? `<li>${data.counts.fix_admin_only_perms} pages need to be fixed to PRIVATE with Administrator only (admin-only)</li>` : ''}
                                         ${data.counts.add_perms_user > 0 ? `<li>${data.counts.add_perms_user} PRIVATE (owner) pages need User permission</li>` : ''}
                                     </ul>
                                 </div>
@@ -728,11 +791,21 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                                 listHTML += '</div></div>';
                             }
 
-                            // Set pages to private (admin)
+                            // Set pages to private (admin+editor)
                             if (data.issues.set_private_admin && data.issues.set_private_admin.length > 0) {
-                                listHTML += `<div class="mt-4"><h6 class="text-danger">⚠️ Set to Private - Admin (${data.issues.set_private_admin.length}): PUBLIC but should be PRIVATE</h6>`;
+                                listHTML += `<div class="mt-4"><h6 class="text-danger">⚠️ Set to Private - Admin+Editor (${data.issues.set_private_admin.length}): PUBLIC but should be PRIVATE</h6>`;
                                 listHTML += '<div style="background-color: #f8f9fa; padding: 10px; border-radius: 4px; font-size: 0.85rem;">';
                                 data.issues.set_private_admin.forEach(issue => {
+                                    listHTML += formatPageItem(issue);
+                                });
+                                listHTML += '</div></div>';
+                            }
+
+                            // Fix admin-only permissions (admin scripts, maintenance portal, etc.)
+                            if (data.issues.fix_admin_only_perms && data.issues.fix_admin_only_perms.length > 0) {
+                                listHTML += `<div class="mt-4"><h6 class="text-danger">⚠️ Fix Admin-Only Permissions (${data.issues.fix_admin_only_perms.length}): should be PRIVATE with Administrator only</h6>`;
+                                listHTML += '<div style="background-color: #f8f9fa; padding: 10px; border-radius: 4px; font-size: 0.85rem;">';
+                                data.issues.fix_admin_only_perms.forEach(issue => {
                                     listHTML += formatPageItem(issue);
                                 });
                                 listHTML += '</div></div>';
@@ -768,9 +841,9 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                                 listHTML += '</div></div>';
                             }
 
-                            // Add permissions (admin)
+                            // Add permissions (admin+editor)
                             if (data.issues.add_perms_admin && data.issues.add_perms_admin.length > 0) {
-                                listHTML += `<div class="mt-4"><h6 class="text-primary">ℹ️ Add Admin Permissions (${data.issues.add_perms_admin.length}): need Administrator + Editor</h6>`;
+                                listHTML += `<div class="mt-4"><h6 class="text-primary">ℹ️ Add Admin+Editor Permissions (${data.issues.add_perms_admin.length}): need Administrator + Editor</h6>`;
                                 listHTML += '<div style="background-color: #f8f9fa; padding: 10px; border-radius: 4px; font-size: 0.85rem;">';
                                 data.issues.add_perms_admin.forEach(issue => {
                                     listHTML += formatPageItem(issue);
@@ -847,12 +920,22 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                             }
                         };
 
-                        // Set pages to private (admin)
+                        // Set pages to private (admin+editor)
                         if (data.issues.set_private_admin && data.issues.set_private_admin.length > 0) {
-                            detailsHTML += `<h6 class="text-danger">⚠️ Set to Private - Admin (${data.issues.set_private_admin.length} pages):</h6>`;
+                            detailsHTML += `<h6 class="text-danger">⚠️ Set to Private - Admin+Editor (${data.issues.set_private_admin.length} pages):</h6>`;
                             detailsHTML += '<table class="table table-sm table-bordered permission-table mb-4"><thead><tr><th>Page</th><th>Current</th><th>Will Be</th></tr></thead><tbody>';
                             data.issues.set_private_admin.forEach(issue => {
                                 detailsHTML += `<tr><td>${formatPageName(issue)}</td><td><span class="badge text-bg-danger">PUBLIC</span></td><td><span class="badge text-bg-primary">PRIVATE - Administrator, Editor</span></td></tr>`;
+                            });
+                            detailsHTML += '</tbody></table>';
+                        }
+
+                        // Fix admin-only permissions (admin scripts, maintenance portal, etc.)
+                        if (data.issues.fix_admin_only_perms && data.issues.fix_admin_only_perms.length > 0) {
+                            detailsHTML += `<h6 class="text-danger">⚠️ Fix Admin-Only Permissions (${data.issues.fix_admin_only_perms.length} pages):</h6>`;
+                            detailsHTML += '<table class="table table-sm table-bordered permission-table mb-4"><thead><tr><th>Page</th><th>Current</th><th>Will Be</th></tr></thead><tbody>';
+                            data.issues.fix_admin_only_perms.forEach(issue => {
+                                detailsHTML += `<tr><td>${formatPageName(issue)}</td><td><span class="badge text-bg-secondary">${escapeHtml(issue.current)}</span></td><td><span class="badge text-bg-primary">PRIVATE - Administrator only</span></td></tr>`;
                             });
                             detailsHTML += '</tbody></table>';
                         }
@@ -887,9 +970,9 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                             detailsHTML += '</tbody></table>';
                         }
 
-                        // Add permissions (admin)
+                        // Add permissions (admin+editor)
                         if (data.issues.add_perms_admin && data.issues.add_perms_admin.length > 0) {
-                            detailsHTML += `<h6 class="text-primary">ℹ️ Add Admin Permissions (${data.issues.add_perms_admin.length} pages):</h6>`;
+                            detailsHTML += `<h6 class="text-primary">ℹ️ Add Admin+Editor Permissions (${data.issues.add_perms_admin.length} pages):</h6>`;
                             detailsHTML += '<table class="table table-sm table-bordered permission-table mb-4"><thead><tr><th>Page</th><th>Current</th><th>Will Add</th></tr></thead><tbody>';
                             data.issues.add_perms_admin.forEach(issue => {
                                 detailsHTML += `<tr><td>${formatPageName(issue)}</td><td><span class="badge text-bg-secondary">${escapeHtml(issue.current)}</span></td><td><span class="badge text-bg-primary">${escapeHtml(issue.missing)}</span></td></tr>`;
@@ -1022,7 +1105,7 @@ function abortProcess() {
                 $totalChanges = count($issues['set_public']) + count($issues['set_private_admin']) +
                                count($issues['set_private_user']) + count($issues['set_private_no_perms']) +
                                count($issues['remove_perms']) + count($issues['add_perms_admin']) +
-                               count($issues['add_perms_user']);
+                               count($issues['add_perms_user']) + count($issues['fix_admin_only_perms']);
 
                 outputMessage("Found {$totalChanges} changes to make");
                 outputMessage("");
@@ -1180,10 +1263,10 @@ function abortProcess() {
                         }
                     }
 
-                    // Add permissions (admin) to private pages
+                    // Add permissions (admin+editor) to private pages
                     if (!empty($issues['add_perms_admin'])) {
                         outputMessage("");
-                        outputMessage("=== Adding Admin Permissions to Private Pages ===");
+                        outputMessage("=== Adding Admin+Editor Permissions to Private Pages ===");
                         foreach ($issues['add_perms_admin'] as $issue) {
                             $global_attempts++;
                             $currentChange++;
@@ -1215,6 +1298,43 @@ function abortProcess() {
                                 logger($user->data()->id, LogCategories::LOG_CATEGORY_PERMISSION_FIX, "Added admin permissions to page: {$issue['page']} (ID: {$issue['id']})");
                             } catch (Exception $e) {
                                 outputMessage("✗ Failed to update {$issue['page']}: " . $e->getMessage(), $percentage);
+                            }
+                        }
+                    }
+
+                    // Fix admin-only permissions (set private=1, add Admin if missing, remove Editor)
+                    if (!empty($issues['fix_admin_only_perms'])) {
+                        outputMessage("");
+                        outputMessage("=== Setting Pages to Private - Admin Only ===");
+                        foreach ($issues['fix_admin_only_perms'] as $issue) {
+                            $global_attempts++;
+                            $currentChange++;
+                            $percentage = round(($currentChange / $totalChanges) * 100);
+
+                            try {
+                                // Set page to private
+                                $db->update('pages', $issue['id'], ['private' => 1]);
+
+                                // Add Administrator permission if not exists
+                                $existingAdmin = $db->query("SELECT id FROM permission_page_matches WHERE page_id = ? AND permission_id = ?",
+                                    [$issue['id'], PERM_ADMIN])->count();
+                                if ($existingAdmin == 0) {
+                                    $db->insert('permission_page_matches', [
+                                        'permission_id' => PERM_ADMIN,
+                                        'page_id' => $issue['id']
+                                    ]);
+                                }
+
+                                // Remove Editor permission if present
+                                $db->query("DELETE FROM permission_page_matches WHERE page_id = ? AND permission_id = ?",
+                                    [$issue['id'], PERM_EDITOR]);
+
+                                $global_successes++;
+                                outputMessage("✅ Set to PRIVATE with Administrator only (no Editor): {$issue['page']}", $percentage);
+                                logger($user->data()->id, LogCategories::LOG_CATEGORY_PERMISSION_FIX, "Set page to PRIVATE with Admin only (no Editor): {$issue['page']} (ID: {$issue['id']})");
+                            } catch (Exception $e) {
+                                outputMessage("✗ Failed to update {$issue['page']}: " . $e->getMessage(), $percentage);
+                                logger($user->data()->id, LogCategories::LOG_CATEGORY_PERMISSION_FIX_ERROR, "Failed to set page to PRIVATE with Admin only (no Editor): {$issue['page']} (ID: {$issue['id']}) - " . $e->getMessage());
                             }
                         }
                     }
@@ -1258,7 +1378,7 @@ function abortProcess() {
                             $remainingIssues = count($issuesAfter['set_public']) + count($issuesAfter['set_private_admin']) +
                                               count($issuesAfter['set_private_user']) + count($issuesAfter['set_private_no_perms']) +
                                               count($issuesAfter['remove_perms']) + count($issuesAfter['add_perms_admin']) +
-                                              count($issuesAfter['add_perms_user']);
+                                              count($issuesAfter['add_perms_user']) + count($issuesAfter['fix_admin_only_perms']);
 
                             if ($remainingIssues == 0) {
                                 outputMessage("✅ SUCCESS: All permissions fixed correctly!");

--- a/app/admin/scripts/maintenance/21-Fix-Page-Permissions.php
+++ b/app/admin/scripts/maintenance/21-Fix-Page-Permissions.php
@@ -76,93 +76,24 @@ define('PERM_USER', 1);
 define('PERM_ADMIN', 2);
 define('PERM_EDITOR', 3);
 
-/**
- * Check if a page should be PRIVATE with NO permissions (special case)
- */
+/** @see PagePermissionClassifier::shouldBePrivateNoPermissions() */
 function shouldBePrivateNoPermissions(string $pagePath): bool {
-    $specialPages = [
-        'usersc/join.php',
-        'usersc/login.php'
-    ];
-    return in_array($pagePath, $specialPages);
+    return PagePermissionClassifier::shouldBePrivateNoPermissions($pagePath);
 }
 
-/**
- * Check if a page is an ADMIN page (should have at least Admin permission)
- *
- * Returns true for any page that should be restricted to admin-tier roles.
- * Use shouldBeAdminOnly() to further distinguish between admin-only and
- * admin+editor tiers.
- */
+/** @see PagePermissionClassifier::shouldHaveAdminPermissions() */
 function shouldHaveAdminPermissions(string $pagePath): bool {
-    if (strpos($pagePath, 'app/admin/scripts/') === 0) {
-        return true;
-    }
-
-    if (strpos($pagePath, 'admin') !== false) {
-        return true;
-    }
-
-    return false;
+    return PagePermissionClassifier::shouldHaveAdminPermissions($pagePath);
 }
 
-/**
- * Check if an admin page should be ADMIN-ONLY (Administrator permission only,
- * no Editor permission). All other admin pages get Admin+Editor.
- *
- * @param  string $pagePath The page path to check
- * @return bool   True if the page should be admin-only, false if admin+editor
- */
+/** @see PagePermissionClassifier::shouldBeAdminOnly() */
 function shouldBeAdminOnly(string $pagePath): bool {
-    if (strpos($pagePath, 'app/admin/scripts/') === 0) {
-        return true;
-    }
-
-    $adminOnlyPages = [
-        'app/admin/manage-maintenance.php',
-        'app/admin/includes/tab-health.php',
-        'app/admin/includes/tab-maintenance.php',
-    ];
-    return in_array($pagePath, $adminOnlyPages);
+    return PagePermissionClassifier::shouldBeAdminOnly($pagePath);
 }
 
-/**
- * Determine if a page should be PRIVATE based on pattern matching
- */
+/** @see PagePermissionClassifier::shouldBePrivate() */
 function shouldBePrivate(string $pagePath): bool {
-    // Error pages (404.php, 403.php, etc.) in root should be PUBLIC
-    if (preg_match('#^40\d\.php$#', $pagePath)) {
-        return false;
-    }
-
-    // docs/* pages should generally be PUBLIC
-    // EXCEPT docs/admin/* (and any path containing "admin") which should be PRIVATE-ADMIN
-    if (strpos($pagePath, 'docs/') === 0) {
-        // docs/*admin* should be PRIVATE
-        if (strpos($pagePath, 'admin') !== false) {
-            return true;
-        }
-        // Other docs pages should be PUBLIC
-        return false;
-    }
-
-    $patterns = [
-        '#^app/admin/scripts/#',             // app/admin/scripts/* maintenance & fix scripts
-        '#^app/admin/#',                     // app/admin/* pages
-        '#admin#',                           // Any path containing "admin"
-        '#^app/cars/actions#',               // app/cars/actions* endpoints
-        '#^app/contact/#',                   // app/contact/* pages
-        '#edit#',                            // Any path containing "edit"
-        '#^usersc/#'                         // usersc/* pages
-    ];
-
-    foreach ($patterns as $pattern) {
-        if (preg_match($pattern, $pagePath)) {
-            return true;
-        }
-    }
-
-    return false;
+    return PagePermissionClassifier::shouldBePrivate($pagePath);
 }
 
 /**

--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -9,6 +9,18 @@ None.
 
 ## Admin-Facing Changes
 
+### Bug Fixes
+
+- **Fix Page Permissions: user_settings.php access restored** ([#795](https://github.com/unibrain1/elanregistry/issues/795)):
+  `usersc/user_settings.php` was incorrectly classified as a special-case private page with no
+  permissions, making it inaccessible to all roles. It is now correctly classified as a
+  private owner page (requires User permission), consistent with all other `usersc/*` pages.
+- **Fix Page Permissions: maintenance portal restricted to Administrators** ([#797](https://github.com/unibrain1/elanregistry/issues/797)):
+  The Fix Page Permissions maintenance script now distinguishes between two admin permission
+  tiers. Maintenance portal pages (`manage-maintenance.php`, scripts under
+  `app/admin/scripts/`) are set to Administrator-only access. The main admin panel
+  (`manage-consolidated.php` and its tabs) retains Administrator + Editor access.
+
 ### Improvements
 
 - **Styled Confirmation Dialogs** ([#571](https://github.com/unibrain1/elanregistry/issues/571)):
@@ -53,3 +65,5 @@ None.
 - [#786](https://github.com/unibrain1/elanregistry/issues/786) — Remove stub 'View All Cars' button from owner sidebar
 - [#787](https://github.com/unibrain1/elanregistry/issues/787) — Remove stub 'View Full History' button from owner sidebar
 - [#788](https://github.com/unibrain1/elanregistry/issues/788) — Remove stub 'Send Email' button from owner sidebar
+- [#795](https://github.com/unibrain1/elanregistry/issues/795) — bug: usersc/user_settings.php incorrectly classified as special-case (no permissions)
+- [#797](https://github.com/unibrain1/elanregistry/issues/797) — bug: maintenance portal pages not restricted to Administrator-only access

--- a/tests/unit/admin/PagePermissionClassifierTest.php
+++ b/tests/unit/admin/PagePermissionClassifierTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Unit tests for PagePermissionClassifier
+ *
+ * Covers the four classification methods that determine which permission tier
+ * a page path belongs to. These classifications control the Fix Page Permissions
+ * maintenance script (issues #795 and #797).
+ */
+#[Group('fast')]
+#[Group('unit')]
+#[Group('admin')]
+final class PagePermissionClassifierTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // shouldBePrivateNoPermissions
+    // -------------------------------------------------------------------------
+
+    /** @return array<string, array{string, bool}> */
+    public static function specialNoPermsProvider(): array
+    {
+        return [
+            'join page'                        => ['usersc/join.php',          true],
+            'login page'                       => ['usersc/login.php',         true],
+            // #795: user_settings must NOT be in this list
+            'user_settings is not special'     => ['usersc/user_settings.php', false],
+            'other usersc page'                => ['usersc/profile.php',       false],
+            'admin page'                       => ['app/admin/manage.php',     false],
+            'public car listing'               => ['app/cars/index.php',       false],
+        ];
+    }
+
+    #[DataProvider('specialNoPermsProvider')]
+    public function testShouldBePrivateNoPermissions(string $path, bool $expected): void
+    {
+        $this->assertSame($expected, PagePermissionClassifier::shouldBePrivateNoPermissions($path));
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldHaveAdminPermissions
+    // -------------------------------------------------------------------------
+
+    /** @return array<string, array{string, bool}> */
+    public static function adminPermissionsProvider(): array
+    {
+        return [
+            'admin scripts prefix'              => ['app/admin/scripts/maintenance/21-Fix-Page-Permissions.php', true],
+            'admin scripts fix'                 => ['app/admin/scripts/fix/01-something.php',                   true],
+            'admin manage page'                 => ['app/admin/manage-consolidated.php',                        true],
+            'admin maintenance page'            => ['app/admin/manage-maintenance.php',                         true],
+            'docs admin'                        => ['docs/admin/guide.php',                                     true],
+            'user settings (owner page)'        => ['usersc/user_settings.php',                                 false],
+            'car listing (public)'              => ['app/cars/index.php',                                       false],
+            'car actions (owner)'               => ['app/cars/actions/save.php',                                false],
+            'contact form (owner)'              => ['app/contact/form.php',                                     false],
+            'error page'                        => ['404.php',                                                  false],
+        ];
+    }
+
+    #[DataProvider('adminPermissionsProvider')]
+    public function testShouldHaveAdminPermissions(string $path, bool $expected): void
+    {
+        $this->assertSame($expected, PagePermissionClassifier::shouldHaveAdminPermissions($path));
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldBeAdminOnly
+    // -------------------------------------------------------------------------
+
+    /** @return array<string, array{string, bool}> */
+    public static function adminOnlyProvider(): array
+    {
+        return [
+            // Admin-only: scripts directory
+            'maintenance script'                => ['app/admin/scripts/maintenance/21-Fix-Page-Permissions.php', true],
+            'fix script'                        => ['app/admin/scripts/fix/01-something.php',                   true],
+            'scripts root'                      => ['app/admin/scripts/index.php',                              true],
+            // Admin-only: maintenance portal pages
+            'manage-maintenance'                => ['app/admin/manage-maintenance.php',                         true],
+            'tab-health'                        => ['app/admin/includes/tab-health.php',                        true],
+            'tab-maintenance'                   => ['app/admin/includes/tab-maintenance.php',                   true],
+            // Admin+Editor: general admin panel
+            'manage-consolidated'               => ['app/admin/manage-consolidated.php',                        false],
+            'tab-cars'                          => ['app/admin/includes/tab-cars.php',                          false],
+            'docs admin'                        => ['docs/admin/guide.php',                                     false],
+            'non-admin page'                    => ['app/cars/index.php',                                       false],
+        ];
+    }
+
+    #[DataProvider('adminOnlyProvider')]
+    public function testShouldBeAdminOnly(string $path, bool $expected): void
+    {
+        $this->assertSame($expected, PagePermissionClassifier::shouldBeAdminOnly($path));
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldBePrivate
+    // -------------------------------------------------------------------------
+
+    /** @return array<string, array{string, bool}> */
+    public static function privateProvider(): array
+    {
+        return [
+            // Admin pages are private
+            'admin page'                        => ['app/admin/manage-consolidated.php',  true],
+            'admin script'                      => ['app/admin/scripts/maintenance/21-Fix-Page-Permissions.php', true],
+            'docs admin'                        => ['docs/admin/guide.php',               true],
+            // Owner pages are private
+            'car action'                        => ['app/cars/actions/save.php',          true],
+            'contact page'                      => ['app/contact/form.php',               true],
+            'edit page'                         => ['app/cars/edit-car.php',              true],
+            'usersc page'                       => ['usersc/user_settings.php',           true],
+            'login page'                        => ['usersc/login.php',                   true],
+            'join page'                         => ['usersc/join.php',                    true],
+            // Public pages
+            'car listing'                       => ['app/cars/index.php',                 false],
+            'car details'                       => ['app/cars/details.php',               false],
+            'statistics'                        => ['app/reports/statistics.php',         false],
+            'docs guide'                        => ['docs/guides/how-to.php',             false],
+            'error 404'                         => ['404.php',                            false],
+            'error 403'                         => ['403.php',                            false],
+        ];
+    }
+
+    #[DataProvider('privateProvider')]
+    public function testShouldBePrivate(string $path, bool $expected): void
+    {
+        $this->assertSame($expected, PagePermissionClassifier::shouldBePrivate($path));
+    }
+
+    // -------------------------------------------------------------------------
+    // Invariant: no special-no-perms page is also an admin page
+    // (the conflict guard in analyzePermissions() relies on this never occurring
+    // with valid configuration)
+    // -------------------------------------------------------------------------
+
+    public function testNoSpecialNoPermsPageIsAlsoAdminPage(): void
+    {
+        $specialPages = ['usersc/join.php', 'usersc/login.php'];
+
+        foreach ($specialPages as $page) {
+            $this->assertFalse(
+                PagePermissionClassifier::shouldHaveAdminPermissions($page),
+                "Page '{$page}' is in shouldBePrivateNoPermissions but also matches shouldHaveAdminPermissions — this would cause the conflict guard to skip it"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // #795 regression: user_settings.php must follow the owner tier
+    // -------------------------------------------------------------------------
+
+    public function testUserSettingsFollowsOwnerTier(): void
+    {
+        $path = 'usersc/user_settings.php';
+
+        $this->assertFalse(
+            PagePermissionClassifier::shouldBePrivateNoPermissions($path),
+            'user_settings.php must NOT be a special-no-perms page (issue #795)'
+        );
+        $this->assertFalse(
+            PagePermissionClassifier::shouldHaveAdminPermissions($path),
+            'user_settings.php must NOT be an admin page'
+        );
+        $this->assertTrue(
+            PagePermissionClassifier::shouldBePrivate($path),
+            'user_settings.php must be private (usersc/* pattern)'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // #797 regression: maintenance portal pages must be admin-only
+    // -------------------------------------------------------------------------
+
+    public function testMaintenancePortalPagesAreAdminOnly(): void
+    {
+        $maintenancePages = [
+            'app/admin/manage-maintenance.php',
+            'app/admin/includes/tab-health.php',
+            'app/admin/includes/tab-maintenance.php',
+        ];
+
+        foreach ($maintenancePages as $page) {
+            $this->assertTrue(
+                PagePermissionClassifier::shouldHaveAdminPermissions($page),
+                "'{$page}' must be an admin page (issue #797)"
+            );
+            $this->assertTrue(
+                PagePermissionClassifier::shouldBeAdminOnly($page),
+                "'{$page}' must be admin-only, not admin+editor (issue #797)"
+            );
+        }
+    }
+
+    public function testAdminScriptsAreAdminOnly(): void
+    {
+        $scriptPaths = [
+            'app/admin/scripts/maintenance/21-Fix-Page-Permissions.php',
+            'app/admin/scripts/fix/01-something.php',
+        ];
+
+        foreach ($scriptPaths as $page) {
+            $this->assertTrue(
+                PagePermissionClassifier::shouldBeAdminOnly($page),
+                "Admin script '{$page}' must be admin-only (issue #797)"
+            );
+        }
+    }
+
+    public function testGeneralAdminPagesAreNotAdminOnly(): void
+    {
+        $adminEditorPages = [
+            'app/admin/manage-consolidated.php',
+            'app/admin/includes/tab-cars.php',
+            'docs/admin/guide.php',
+        ];
+
+        foreach ($adminEditorPages as $page) {
+            $this->assertTrue(
+                PagePermissionClassifier::shouldHaveAdminPermissions($page),
+                "'{$page}' must require admin permission"
+            );
+            $this->assertFalse(
+                PagePermissionClassifier::shouldBeAdminOnly($page),
+                "'{$page}' must be admin+editor (not admin-only)"
+            );
+        }
+    }
+}

--- a/usersc/classes/admin/PagePermissionClassifier.php
+++ b/usersc/classes/admin/PagePermissionClassifier.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PagePermissionClassifier
+ *
+ * Pure classification logic for the Fix Page Permissions maintenance script.
+ * Determines which permission tier each page path belongs to based on pattern
+ * matching against the application's page structure.
+ *
+ * Permission tiers (in priority order):
+ * - Special-no-perms: PRIVATE with no permission entries (login, join)
+ * - Admin-only: PRIVATE with Administrator only (maintenance scripts, portal)
+ * - Admin+Editor: PRIVATE with Administrator + Editor (general admin panel)
+ * - Owner: PRIVATE with User permission (usersc/*, edit pages, car actions)
+ * - Public: private=0, no permissions (everything else)
+ */
+class PagePermissionClassifier
+{
+    /**
+     * Pages that should be PRIVATE with NO permissions (special case).
+     * These are pages that must be accessible without a permission check
+     * (e.g. the login page itself), but should not be publicly indexed.
+     */
+    private const SPECIAL_NO_PERMS_PAGES = [
+        'usersc/join.php',
+        'usersc/login.php',
+    ];
+
+    /**
+     * Pages within the admin hierarchy that should be restricted to
+     * Administrator only (no Editor access).
+     */
+    private const ADMIN_ONLY_PAGES = [
+        'app/admin/manage-maintenance.php',
+        'app/admin/includes/tab-health.php',
+        'app/admin/includes/tab-maintenance.php',
+    ];
+
+    /**
+     * Check if a page should be PRIVATE with NO permissions (special case).
+     */
+    public static function shouldBePrivateNoPermissions(string $pagePath): bool
+    {
+        return in_array($pagePath, self::SPECIAL_NO_PERMS_PAGES);
+    }
+
+    /**
+     * Check if a page is an ADMIN page (should have at least Admin permission).
+     *
+     * Returns true for any page that should be restricted to admin-tier roles.
+     * Use shouldBeAdminOnly() to further distinguish between admin-only and
+     * admin+editor tiers.
+     */
+    public static function shouldHaveAdminPermissions(string $pagePath): bool
+    {
+        if (strpos($pagePath, 'app/admin/scripts/') === 0) {
+            return true;
+        }
+
+        if (strpos($pagePath, 'admin') !== false) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if an admin page should be ADMIN-ONLY (Administrator permission only,
+     * no Editor permission). All other admin pages get Admin+Editor.
+     *
+     * @param  string $pagePath The page path to check
+     * @return bool   True if the page should be admin-only, false if admin+editor
+     */
+    public static function shouldBeAdminOnly(string $pagePath): bool
+    {
+        if (strpos($pagePath, 'app/admin/scripts/') === 0) {
+            return true;
+        }
+
+        return in_array($pagePath, self::ADMIN_ONLY_PAGES);
+    }
+
+    /**
+     * Determine if a page should be PRIVATE based on pattern matching.
+     */
+    public static function shouldBePrivate(string $pagePath): bool
+    {
+        // Error pages (404.php, 403.php, etc.) in root should be PUBLIC
+        if (preg_match('#^40\d\.php$#', $pagePath)) {
+            return false;
+        }
+
+        // docs/* pages should generally be PUBLIC
+        // EXCEPT docs/admin/* (and any path containing "admin") which should be PRIVATE-ADMIN
+        if (strpos($pagePath, 'docs/') === 0) {
+            return strpos($pagePath, 'admin') !== false;
+        }
+
+        $patterns = [
+            '#^app/admin/scripts/#',             // app/admin/scripts/* maintenance & fix scripts
+            '#^app/admin/#',                     // app/admin/* pages
+            '#admin#',                           // Any path containing "admin"
+            '#^app/cars/actions#',               // app/cars/actions* endpoints
+            '#^app/contact/#',                   // app/contact/* pages
+            '#edit#',                            // Any path containing "edit"
+            '#^usersc/#'                         // usersc/* pages
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $pagePath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/usersc/classes/admin/PagePermissionClassifier.php
+++ b/usersc/classes/admin/PagePermissionClassifier.php
@@ -40,6 +40,9 @@ class PagePermissionClassifier
 
     /**
      * Check if a page should be PRIVATE with NO permissions (special case).
+     *
+     * @param  string $pagePath The page path to classify
+     * @return bool   True if the page should be private with no permission entries
      */
     public static function shouldBePrivateNoPermissions(string $pagePath): bool
     {
@@ -52,6 +55,9 @@ class PagePermissionClassifier
      * Returns true for any page that should be restricted to admin-tier roles.
      * Use shouldBeAdminOnly() to further distinguish between admin-only and
      * admin+editor tiers.
+     *
+     * @param  string $pagePath The page path to classify
+     * @return bool   True if the page requires at least Administrator permission
      */
     public static function shouldHaveAdminPermissions(string $pagePath): bool
     {
@@ -84,6 +90,9 @@ class PagePermissionClassifier
 
     /**
      * Determine if a page should be PRIVATE based on pattern matching.
+     *
+     * @param  string $pagePath The page path to classify
+     * @return bool   True if the page should be private (any permission tier), false if public
      */
     public static function shouldBePrivate(string $pagePath): bool
     {


### PR DESCRIPTION
## Summary

- `usersc/user_settings.php` was listed in `shouldBePrivateNoPermissions()`, making it inaccessible to all roles. Removed from the special-case list so it falls through to the `usersc/*` pattern and is correctly treated as a private owner page (User permission).
- The script treated all admin pages uniformly as private with Admin+Editor. Maintenance portal pages (`manage-maintenance.php`, `tab-health.php`, `tab-maintenance.php`) and all scripts under `app/admin/scripts/` are now classified as admin-only (Administrator permission, no Editor).
- Added conflict guard in `analyzePermissions()` — skips and logs any page that matches both `shouldBePrivateNoPermissions()` and `shouldHaveAdminPermissions()`.

## Bug Escape Analysis

**Root cause (#795):** `usersc/user_settings.php` was manually added to the special-case no-permissions list when the Fix Page Permissions script was first written, rather than relying on the existing `usersc/*` pattern that handles all other pages in that directory.

**Root cause (#797):** The original script had only one admin tier (Admin+Editor). When the maintenance portal was introduced in v2.20.0, the scripts and portal pages were not distinguished from the general admin panel.

**Testing gap:** The `shouldBePrivateNoPermissions()` and `shouldHaveAdminPermissions()` classification functions had no unit tests. The new tests in `tests/Unit/Admin/FixPagePermissionsClassificationTest.php` cover both fixes and will prevent recurrence.

## Test plan

- [ ] `composer test:quick` passes (815 unit tests)
- [ ] Run the maintenance script on a dev DB — verify `usersc/user_settings.php` is classified as PRIVATE-OWNER (User permission)
- [ ] Verify `app/admin/scripts/maintenance/21-Fix-Page-Permissions.php` is classified as PRIVATE-ADMIN-ONLY (Administrator only, no Editor)
- [ ] Verify `app/admin/manage-consolidated.php` remains classified as PRIVATE-ADMIN+EDITOR

Closes #795
Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)