### PR TITLE
chore: pre-upgrade audit — UserSpice override inventory snapshot (6.0.5 → 6.0.8)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.21.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.21.0.md
@@ -1,0 +1,34 @@
+# Elan Registry v2.21.0 Release Notes
+
+**Release Date:** [DATE]
+**Type:** Minor Release - UserSpice 6.0.8 Update
+
+## Required Actions After Deployment
+
+1. Run the UserSpice DB updater: navigate to `/users/admin/` and apply new indexes from 6.0.8 (#02296).
+2. Log in via production (behind Cloudflare) and verify the `Secure` cookie flag is set in browser devtools.
+
+## User-Facing Changes
+
+No direct user-facing feature changes in this release. All changes are infrastructure and security improvements.
+
+## Admin-Facing Changes
+
+### Improvements
+
+- **Login open redirect and XSS fixed** ([#820](https://github.com/unibrain1/elanregistry/issues/820)): Fixes open redirect, passkey JS XSS, and CSP nonce gaps.
+- **Secure session cookies behind Cloudflare** ([#806](https://github.com/unibrain1/elanregistry/issues/806)): Secure and SameSite=Strict flags set correctly.
+- **UserSpice 6.0.8 upgrade** ([#805](https://github.com/unibrain1/elanregistry/issues/805)): Closes CVE-2026-30964 (passkey path); applies DB performance indexes.
+- **User Manager columns reconciled** ([#808](https://github.com/unibrain1/elanregistry/issues/808)): Override aligned to 6.0.8; custom columns preserved.
+- **Customizer template updated to 2.1.0** ([#807](https://github.com/unibrain1/elanregistry/issues/807)): iPad mini layout fix; Lotus green CSS re-saved.
+
+## Issues Resolved
+
+- [#804](https://github.com/unibrain1/elanregistry/issues/804) — chore: pre-upgrade audit — snapshot UserSpice override inventory before 6.0.8 update
+- [#805](https://github.com/unibrain1/elanregistry/issues/805) — chore: apply UserSpice 6.0.8 update and run DB updater
+- [#806](https://github.com/unibrain1/elanregistry/issues/806) — security: port secure-cookie and trusted-proxy pattern into users/init.php for Cloudflare
+- [#807](https://github.com/unibrain1/elanregistry/issues/807) — chore: update Customizer template to 2.1.0 and re-save custom CSS
+- [#808](https://github.com/unibrain1/elanregistry/issues/808) — chore: diff and reconcile usersc/includes/user_manager_columns.php against 6.0.8 upstream shape
+- [#809](https://github.com/unibrain1/elanregistry/issues/809) — test: smoke-test plan — authentication flows, account page, User Manager after 6.0.8
+- [#810](https://github.com/unibrain1/elanregistry/issues/810) — docs: update USERSPICE_FUNCTIONS.md with new/changed function references from 6.0.8
+- [#820](https://github.com/unibrain1/elanregistry/issues/820) — security: port 6.0.8 security fixes into usersc/login.php (open redirect, XSS, CSP nonce)


### PR DESCRIPTION
## Summary

- Documents every `usersc/` override that shadows a `users/` file, with nature of each customization
- Identifies `users/init.php` as the only critical file requiring manual restoration after the updater runs (228-line diff: phpdotenv, session cookie params, custom autoloader loading, PDO options)
- Provides porting analysis for `usersc/login.php`: found open redirect, XSS in passkey JS, and CSP nonce gaps that exist in current code — tracked as new issue #820
- Key finding: `usersc/includes/user_manager_columns.php` is already byte-for-byte identical to 6.0.8 source — issue #808 will be trivial
- Creates draft release notes for v2.21.0

## Test plan

- [ ] Review `plans/userspice-608-upgrade-audit.md` (gitignored, temporary working doc — view locally)
- [ ] Confirm `docs/releases/RELEASE_NOTES_v2.21.0.md` passes markdownlint
- [ ] No code changes in this PR — audit and release notes only

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)