### PR TITLE
test(coverage): add missing tests for escapeHtml(), BackupManager path-traversal guard, and getBaseUrl() fallback

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -59,6 +59,16 @@ None.
   The unimplemented 'View All Cars', 'View Full History', and 'Send Email' buttons have been
   removed from the owner sidebar.
 
+## Technical Changes
+
+- **Test coverage for security-critical code paths** ([#800](https://github.com/unibrain1/elanregistry/issues/800)):
+  Added automated tests for three previously uncovered paths identified in the PR #794 deep review:
+  `escapeHtml()` now has a Playwright test with seven XSS vectors (`<script>`, `"`, `'`, `&`, `>`,
+  combined attribute injection, and non-string passthrough); `BackupManager::cleanupOldBackups()`
+  now has PHPUnit tests for the `realpath()` path-traversal guard (symlink traversal blocked, valid
+  old file deleted); and `getBaseUrl()` now has integration tests for the server-globals-absent
+  fallback path.
+
 ## Issues Resolved
 
 - [#571](https://github.com/unibrain1/elanregistry/issues/571) — Convert native confirm() dialogs to app modal for destructive actions
@@ -78,3 +88,5 @@ None.
 - [#797](https://github.com/unibrain1/elanregistry/issues/797) — bug: maintenance portal pages not restricted to Administrator-only access
 - [#789](https://github.com/unibrain1/elanregistry/issues/789) — Fix stored XSS: escape HTML in admin panel dynamic content
 - [#798](https://github.com/unibrain1/elanregistry/issues/798) — tech-debt: silent failures in LocationService and BackupManager swallow errors without logging
+- [#800](https://github.com/unibrain1/elanregistry/issues/800) — tech-debt: add missing test coverage for escapeHtml(),
+  BackupManager path-traversal guard, and getBaseUrl() fallback

--- a/tests/integration/GetBaseUrlTest.php
+++ b/tests/integration/GetBaseUrlTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration tests for getBaseUrl() (usersc/includes/custom_functions.php).
+ *
+ * The unit-test bootstrap defines a mock getBaseUrl() that always returns
+ * 'https://test.elanregistry.org'. To exercise the real implementation we
+ * use the integration bootstrap, which loads UserSpice and the real
+ * custom_functions.php.
+ *
+ * Caching notes:
+ *  - Server::$cache memoises sanitized $_SERVER values per key. setUp()
+ *    clears it via reflection so each test sees the SERVER_PORT it sets.
+ *  - getBaseUrl() caches its FALLBACK result in a function-level
+ *    `static $baseUrl` variable that PHP does not expose to reflection.
+ *    As of this implementation, the happy-path branch returns before
+ *    reaching the static variable, so happy-path tests neither read nor
+ *    write the cache. The fallback test asserts only on properties of the
+ *    cached value (non-empty, valid absolute URL) so it passes whether
+ *    the cache was warm or cold.
+ */
+#[Group('integration')]
+#[Group('email')]
+final class GetBaseUrlTest extends IntegrationTestCase
+{
+    /**
+     * Reset Server class cache so per-test SERVER_PORT changes are observed.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (class_exists('Server')) {
+            $reflection = new \ReflectionClass('Server');
+            if ($reflection->hasProperty('cache')) {
+                $cacheProp = $reflection->getProperty('cache');
+                $cacheProp->setValue(null, []);
+            }
+        }
+    }
+
+    /**
+     * Test that getBaseUrl() returns the constructed URL when server globals
+     * ($scheme, $host, $us_url_root) are populated.
+     *
+     * In this happy-path branch the function does not query the database
+     * and does not consult the cached static fallback; it simply assembles
+     * scheme + host + path.
+     *
+     * @return void
+     */
+    #[Group('integration')]
+    public function testGetBaseUrlReturnsConstructedUrlWhenGlobalsSet(): void
+    {
+        global $scheme, $host, $us_url_root;
+
+        $originalScheme    = $scheme    ?? null;
+        $originalHost      = $host      ?? null;
+        $originalUsUrlRoot = $us_url_root ?? null;
+        $originalPort      = $_SERVER['SERVER_PORT'] ?? null;
+
+        try {
+            $scheme               = 'https';
+            $host                 = 'test.elanregistry.org';
+            $us_url_root          = '/';
+            // Default HTTPS port → not appended to the URL
+            $_SERVER['SERVER_PORT'] = 443;
+
+            $result = getBaseUrl();
+
+            $this->assertSame('https://test.elanregistry.org', $result);
+        } finally {
+            $scheme      = $originalScheme;
+            $host        = $originalHost;
+            $us_url_root = $originalUsUrlRoot;
+            if ($originalPort === null) {
+                unset($_SERVER['SERVER_PORT']);
+            } else {
+                $_SERVER['SERVER_PORT'] = $originalPort;
+            }
+        }
+    }
+
+    /**
+     * Test that getBaseUrl() falls back to a usable URL when the server
+     * globals are empty (CLI / early-boot context).
+     *
+     * The function attempts to read the `verify_url` column from the `email`
+     * table and, if unavailable, falls back to the hardcoded production URL. Either
+     * way the result must be a non-empty, well-formed absolute URL with no
+     * trailing slash.
+     *
+     * Asserts only on properties that hold whether or not the function-level
+     * static cache has been populated by a prior call in this process, so
+     * test-order independence is preserved.
+     *
+     * @return void
+     */
+    #[Group('integration')]
+    public function testGetBaseUrlFallsBackWhenServerGlobalsEmpty(): void
+    {
+        global $scheme, $host, $us_url_root;
+
+        $originalScheme    = $scheme    ?? null;
+        $originalHost      = $host      ?? null;
+        $originalUsUrlRoot = $us_url_root ?? null;
+
+        try {
+            $scheme      = '';
+            $host        = '';
+            $us_url_root = '';
+
+            $result = getBaseUrl();
+
+            $this->assertIsString($result);
+            $this->assertNotEmpty($result);
+            // Must be a syntactically valid absolute URL (http or https)
+            $this->assertNotFalse(
+                filter_var($result, FILTER_VALIDATE_URL),
+                "getBaseUrl() fallback returned an invalid URL: {$result}"
+            );
+            $parsedScheme = parse_url($result, PHP_URL_SCHEME);
+            $this->assertContains(
+                $parsedScheme,
+                ['http', 'https'],
+                "getBaseUrl() fallback URL has unexpected scheme: {$parsedScheme}"
+            );
+            // No trailing slash (function rtrim()s the result)
+            $this->assertStringEndsNotWith('/', $result);
+        } finally {
+            $scheme      = $originalScheme;
+            $host        = $originalHost;
+            $us_url_root = $originalUsUrlRoot;
+        }
+    }
+}

--- a/tests/playwright/admin-escapeHtml.test.js
+++ b/tests/playwright/admin-escapeHtml.test.js
@@ -1,0 +1,65 @@
+// tests/playwright/admin-escapeHtml.test.js
+//
+// Tests for escapeHtml() XSS-prevention helper in manage-consolidated.js.
+// Verifies that user-supplied content is safely escaped for DOM insertion.
+// The function is loaded globally on /app/admin/manage-consolidated.php and
+// is exercised here via page.evaluate() with a battery of XSS vectors.
+//
+// Requires local MAMP at http://localhost:9999/elan_registry
+
+const { test, expect } = require('@playwright/test');
+const { ensureLoggedIn } = require('./auth-helper.js');
+
+test.describe('escapeHtml() — XSS prevention', () => {
+    test.beforeEach(async ({ page }) => {
+        await ensureLoggedIn(page);
+        await page.goto('/app/admin/manage-consolidated.php?tab=car-mgmt', { waitUntil: 'networkidle' });
+    });
+
+    test('escapes <script> tags', async ({ page }) => {
+        const result = await page.evaluate(() => escapeHtml('<script>alert(1)</script>'));
+        expect(result).toContain('&lt;script&gt;');
+        expect(result).toContain('&lt;/script&gt;');
+    });
+
+    test('escapes double quotes', async ({ page }) => {
+        const result = await page.evaluate(() => escapeHtml('"'));
+        expect(result).toBe('&quot;');
+    });
+
+    test('escapes single quotes', async ({ page }) => {
+        const result = await page.evaluate(() => escapeHtml("'"));
+        expect(result).toBe('&#039;');
+    });
+
+    test('escapes ampersands', async ({ page }) => {
+        const result = await page.evaluate(() => escapeHtml('&'));
+        expect(result).toBe('&amp;');
+    });
+
+    test('escapes greater-than character', async ({ page }) => {
+        const result = await page.evaluate(() => escapeHtml('>'));
+        expect(result).toBe('&gt;');
+    });
+
+    test('escapes combined attribute-injection vector', async ({ page }) => {
+        const result = await page.evaluate(() => escapeHtml('<img src=x onerror="alert(\'xss\')">'));
+        expect(result).not.toContain('<img');
+        expect(result).not.toContain('"');
+        expect(result).not.toContain("'");
+        expect(result).toContain('&lt;img');
+        expect(result).toContain('&quot;');
+        expect(result).toContain('&#039;');
+        expect(result).toContain('&gt;');
+    });
+
+    test('passes non-string values through unchanged', async ({ page }) => {
+        const result = await page.evaluate(() => escapeHtml(42));
+        expect(result).toBe(42);
+    });
+
+    test('double-escapes already-escaped strings (idempotency check)', async ({ page }) => {
+        const result = await page.evaluate(() => escapeHtml('&lt;b&gt;'));
+        expect(result).toBe('&amp;lt;b&amp;gt;');
+    });
+});

--- a/tests/unit/admin/BackupManagerTest.php
+++ b/tests/unit/admin/BackupManagerTest.php
@@ -339,6 +339,93 @@ final class BackupManagerTest extends TestCase
     }
 
     /**
+     * Test that cleanupOldBackups blocks symlink path traversal.
+     *
+     * Creates a symlink inside the backup directory pointing to a file
+     * OUTSIDE the backup base. After ageing the symlink past the retention
+     * cutoff, performEnhancedCleanup() must NOT delete the target file —
+     * the realpath guard detects the traversal and skips the entry.
+     *
+     * The filename embeds `_development_` so that extractEnvironmentFromFilename()
+     * resolves a real retention tier rather than falling through to its default,
+     * keeping the test sensitive to changes in the environment-extraction regex.
+     *
+     * @return void
+     */
+    #[Group('fast')]
+    #[Group('unit')]
+    public function testCleanupBlocksSymlinkTraversal(): void
+    {
+        if (!function_exists('symlink') || (PHP_OS_FAMILY === 'Windows' && !extension_loaded('com_dotnet'))) {
+            $this->markTestSkipped('symlink() unavailable on this platform');
+        }
+
+        // Create a directory and target file OUTSIDE the backup base
+        $outsideDir = sys_get_temp_dir() . '/outside_' . uniqid() . '/';
+        mkdir($outsideDir);
+        $secretPath = $outsideDir . 'secret.txt';
+        file_put_contents($secretPath, 'sensitive data that must not be deleted');
+
+        try {
+            $symlinkPath = $this->testBackupDir
+                . 'automated/elanregistry_automated_development_2024-01-01T000000_schema.sql';
+
+            if (!@symlink($secretPath, $symlinkPath)) {
+                $this->markTestSkipped('symlink() call failed (insufficient privileges or unsupported filesystem)');
+            }
+
+            // Age the symlink past any retention cutoff (100 days old)
+            touch($symlinkPath, time() - 100 * 86400);
+
+            $result = $this->backupManager->performEnhancedCleanup();
+
+            // Target file outside backup base must still exist
+            $this->assertFileExists($secretPath, 'Path-traversal target was deleted');
+
+            // The realpath guard blocked deletion; deleted count for automated must be 0
+            $this->assertSame(0, $result['automated']['deleted']);
+        } finally {
+            if (is_link($symlinkPath ?? '')) {
+                unlink($symlinkPath);
+            }
+            $this->recursiveRemoveDirectory($outsideDir);
+        }
+    }
+
+    /**
+     * Test that cleanupOldBackups deletes a real old file inside the backup base.
+     *
+     * Companion to testCleanupBlocksSymlinkTraversal: verifies that the
+     * realpath guard does NOT block legitimate deletions of aged backup files
+     * that genuinely live within the backup directory.
+     *
+     * The filename embeds `_development_` so that extractEnvironmentFromFilename()
+     * resolves a real retention tier rather than falling through to its default,
+     * keeping the test sensitive to changes in the environment-extraction regex.
+     *
+     * @return void
+     */
+    #[Group('fast')]
+    #[Group('unit')]
+    public function testCleanupDeletesOldFileWithinBackupBase(): void
+    {
+        // Create a real backup file (not a symlink) inside the backup base.
+        // Filename matches extractEnvironmentFromFilename regex
+        // /_(development|test|production)_/ so retention is resolved.
+        $oldBackup = $this->testBackupDir
+            . 'automated/elanregistry_automated_development_2024-01-01T000000_schema.sql';
+        file_put_contents($oldBackup, "-- old backup content\n");
+
+        // Age past development/automated retention (default 7 days)
+        touch($oldBackup, time() - 100 * 86400);
+
+        $result = $this->backupManager->performEnhancedCleanup();
+
+        $this->assertSame(1, $result['automated']['deleted']);
+        $this->assertFileDoesNotExist($oldBackup);
+    }
+
+    /**
      * Helper: Create a mock database object
      *
      * @return object Mock database object with query method


### PR DESCRIPTION
## Summary

- Adds Playwright test for `escapeHtml()` covering all five HTML special characters plus a combined XSS vector and non-string passthrough
- Adds PHPUnit tests for `BackupManager::cleanupOldBackups()` realpath path-traversal guard (symlink traversal blocked + legitimate aged file deleted)
- Adds integration tests for `getBaseUrl()` server-globals-absent fallback path (happy path and DB-query fallback)

Closes #800

## Test plan

- [ ] `composer test:quick` — 883 unit tests pass
- [ ] `npm run playwright:test -- admin-escapeHtml.test.js` — 8 XSS prevention tests pass (requires local MAMP)
- [ ] `composer test:medium` — integration tests including `GetBaseUrlTest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)