### PR TITLE
refactor(admin): extract duplicated script-enumeration logic into shared helper (#801)

### DIFF
--- a/app/admin/includes/system/script-enumeration.php
+++ b/app/admin/includes/system/script-enumeration.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Enumerate valid runnable PHP script files in an admin scripts directory.
+ *
+ * Filters out directories, non-PHP files, template/index stubs, and
+ * backup- or test-prefixed filenames that are not meant to be run directly.
+ * Returns an empty array without error if $directory does not exist.
+ *
+ * @param string $directory Absolute path to the directory to scan.
+ * @return array<string> Unsorted list of valid PHP filenames (basenames only); callers are responsible for sorting.
+ */
+function enumerateScriptFiles(string $directory): array
+{
+    $directory = rtrim($directory, '/') . '/';
+    $allItems = is_dir($directory) ? (scandir($directory) ?: []) : [];
+    $scripts  = [];
+
+    foreach ($allItems as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+        if (is_dir($directory . $item) || pathinfo($item, PATHINFO_EXTENSION) !== 'php') {
+            continue;
+        }
+        if (in_array($item, ['index.php', '_TEMPLATE_Fix-Script.php', 'backup-functions.php'], true)) {
+            continue;
+        }
+        if (preg_match('/^(backup_|rollback_|.*_backup_|test-)/', $item)) {
+            continue;
+        }
+        $scripts[] = $item;
+    }
+
+    return $scripts;
+}

--- a/app/admin/includes/tab-health.php
+++ b/app/admin/includes/tab-health.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 use ElanRegistry\Exceptions\AdminOperationException;
 use ElanRegistry\Exceptions\BackupException;
 
+require_once $abs_us_root . $us_url_root . 'app/admin/includes/system/script-enumeration.php';
+
 /**
  * tab-health.php
  * System Health Tab Content
@@ -14,26 +16,7 @@ use ElanRegistry\Exceptions\BackupException;
 $backupManager = new BackupManager($db, $abs_us_root . $us_url_root . BACKUP_BASE_DIR, (int)$user->data()->id);
 
 $fixDirectory = $abs_us_root . $us_url_root . 'app/admin/scripts/fix/';
-$allItems = scandir($fixDirectory) ?: [];
-
-$fixScripts = [];
-foreach ($allItems as $item) {
-    $fullPath = $fixDirectory . $item;
-
-    if (is_dir($fullPath) || pathinfo($item, PATHINFO_EXTENSION) !== 'php') {
-        continue;
-    }
-
-    if (in_array($item, ['index.php', '_TEMPLATE_Fix-Script.php', 'backup-functions.php'])) {
-        continue;
-    }
-
-    if (preg_match('/^(backup_|rollback_|.*_backup_|test-)/', $item)) {
-        continue;
-    }
-
-    $fixScripts[] = $item;
-}
+$fixScripts   = enumerateScriptFiles($fixDirectory);
 
 $scriptRunStatus = array_fill_keys($fixScripts, ['has_run' => false, 'last_run' => null]);
 if (!empty($fixScripts)) {

--- a/app/admin/includes/tab-maintenance.php
+++ b/app/admin/includes/tab-maintenance.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 use ElanRegistry\Exceptions\AdminOperationException;
 use ElanRegistry\Exceptions\BackupException;
 
+require_once $abs_us_root . $us_url_root . 'app/admin/includes/system/script-enumeration.php';
+
 /**
  * tab-maintenance.php
  * Maintenance Tab Content
@@ -14,50 +16,12 @@ use ElanRegistry\Exceptions\BackupException;
 $backupManager = new BackupManager($db, $abs_us_root . $us_url_root . BACKUP_BASE_DIR, (int)$user->data()->id);
 
 $fixDirectory = $abs_us_root . $us_url_root . 'app/admin/scripts/fix/';
-$allItems = scandir($fixDirectory) ?: [];
-
-$fixScripts = [];
-foreach ($allItems as $item) {
-    $fullPath = $fixDirectory . $item;
-
-    if (is_dir($fullPath) || pathinfo($item, PATHINFO_EXTENSION) !== 'php') {
-        continue;
-    }
-
-    if (in_array($item, ['index.php', '_TEMPLATE_Fix-Script.php', 'backup-functions.php'])) {
-        continue;
-    }
-
-    if (preg_match('/^(backup_|rollback_|.*_backup_|test-)/', $item)) {
-        continue;
-    }
-
-    $fixScripts[] = $item;
-}
+$fixScripts   = enumerateScriptFiles($fixDirectory);
 
 rsort($fixScripts, SORT_NATURAL);
 
 $maintenanceDirectory = $abs_us_root . $us_url_root . 'app/admin/scripts/maintenance/';
-$allMaintenanceItems = is_dir($maintenanceDirectory) ? scandir($maintenanceDirectory) : [];
-
-$maintenanceScripts = [];
-foreach ($allMaintenanceItems as $item) {
-    $fullPath = $maintenanceDirectory . $item;
-
-    if (is_dir($fullPath) || pathinfo($item, PATHINFO_EXTENSION) !== 'php') {
-        continue;
-    }
-
-    if (in_array($item, ['index.php', '_TEMPLATE_Fix-Script.php', 'backup-functions.php'])) {
-        continue;
-    }
-
-    if (preg_match('/^(backup_|rollback_|.*_backup_|test-)/', $item)) {
-        continue;
-    }
-
-    $maintenanceScripts[] = $item;
-}
+$maintenanceScripts   = enumerateScriptFiles($maintenanceDirectory);
 
 sort($maintenanceScripts, SORT_NATURAL);
 

--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -61,6 +61,12 @@ None.
 
 ## Technical Changes
 
+- **Extract duplicated script-enumeration logic into shared helper** ([#801](https://github.com/unibrain1/elanregistry/issues/801)):
+  Identical 21-line directory-scan blocks in `tab-health.php` and `tab-maintenance.php` replaced
+  with calls to a new `enumerateScriptFiles(string $directory): array` helper in
+  `app/admin/includes/system/script-enumeration.php`. Also eliminates a second near-duplicate
+  block in `tab-maintenance.php` for the maintenance scripts directory.
+
 - **Test coverage for security-critical code paths** ([#800](https://github.com/unibrain1/elanregistry/issues/800)):
   Added automated tests for three previously uncovered paths identified in the PR #794 deep review:
   `escapeHtml()` now has a Playwright test with seven XSS vectors (`<script>`, `"`, `'`, `&`, `>`,
@@ -90,3 +96,5 @@ None.
 - [#798](https://github.com/unibrain1/elanregistry/issues/798) — tech-debt: silent failures in LocationService and BackupManager swallow errors without logging
 - [#800](https://github.com/unibrain1/elanregistry/issues/800) — tech-debt: add missing test coverage for escapeHtml(),
   BackupManager path-traversal guard, and getBaseUrl() fallback
+- [#801](https://github.com/unibrain1/elanregistry/issues/801) — tech-debt: extract duplicated script-enumeration logic
+  from tab-health.php and tab-maintenance.php


### PR DESCRIPTION
## Summary

- Extracts three identical 21-line directory-scan blocks from `tab-health.php` and `tab-maintenance.php` into a single `enumerateScriptFiles(string $directory): array` helper in `app/admin/includes/system/script-enumeration.php`
- Helper normalizes the trailing slash internally, documents the unsorted-return contract, and handles a missing directory gracefully
- `require_once` prevents double-inclusion when both tab files load in the same request

Closes #801

## Test plan

- [ ] All 883 PHPUnit unit tests pass (verified in pre-commit hook)
- [ ] PHPStan reports no errors on the new helper and modified tab files
- [ ] Manually verify the Fix Scripts and Maintenance Scripts lists render correctly on the admin maintenance tab
- [ ] Manually verify the Fix Scripts list renders correctly on the admin health tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)