### PR TITLE
feat(ux): add contact form link to car transfer guide and footer (#811)

### DIFF
--- a/docs/guides/CAR_TRANSFER_USER_GUIDE.md
+++ b/docs/guides/CAR_TRANSFER_USER_GUIDE.md
@@ -220,7 +220,7 @@ Contact registry administrators if:
 
 ### How to Contact Support
 
-**Email:** [Administrator contact information from registry]
+**Need help?** Use the [online contact form](/app/contact/index.php).
 
 **Subject Line:** Include "Transfer Request - [Chassis Number]" for faster processing
 

--- a/docs/releases/RELEASE_NOTES_v2.20.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.20.0.md
@@ -7,6 +7,13 @@
 
 None.
 
+## User-Facing Changes
+
+- **Contact form link in car transfer guide and footer** ([#811](https://github.com/unibrain1/elanregistry/issues/811)):
+  The unfilled placeholder in the car transfer guide's "How to Contact Support" section is replaced
+  with a direct link to the online contact form. A "Contact Us" link is also added to the site
+  footer alongside the existing Privacy Policy link (`Privacy Policy | Contact Us`).
+
 ## Admin-Facing Changes
 
 ### Bug Fixes
@@ -98,3 +105,4 @@ None.
   BackupManager path-traversal guard, and getBaseUrl() fallback
 - [#801](https://github.com/unibrain1/elanregistry/issues/801) — tech-debt: extract duplicated script-enumeration logic
   from tab-health.php and tab-maintenance.php
+- [#811](https://github.com/unibrain1/elanregistry/issues/811) — Add contact form link to car transfer guide and footer

--- a/usersc/classes/MarkdownParser.php
+++ b/usersc/classes/MarkdownParser.php
@@ -61,9 +61,12 @@ class MarkdownParser
                 $url = htmlspecialchars($matches[2], ENT_QUOTES, 'UTF-8');
                 // Only allow safe image URLs
                 if (self::isSafeUrl($url)) {
-                    // If baseUrl is provided, prepend it to relative paths in the docs directory
                     if (!empty($baseUrl) && strpos($url, '#') !== 0 && strpos($url, '/') !== 0 && parse_url($url, PHP_URL_SCHEME) === null) {
+                        // Relative path: prepend baseUrl + docs/ directory
                         $url = $baseUrl . 'docs/' . $url;
+                    } elseif (!empty($baseUrl) && strpos($url, '/') === 0) {
+                        // Root-relative path: prepend baseUrl so /app/foo resolves correctly on any install path
+                        $url = rtrim($baseUrl, '/') . $url;
                     }
                     return '<img src="' . $url . '" alt="' . $alt . '" class="img-fluid" />';
                 }
@@ -80,9 +83,12 @@ class MarkdownParser
                 $url = htmlspecialchars($matches[2], ENT_QUOTES, 'UTF-8');
                 // Only allow safe URL schemes
                 if (self::isSafeUrl($url)) {
-                    // If baseUrl is provided, prepend it to relative paths in the docs directory
                     if (!empty($baseUrl) && strpos($url, '#') !== 0 && strpos($url, '/') !== 0 && parse_url($url, PHP_URL_SCHEME) === null) {
+                        // Relative path: prepend baseUrl + docs/ directory
                         $url = $baseUrl . 'docs/' . $url;
+                    } elseif (!empty($baseUrl) && strpos($url, '/') === 0) {
+                        // Root-relative path: prepend baseUrl so /app/foo resolves correctly on any install path
+                        $url = rtrim($baseUrl, '/') . $url;
                     }
                     // Don't open anchor links or absolute paths in new tab
                     $target = (strpos($url, '#') === 0 || strpos($url, '/') === 0) ? '' : ' target="_blank"';

--- a/usersc/includes/footer.php
+++ b/usersc/includes/footer.php
@@ -21,18 +21,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //This will go in every template.
 ?>
 
-<!-- Privacy Policy link injected into footer without modifying upstream template -->
+<!-- Privacy Policy and Contact Us links injected into footer without modifying upstream template -->
 <script nonce="<?=htmlspecialchars($usespice_nonce ?? '')?>">
 (function () {
     var container = document.querySelector('#footer .container');
     if (container) {
         var p = document.createElement('p');
         p.className = 'text-center small';
-        var a = document.createElement('a');
-        a.href = '<?=$us_url_root?>app/privacy.php';
-        a.className = 'text-muted';
-        a.textContent = 'Privacy Policy';
-        p.appendChild(a);
+        var aPrivacy = document.createElement('a');
+        aPrivacy.href = '<?=$us_url_root?>app/privacy.php';
+        aPrivacy.className = 'text-muted';
+        aPrivacy.textContent = 'Privacy Policy';
+        p.appendChild(aPrivacy);
+        p.appendChild(document.createTextNode(' | '));
+        var aContact = document.createElement('a');
+        aContact.href = '<?=$us_url_root?>app/contact/index.php';
+        aContact.className = 'text-muted';
+        aContact.textContent = 'Contact Us';
+        p.appendChild(aContact);
         container.appendChild(p);
     }
 }());

--- a/usersc/includes/footer.php
+++ b/usersc/includes/footer.php
@@ -33,12 +33,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         aPrivacy.className = 'text-muted';
         aPrivacy.textContent = 'Privacy Policy';
         p.appendChild(aPrivacy);
+        <?php if (isset($user) && $user->isLoggedIn()) { ?>
         p.appendChild(document.createTextNode(' | '));
         var aContact = document.createElement('a');
         aContact.href = '<?=$us_url_root?>app/contact/index.php';
         aContact.className = 'text-muted';
         aContact.textContent = 'Contact Us';
         p.appendChild(aContact);
+        <?php } ?>
         container.appendChild(p);
     }
 }());


### PR DESCRIPTION
## Summary

- Replaces the unfilled `[Administrator contact information from registry]` placeholder in `docs/guides/CAR_TRANSFER_USER_GUIDE.md` with a direct link to the online contact form
- Injects a "Contact Us" link into the site footer alongside the existing Privacy Policy link (`Privacy Policy | Contact Us`), visible only to logged-in users
- Fixes `MarkdownParser::toHtml()` to correctly resolve root-relative paths (e.g. `/app/foo`) on subdirectory installs by prepending `$baseUrl` — previously these resolved against the server root rather than the install path

Closes #811

## Test plan

- [ ] Visit the car transfer guide as a logged-in user — "Need help? Use the online contact form" link navigates to the contact form correctly on both localhost and production
- [ ] Verify footer shows `Privacy Policy | Contact Us` when logged in
- [ ] Verify footer shows only `Privacy Policy` when logged out (no Contact Us link)
- [ ] No upstream template files under `usersc/templates/customizer/` were modified
- [ ] 883 PHPUnit unit tests pass (verified in pre-commit hook)
- [ ] PHPStan and phpcs report no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)