### PR TITLE
security: harden HTTPS detection — validate X-Forwarded-Proto against Cloudflare CIDR list

### DIFF
--- a/tests/unit/system/ServerGlobalsTest.php
+++ b/tests/unit/system/ServerGlobalsTest.php
@@ -170,14 +170,18 @@ class ServerGlobalsTest extends TestCase
     }
 
     /**
-     * Test that proxy-aware scheme detection via Server::getScheme() is used.
-     * Replaced direct REQUEST_SCHEME check; getScheme() handles HTTPS, proxy
-     * headers, and port 443 detection internally.
+     * Test that proxy-aware scheme detection via Server::getScheme() is used
+     * rather than reading a raw $_SERVER key directly.
      */
     public function testDocumentsRequestSchemeUsage(): void
     {
         $content = (string) file_get_contents($this->globalsFile);
         $this->assertStringContainsString('getScheme', $content);
+        $this->assertStringNotContainsString(
+            'HTTP_X_FORWARDED_PROTO',
+            $content,
+            'server_globals.php must not access X-Forwarded-Proto directly — use Server::getScheme()'
+        );
     }
 
     /**

--- a/tests/unit/system/ServerGlobalsTest.php
+++ b/tests/unit/system/ServerGlobalsTest.php
@@ -170,12 +170,14 @@ class ServerGlobalsTest extends TestCase
     }
 
     /**
-     * Test that REQUEST_SCHEME is documented as a required value
+     * Test that proxy-aware scheme detection via Server::getScheme() is used.
+     * Replaced direct REQUEST_SCHEME check; getScheme() handles HTTPS, proxy
+     * headers, and port 443 detection internally.
      */
     public function testDocumentsRequestSchemeUsage(): void
     {
         $content = (string) file_get_contents($this->globalsFile);
-        $this->assertStringContainsString('REQUEST_SCHEME', $content);
+        $this->assertStringContainsString('getScheme', $content);
     }
 
     /**

--- a/users/init.php
+++ b/users/init.php
@@ -6,23 +6,27 @@ require_once __DIR__ . '/classes/class.autoloader.php';
 
 // ER START: trusted-proxy HTTPS detection for Cloudflare
 // Cloudflare terminates TLS before requests reach the origin, so $_SERVER['HTTPS']
-// is not set on the origin server. We must read X-Forwarded-Proto, but only when
-// the request comes from a known Cloudflare IP (to prevent header spoofing).
-// Server::getScheme() checks direct HTTPS first, then falls back to the proxy
-// header only when REMOTE_ADDR is in one of these CIDRs.
+// is not set on the origin server. We must read X-Forwarded-Proto (or the RFC 7239
+// Forwarded: proto= header), but only when the request comes from a known Cloudflare
+// IP (to prevent header spoofing). Server::getScheme() checks direct HTTPS first,
+// then the proxy headers only when REMOTE_ADDR is in one of these CIDRs.
 //
 // Source: https://www.cloudflare.com/ips-v4  /  https://www.cloudflare.com/ips-v6
-// Last verified: 2026-05-04. Re-check when Cloudflare announces IP range changes.
-define('CLOUDFLARE_CIDRS', [
-    // IPv4
-    '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22',
-    '141.101.64.0/18', '108.162.192.0/18', '190.93.240.0/20', '188.114.96.0/20',
-    '197.234.240.0/22', '198.41.128.0/17', '162.158.0.0/15', '104.16.0.0/13',
-    '104.24.0.0/14',   '172.64.0.0/13',   '131.0.72.0/22',
-    // IPv6
-    '2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32',
-    '2405:8100::/32', '2a06:98c0::/29', '2c0f:f248::/32',
-]);
+// Last verified: 2026-05-04. Re-verify at https://www.cloudflare.com/ips-v4 and
+// https://www.cloudflare.com/ips-v6 on each significant Cloudflare infrastructure
+// announcement or annually.
+if (!defined('CLOUDFLARE_CIDRS')) {
+    define('CLOUDFLARE_CIDRS', [
+        // IPv4
+        '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22',
+        '141.101.64.0/18', '108.162.192.0/18', '190.93.240.0/20', '188.114.96.0/20',
+        '197.234.240.0/22', '198.41.128.0/17', '162.158.0.0/15', '104.16.0.0/13',
+        '104.24.0.0/14',   '172.64.0.0/13',   '131.0.72.0/22',
+        // IPv6
+        '2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32',
+        '2405:8100::/32', '2a06:98c0::/29', '2c0f:f248::/32',
+    ]);
+}
 // ER END
 
 // Set secure session cookie parameters before starting session

--- a/users/init.php
+++ b/users/init.php
@@ -4,12 +4,33 @@ define('USERSPICE_ACTIVE_LOGGING', false);
 // Load UserSpice core autoloader
 require_once __DIR__ . '/classes/class.autoloader.php';
 
+// ER START: trusted-proxy HTTPS detection for Cloudflare
+// Cloudflare terminates TLS before requests reach the origin, so $_SERVER['HTTPS']
+// is not set on the origin server. We must read X-Forwarded-Proto, but only when
+// the request comes from a known Cloudflare IP (to prevent header spoofing).
+// Server::getScheme() checks direct HTTPS first, then falls back to the proxy
+// header only when REMOTE_ADDR is in one of these CIDRs.
+//
+// Source: https://www.cloudflare.com/ips-v4  /  https://www.cloudflare.com/ips-v6
+// Last verified: 2026-05-04. Re-check when Cloudflare announces IP range changes.
+define('CLOUDFLARE_CIDRS', [
+    // IPv4
+    '173.245.48.0/20', '103.21.244.0/22', '103.22.200.0/22', '103.31.4.0/22',
+    '141.101.64.0/18', '108.162.192.0/18', '190.93.240.0/20', '188.114.96.0/20',
+    '197.234.240.0/22', '198.41.128.0/17', '162.158.0.0/15', '104.16.0.0/13',
+    '104.24.0.0/14',   '172.64.0.0/13',   '131.0.72.0/22',
+    // IPv6
+    '2400:cb00::/32', '2606:4700::/32', '2803:f800::/32', '2405:b500::/32',
+    '2405:8100::/32', '2a06:98c0::/29', '2c0f:f248::/32',
+]);
+// ER END
+
 // Set secure session cookie parameters before starting session
 session_set_cookie_params([
     'lifetime' => 0,           // Session cookie (expires when browser closes)
     'path' => '/',             // Available across entire site
     'domain' => '',            // Use default domain
-    'secure' => Server::get('HTTPS') !== '', // Only send over HTTPS if available
+    'secure' => Server::getScheme(CLOUDFLARE_CIDRS) === 'https', // ER: proxy-aware HTTPS detection
     'httponly' => true,        // Prevent JavaScript access to session cookie
     'samesite' => 'Strict'     // CSRF protection - only send with same-site requests
 ]);

--- a/usersc/includes/server_globals.php
+++ b/usersc/includes/server_globals.php
@@ -41,13 +41,11 @@ declare(strict_types=1);
  */
 
 // HTTP Scheme Detection
-// Determines if request is secure (HTTPS) or plain HTTP.
-// Also checks X-Forwarded-Proto for reverse proxy / Cloudflare Tunnel setups
-// where SSL is terminated upstream and the backend sees plain HTTP internally.
-$scheme = Server::get('REQUEST_SCHEME', 'http');
-if (Server::get('HTTP_X_FORWARDED_PROTO', '') === 'https') {
-    $scheme = 'https';
-}
+// Uses Server::getScheme() with the Cloudflare CIDR list defined in users/init.php.
+// X-Forwarded-Proto is trusted only when REMOTE_ADDR matches a Cloudflare IP;
+// direct HTTPS ($SERVER['HTTPS'] set) is always trusted regardless of proxy.
+// Falls back to 'http' when neither signal is present (local dev, plain HTTP).
+$scheme   = Server::getScheme(CLOUDFLARE_CIDRS);
 $is_https = ($scheme === 'https');
 
 // Host and Origin

--- a/usersc/includes/server_globals.php
+++ b/usersc/includes/server_globals.php
@@ -42,9 +42,10 @@ declare(strict_types=1);
 
 // HTTP Scheme Detection
 // Uses Server::getScheme() with the Cloudflare CIDR list defined in users/init.php.
-// X-Forwarded-Proto is trusted only when REMOTE_ADDR matches a Cloudflare IP;
-// direct HTTPS ($SERVER['HTTPS'] set) is always trusted regardless of proxy.
-// Falls back to 'http' when neither signal is present (local dev, plain HTTP).
+// X-Forwarded-Proto (and RFC 7239 Forwarded: proto=) are trusted only when
+// REMOTE_ADDR matches a Cloudflare IP; direct HTTPS ($_SERVER['HTTPS'] set) is
+// always trusted regardless of proxy. Falls back to 'https' if SERVER_PORT is 443,
+// otherwise 'http' (plain HTTP, local dev).
 $scheme   = Server::getScheme(CLOUDFLARE_CIDRS);
 $is_https = ($scheme === 'https');
 


### PR DESCRIPTION
## Summary

- Replaces unsafe unconditional trust of `HTTP_X_FORWARDED_PROTO` in `server_globals.php` and `session_set_cookie_params()` in `init.php` with `Server::getScheme(CLOUDFLARE_CIDRS)`, which validates the proxy header only when `REMOTE_ADDR` matches a known Cloudflare IP
- Defines `CLOUDFLARE_CIDRS` constant (22 IPv4/IPv6 CIDRs from Cloudflare's published ranges) in `users/init.php` so the trusted proxy list is declared once and shared across all call sites
- Adds a regression guard in `ServerGlobalsTest` preventing re-introduction of direct `HTTP_X_FORWARDED_PROTO` reads, matching the pattern already used in `SecurityHeadersTest`

## Security impact

Before this change, any client that could reach the origin server directly (bypassing Cloudflare) could send `X-Forwarded-Proto: https` to force HTTPS treatment — causing the session cookie `secure` flag to be set, and `$is_https`/`$scheme` globals to report HTTPS when the connection was plain HTTP. `Server::getScheme()` with a trusted CIDR list closes this spoofing vector.

## Test plan

- [ ] 883 unit tests pass (`composer test:quick`)
- [ ] PHPStan reports no errors (`composer check:php`)
- [ ] Verify `$is_https` is `true` on production (behind Cloudflare)
- [ ] Verify `$is_https` is `false` on local dev (plain HTTP, no proxy)
- [ ] Confirm session cookie has `Secure` flag set in production browser DevTools

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)