### PR TITLE
fix: correct dangling tab-system.php reference in 3-configuration.sql

### DIFF
--- a/database/3-configuration.sql
+++ b/database/3-configuration.sql
@@ -193,7 +193,7 @@ INSERT INTO `pages` (`id`, `page`, `title`, `private`, `re_auth`, `core`) VALUES
 (300, 'app/admin/includes/tab-car_mgmt.php', 'Admin - Car Management Tab', 1, 0, 0),
 (304, 'app/admin/includes/tab-placeholder.php', 'Admin - Tab Placeholder', 1, 0, 0),
 (305, 'app/admin/includes/tab-settings.php', 'Admin - Settings Tab', 1, 0, 0),
-(306, 'app/admin/includes/tab-system.php', 'Admin - System Management Tab', 1, 0, 0),
+(306, 'app/admin/includes/tab-health.php', 'Admin - System Health Tab', 1, 0, 0),
 (309, 'app/admin/includes/load-owner-info.php', 'Admin - Load Owner Information', 1, 0, 0),
 (310, 'app/admin/includes/load-owner-profile.php', 'Admin - Load Owner Profile', 1, 0, 0),
 (311, 'app/admin/includes/process-owner-search.php', 'Admin - Owner Search Process', 1, 0, 0),

--- a/docs/releases/RELEASE_NOTES_v2.22.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.22.0.md
@@ -1,0 +1,36 @@
+# Elan Registry v2.22.0 Release Notes
+
+**Release Date:** [DATE]
+**Type:** Minor Release - Google-Free Maps
+
+## Required Actions After Deployment
+
+Run the following FIX scripts in order after deploying:
+
+1. FIX script from #433: removes `elan_google_geo_key` from the `settings` table
+2. FIX script from #724: removes `elan_google_maps_key` from the `settings` table (must run after #433 FIX script)
+
+## User-Facing Changes
+
+### New Features
+
+- **Google-Free Map Display** ([#724](https://github.com/unibrain1/elanregistry/issues/724)): Statistics and Car Details pages now use Leaflet/OpenStreetMap instead of Google Maps — no Google scripts, no tracking, and a smaller page payload (~42KB vs 150KB+).
+
+### Improvements
+
+- **Faster Car Saves** ([#796](https://github.com/unibrain1/elanregistry/issues/796)): Fixed v2.19.0 regression where FilePond re-processed all existing images on every form submit, causing slow saves even for simple text-only changes.
+
+## Admin-Facing Changes
+
+### Improvements
+
+- **Removed Google Maps API Key Setting** ([#724](https://github.com/unibrain1/elanregistry/issues/724)): Google Maps API key field and "Test Maps API Key" button removed from Admin Settings; `elan_google_maps_key` cleaned up via FIX script.
+- **Fixed Dangling Page Reference in Seed SQL** ([#799](https://github.com/unibrain1/elanregistry/issues/799)): `database/3-configuration.sql` now correctly references `tab-health.php` (page ID 306) instead of the deleted `tab-system.php`.
+- **Removed Deprecated Google Geocoding Code** ([#433](https://github.com/unibrain1/elanregistry/issues/433)): Deleted `LocationGeocoder.php` and removed deprecated `geocodeAddress()`/`applyGeocoding()` methods from `ElanRegistryOwner`; cleaned up `elan_google_geo_key` via FIX script.
+
+## Issues Resolved
+
+- [#433](https://github.com/unibrain1/elanregistry/issues/433) — CLEANUP: Remove deprecated Google Geocoding API code
+- [#724](https://github.com/unibrain1/elanregistry/issues/724) — feat: replace Google Maps with Leaflet/OpenStreetMap for all map display
+- [#796](https://github.com/unibrain1/elanregistry/issues/796) — Bug: saving a car is slow even for simple text-only changes (v2.19.0 regression)
+- [#799](https://github.com/unibrain1/elanregistry/issues/799) — bug: database/3-configuration.sql references deleted tab-system.php (page ID 306)


### PR DESCRIPTION
## Summary

- Fixes page ID 306 in `database/3-configuration.sql` which referenced the deleted `app/admin/includes/tab-system.php` (removed in v2.20.0, PR #781)
- Updated path to the replacement file `app/admin/includes/tab-health.php` and corrected the title to match the actual UI heading ("System Health Tab")

## Bug Escape Analysis

**Root cause:** `tab-system.php` was deleted in PR #781 but `database/3-configuration.sql` was not updated in the same change — a data migration oversight.

**Testing gap:** No test validates that page paths in the seed SQL correspond to files that exist on disk. The maintenance script `21-Fix-Page-Permissions.php` classifies pages by path pattern but never checks file existence.

**Preventive:** A follow-up PHPUnit test that reads all `pages` INSERT values from `3-configuration.sql` and asserts each path exists on disk would catch this class of regression.

## Test plan

- [ ] Verify `database/3-configuration.sql` contains no reference to `tab-system.php`
- [ ] Verify page ID 306 now references `tab-health.php`, which exists on disk
- [ ] Confirm role grants for page 306 (permission groups 2 and 3) are unchanged

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)