### PR TITLE
fix: add missing htmlspecialchars() to car details and account templates (#840)

### DIFF
--- a/app/cars/details.php
+++ b/app/cars/details.php
@@ -200,7 +200,7 @@ if (!empty($_GET)) {
                                         }
                                     } else {
                                         echo "<div class='text-white-50'><i class='fas fa-sign-in-alt'></i> Log in to contact owner</div>";
-                                        echo "<input type='hidden' name='car_id' id='car_id' value='" . $carData->id . "' />";
+                                        echo "<input type='hidden' name='car_id' id='car_id' value='" . htmlspecialchars((string)$carData->id, ENT_QUOTES, 'UTF-8') . "' />";
                                     }
                                     ?>
                                 </div>
@@ -305,7 +305,7 @@ if (!empty($_GET)) {
                                 <i class="fas fa-comment text-secondary"></i> Owner Comments
                             </h6>
                             <div class="bg-light p-3 rounded">
-                                <?= nl2br(htmlspecialchars($carData->comments)) ?>
+                                <?= nl2br(htmlspecialchars($carData->comments, ENT_QUOTES, 'UTF-8')) ?>
                             </div>
                             <?php } ?>
 
@@ -476,7 +476,7 @@ if (!empty($_GET)) {
                             <hr>
                             <h6 class="text-muted mb-2">Factory Notes</h6>
                             <div class="bg-light p-3 rounded">
-                                <small><?= htmlspecialchars($factoryData->note) ?></small>
+                                <small><?= htmlspecialchars($factoryData->note, ENT_QUOTES, 'UTF-8') ?></small>
                             </div>
                             <?php } ?>
                         </div>

--- a/app/cars/details.php
+++ b/app/cars/details.php
@@ -90,7 +90,7 @@ if (!empty($_GET)) {
                             <li class="breadcrumb-item"><a href="<?= $us_url_root ?>" class="text-primary"><i class="fas fa-home"></i> Home</a></li>
                             <li class="breadcrumb-item"><a href="<?= $us_url_root ?>app/cars/index.php" class="text-primary"><i class="fas fa-list"></i> Cars</a></li>
                             <li class="breadcrumb-item active text-muted" aria-current="page">
-                                <i class="fas fa-car"></i> <?= $carData->year ?> <?= $carData->series ?> 
+                                <i class="fas fa-car"></i> <?= htmlspecialchars((string)($carData->year ?? ''), ENT_QUOTES, 'UTF-8') ?> <?= htmlspecialchars($carData->series ?? '', ENT_QUOTES, 'UTF-8') ?> 
                             </li>
                         </ol>
                     </nav>
@@ -106,8 +106,8 @@ if (!empty($_GET)) {
                                 <div class="col-md-8">
                                     <h1 class="mb-0">
                                         <i class="fas fa-car me-2"></i>
-                                        <?= $carData->year ?> Lotus Elan <?= $carData->series ?>
-                                        <?= !empty($carData->variant) ? ' (' . $carData->variant . ')' : '' ?>
+                                        <?= htmlspecialchars((string)($carData->year ?? ''), ENT_QUOTES, 'UTF-8') ?> Lotus Elan <?= htmlspecialchars($carData->series ?? '', ENT_QUOTES, 'UTF-8') ?>
+                                        <?= !empty($carData->variant) ? ' (' . htmlspecialchars($carData->variant, ENT_QUOTES, 'UTF-8') . ')' : '' ?>
                                     </h1>
                                     <div class="row mt-4">
                                         <div class="col-sm-6 col-lg-3 mb-3">
@@ -124,7 +124,7 @@ if (!empty($_GET)) {
                                                 <i class="fas fa-barcode me-3 fa-lg"></i>
                                                 <div>
                                                     <div class="text-white-75 fw-medium mb-1">Chassis</div>
-                                                    <div class="fw-bold fs-5"><?= $carData->chassis ?: 'Not specified' ?></div>
+                                                    <div class="fw-bold fs-5"><?= htmlspecialchars($carData->chassis ?: 'Not specified', ENT_QUOTES, 'UTF-8') ?></div>
                                                 </div>
                                             </div>
                                         </div>
@@ -133,7 +133,7 @@ if (!empty($_GET)) {
                                                 <i class="fas fa-palette me-3 fa-lg"></i>
                                                 <div>
                                                     <div class="text-white-75 fw-medium mb-1">Color</div>
-                                                    <div class="fw-bold fs-5"><?= $carData->color ?: 'Not specified' ?></div>
+                                                    <div class="fw-bold fs-5"><?= htmlspecialchars($carData->color ?: 'Not specified', ENT_QUOTES, 'UTF-8') ?></div>
                                                 </div>
                                             </div>
                                         </div>
@@ -142,7 +142,7 @@ if (!empty($_GET)) {
                                                 <i class="fas fa-cog me-3 fa-lg"></i>
                                                 <div>
                                                     <div class="text-white-75 fw-medium mb-1">Engine</div>
-                                                    <div class="fw-bold fs-5"><?= $carData->engine ?: 'Not specified' ?></div>
+                                                    <div class="fw-bold fs-5"><?= htmlspecialchars($carData->engine ?: 'Not specified', ENT_QUOTES, 'UTF-8') ?></div>
                                                 </div>
                                             </div>
                                         </div>
@@ -224,29 +224,29 @@ if (!empty($_GET)) {
                                     <i class="fas fa-calendar text-primary"></i> Model Year
                                 </dt>
                                 <dd class="col-sm-8">
-                                    <?= $carData->year ?>
+                                    <?= htmlspecialchars((string)($carData->year ?? ''), ENT_QUOTES, 'UTF-8') ?>
                                 </dd>
                                 
                                 <dt class="col-sm-4 text-muted">
                                     <i class="fas fa-tag text-primary"></i> Series
                                 </dt>
                                 <dd class="col-sm-8">
-                                    <?= $carData->series ?>
-                                    <?= !empty($carData->variant) ? ' - ' . $carData->variant : '' ?>
+                                    <?= htmlspecialchars($carData->series ?? '', ENT_QUOTES, 'UTF-8') ?>
+                                    <?= !empty($carData->variant) ? ' - ' . htmlspecialchars($carData->variant, ENT_QUOTES, 'UTF-8') : '' ?>
                                 </dd>
                                 
                                 <dt class="col-sm-4 text-muted">
                                     <i class="fas fa-car text-primary"></i> Type
                                 </dt>
                                 <dd class="col-sm-8">
-                                    <?= $carData->type ?: '<em class="text-muted">Not specified</em>' ?>
+                                    <?= $carData->type ? htmlspecialchars($carData->type, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
                                 </dd>
                                 
                                 <dt class="col-sm-4 text-muted">
                                     <i class="fas fa-barcode text-primary"></i> Chassis
                                 </dt>
                                 <dd class="col-sm-8">
-                                    <strong><?= $carData->chassis ?: '<em class="text-muted">Not specified</em>' ?></strong>
+                                    <strong><?= $carData->chassis ? htmlspecialchars($carData->chassis, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></strong>
                                 </dd>
                             </dl>
 
@@ -259,12 +259,12 @@ if (!empty($_GET)) {
                             <dl class="row mb-4">
                                 <dt class="col-sm-4 text-muted">Color</dt>
                                 <dd class="col-sm-8">
-                                    <?= $carData->color ?: '<em class="text-muted">Not specified</em>' ?>
+                                    <?= $carData->color ? htmlspecialchars($carData->color, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
                                 </dd>
                                 
                                 <dt class="col-sm-4 text-muted">Engine</dt>
                                 <dd class="col-sm-8">
-                                    <?= $carData->engine ?: '<em class="text-muted">Not specified</em>' ?>
+                                    <?= $carData->engine ? htmlspecialchars($carData->engine, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
                                 </dd>
                             </dl>
 
@@ -289,10 +289,10 @@ if (!empty($_GET)) {
                                 </dd>
                                 <?php } ?>
                                 
-                                <?php if (!empty($carData->website)) { ?>
+                                <?php if (!empty($carData->website) && in_array(strtolower((string)parse_url($carData->website, PHP_URL_SCHEME)), ['http', 'https'], true)) { ?>
                                 <dt class="col-sm-4 text-muted">Website</dt>
                                 <dd class="col-sm-8">
-                                    <a href="<?= $carData->website ?>" target="_blank" class="btn btn-outline-primary btn-sm">
+                                    <a href="<?= htmlspecialchars($carData->website, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">
                                         <i class="fas fa-external-link-alt"></i> Visit Website
                                     </a>
                                 </dd>
@@ -347,7 +347,7 @@ if (!empty($_GET)) {
                                     <i class="fas fa-user text-primary"></i> Owner Name
                                 </dt>
                                 <dd class="col-sm-8">
-                                    <?= !empty($carData->fname) ? ucfirst($carData->fname) : '<em class="text-muted">Not specified</em>' ?>
+                                    <?= !empty($carData->fname) ? htmlspecialchars(ucfirst($carData->fname), ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
                                 </dd>
                                 
                                 <dt class="col-sm-4 text-muted">
@@ -359,7 +359,7 @@ if (!empty($_GET)) {
                                     if (!empty($carData->city)) $location[] = html_entity_decode($carData->city);
                                     if (!empty($carData->state)) $location[] = html_entity_decode($carData->state);
                                     if (!empty($carData->country)) $location[] = html_entity_decode($carData->country);
-                                    echo !empty($location) ? implode(', ', $location) : '<em class="text-muted">Location not specified</em>';
+                                    echo !empty($location) ? htmlspecialchars(implode(', ', $location), ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Location not specified</em>';
                                     ?>
                                 </dd>
                             </dl>
@@ -434,35 +434,35 @@ if (!empty($_GET)) {
                             
                             <dl class="row">
                                 <dt class="col-sm-5 text-muted">Production Year</dt>
-                                <dd class="col-sm-7"><?= $factoryData->year ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                <dd class="col-sm-7"><?= $factoryData->year ? htmlspecialchars((string)$factoryData->year, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                 
                                 <dt class="col-sm-5 text-muted">Production Month</dt>
-                                <dd class="col-sm-7"><?= $factoryData->month ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                <dd class="col-sm-7"><?= $factoryData->month ? htmlspecialchars((string)$factoryData->month, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                 
                                 <dt class="col-sm-5 text-muted">Production Batch</dt>
-                                <dd class="col-sm-7"><?= $factoryData->batch ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                <dd class="col-sm-7"><?= $factoryData->batch ? htmlspecialchars((string)$factoryData->batch, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                 
                                 <dt class="col-sm-5 text-muted">Factory Type</dt>
-                                <dd class="col-sm-7"><?= $factoryData->type ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                <dd class="col-sm-7"><?= $factoryData->type ? htmlspecialchars((string)$factoryData->type, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                 
                                 <dt class="col-sm-5 text-muted">Factory Chassis</dt>
                                 <dd class="col-sm-7">
-                                    <strong><?= $factoryData->serial ?: '<em class="text-muted">Unknown</em>' ?></strong>
+                                    <strong><?= $factoryData->serial ? htmlspecialchars((string)$factoryData->serial, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></strong>
                                 </dd>
                                 
                                 <dt class="col-sm-5 text-muted">Chassis Suffix</dt>
-                                <dd class="col-sm-7"><?= $factoryData->suffix ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                <dd class="col-sm-7"><?= $factoryData->suffix ? htmlspecialchars((string)$factoryData->suffix, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                 
                                 <dt class="col-sm-5 text-muted">Factory Engine</dt>
                                 <dd class="col-sm-7">
-                                    <?= $factoryData->engineletter ?><?= $factoryData->enginenumber ?>
+                                    <?= htmlspecialchars((string)($factoryData->engineletter ?? ''), ENT_QUOTES, 'UTF-8') ?><?= htmlspecialchars((string)($factoryData->enginenumber ?? ''), ENT_QUOTES, 'UTF-8') ?>
                                 </dd>
                                 
                                 <dt class="col-sm-5 text-muted">Gearbox</dt>
-                                <dd class="col-sm-7"><?= $factoryData->gearbox ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                <dd class="col-sm-7"><?= $factoryData->gearbox ? htmlspecialchars((string)$factoryData->gearbox, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                 
                                 <dt class="col-sm-5 text-muted">Factory Color</dt>
-                                <dd class="col-sm-7"><?= $factoryData->color ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                <dd class="col-sm-7"><?= $factoryData->color ? htmlspecialchars((string)$factoryData->color, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                 
                                 <?php if ($buildDate) { ?>
                                 <dt class="col-sm-5 text-muted">Build Date</dt>

--- a/docs/releases/RELEASE_NOTES_v2.23.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.23.0.md
@@ -31,6 +31,7 @@ The script creates a `BackupManager` snapshot of `cars`, `users`, and `profiles`
 ## Technical Changes
 
 - **`ElanRegistry\Input::raw()` storage-safe input method** ([#843](https://github.com/unibrain1/elanregistry/issues/843)): New project-owned `ElanRegistry\Input` class in `usersc/classes/Input.php` provides `Input::raw()` — a POST/GET reader that performs no HTML encoding, establishing the correct pattern for all values destined for the database. `CODING_STANDARDS.md` updated with input/output encoding guidance.
+- **Output escaping on car detail and account templates** ([#840](https://github.com/unibrain1/elanregistry/issues/840)): `htmlspecialchars(…, ENT_QUOTES, 'UTF-8')` applied to all unescaped car and factory data output points in `app/cars/details.php` and `usersc/plugins/hooker/hooks/account_bottom_hook.php` (~40 output points total). Location fields (`city`, `state`, `country`) also hardened. Website href restricted to `http`/`https` schemes only and `rel="noopener noreferrer"` added. Regression test added in `tests/playwright/car-details-output-escaping.test.js`.
 
 ## Issues Resolved
 

--- a/tests/playwright/car-details-output-escaping.test.js
+++ b/tests/playwright/car-details-output-escaping.test.js
@@ -1,0 +1,92 @@
+// tests/playwright/car-details-output-escaping.test.js
+//
+// Regression test for issue #840: missing htmlspecialchars() on car detail fields.
+//
+// Verifies that car field display areas in details.php and account_bottom_hook.php
+// render as plain text without raw HTML characters that would indicate unescaped
+// output. These fields were "accidentally safe" before the encode-at-output reform
+// because Input::sanitize() pre-encoded values at storage time.
+//
+// Requires local MAMP at http://localhost:9999/elan_registry
+
+const { test, expect } = require('@playwright/test');
+
+const DETAILS_URL = '/app/cars/details.php?car_id=1';
+
+test.describe('Car details — output escaping (issue #840)', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto(DETAILS_URL, { waitUntil: 'networkidle' });
+    });
+
+    test('page loads without XSS execution', async ({ page }) => {
+        const dialogs = [];
+        page.on('dialog', dialog => {
+            dialogs.push(dialog.message());
+            dialog.dismiss();
+        });
+
+        await page.goto(DETAILS_URL, { waitUntil: 'networkidle' });
+
+        expect(dialogs).toHaveLength(0);
+    });
+
+    test('hero quick-facts fields do not contain raw HTML tag characters', async ({ page }) => {
+        // .fw-bold.fs-5 divs inside the hero card hold chassis, color, engine, and registry ID
+        const heroFields = page.locator('.card.bg-info .fw-bold.fs-5');
+        const count = await heroFields.count();
+        expect(count).toBeGreaterThan(0);
+
+        for (let i = 0; i < count; i++) {
+            const text = await heroFields.nth(i).textContent();
+            if (text && text.trim()) {
+                expect(text).not.toMatch(/<script/i);
+                expect(text).not.toMatch(/onerror=/i);
+                expect(text).not.toContain('<img');
+            }
+        }
+    });
+
+    test('vehicle information dl/dd values do not contain injected markup', async ({ page }) => {
+        const vehicleCard = page.locator('.registry-card').first();
+        const ddElements = vehicleCard.locator('dd');
+        const count = await ddElements.count();
+
+        for (let i = 0; i < count; i++) {
+            const text = await ddElements.nth(i).textContent();
+            if (text && text.trim()) {
+                expect(text).not.toMatch(/<script/i);
+                expect(text).not.toMatch(/onerror=/i);
+            }
+        }
+    });
+
+    test('breadcrumb car title renders as plain text', async ({ page }) => {
+        const breadcrumb = page.locator('.breadcrumb-item.active');
+        await expect(breadcrumb).toBeVisible();
+
+        const text = await breadcrumb.textContent();
+        expect(text).not.toMatch(/<script/i);
+        expect(text).not.toMatch(/onerror=/i);
+    });
+
+    test('website href does not contain unescaped quotes or javascript protocol', async ({ page }) => {
+        const websiteLinks = page.locator('a:has-text("Visit Website")');
+        const count = await websiteLinks.count();
+
+        for (let i = 0; i < count; i++) {
+            const href = await websiteLinks.nth(i).getAttribute('href');
+            if (href) {
+                expect(href).not.toMatch(/javascript:/i);
+                expect(href).not.toContain('"');
+            }
+        }
+    });
+
+    test('no injected script elements inside card bodies', async ({ page }) => {
+        // Script tags inside .card-body would indicate XSS injection through car fields
+        const injectedScripts = await page.locator('.registry-card .card-body script').count();
+        expect(injectedScripts).toBe(0);
+    });
+
+});

--- a/usersc/plugins/hooker/hooks/account_bottom_hook.php
+++ b/usersc/plugins/hooker/hooks/account_bottom_hook.php
@@ -43,6 +43,8 @@ $cars = Car::findByOwner($user_id);
         } else {
             // Display cars with enhanced styling similar to details page
             foreach ($cars as $car) {
+                $carData = $car->data();
+                $factoryData = $car->factory();
             ?>
                 <!-- Car Hero Section -->
                 <div class="card registry-card bg-info text-white mb-4">
@@ -51,8 +53,8 @@ $cars = Car::findByOwner($user_id);
                             <div class="col-md-8">
                                 <h3 class="mb-0">
                                     <i class="fas fa-car me-2"></i>
-                                    <?= $car->data()->year ?> Lotus Elan <?= $car->data()->series ?>
-                                    <?= !empty($car->data()->variant) ? ' (' . $car->data()->variant . ')' : '' ?>
+                                    <?= htmlspecialchars((string)($carData->year ?? ''), ENT_QUOTES, 'UTF-8') ?> Lotus Elan <?= htmlspecialchars($carData->series ?? '', ENT_QUOTES, 'UTF-8') ?>
+                                    <?= !empty($carData->variant) ? ' (' . htmlspecialchars($carData->variant, ENT_QUOTES, 'UTF-8') . ')' : '' ?>
                                 </h3>
                                 <div class="row mt-3">
                                     <div class="col-sm-6 col-lg-3 mb-2">
@@ -60,7 +62,7 @@ $cars = Car::findByOwner($user_id);
                                             <i class="fas fa-hashtag me-3 fa-lg"></i>
                                             <div>
                                                 <div class="text-white-75 fw-medium mb-1">Registry ID</div>
-                                                <div class="fw-bold fs-5"><?= $car->data()->id ?></div>
+                                                <div class="fw-bold fs-5"><?= $carData->id ?></div>
                                             </div>
                                         </div>
                                     </div>
@@ -69,7 +71,7 @@ $cars = Car::findByOwner($user_id);
                                             <i class="fas fa-barcode me-3 fa-lg"></i>
                                             <div>
                                                 <div class="text-white-75 fw-medium mb-1">Chassis</div>
-                                                <div class="fw-bold fs-5"><?= $car->data()->chassis ?: 'Not specified' ?></div>
+                                                <div class="fw-bold fs-5"><?= htmlspecialchars($carData->chassis ?: 'Not specified', ENT_QUOTES, 'UTF-8') ?></div>
                                             </div>
                                         </div>
                                     </div>
@@ -78,7 +80,7 @@ $cars = Car::findByOwner($user_id);
                                             <i class="fas fa-palette me-3 fa-lg"></i>
                                             <div>
                                                 <div class="text-white-75 fw-medium mb-1">Color</div>
-                                                <div class="fw-bold fs-5"><?= $car->data()->color ?: 'Not specified' ?></div>
+                                                <div class="fw-bold fs-5"><?= htmlspecialchars($carData->color ?: 'Not specified', ENT_QUOTES, 'UTF-8') ?></div>
                                             </div>
                                         </div>
                                     </div>
@@ -87,7 +89,7 @@ $cars = Car::findByOwner($user_id);
                                             <i class="fas fa-cog me-3 fa-lg"></i>
                                             <div>
                                                 <div class="text-white-75 fw-medium mb-1">Engine</div>
-                                                <div class="fw-bold fs-5"><?= $car->data()->engine ?: 'Not specified' ?></div>
+                                                <div class="fw-bold fs-5"><?= htmlspecialchars($carData->engine ?: 'Not specified', ENT_QUOTES, 'UTF-8') ?></div>
                                             </div>
                                         </div>
                                     </div>
@@ -97,12 +99,12 @@ $cars = Car::findByOwner($user_id);
                                 <form method='POST' action='<?= $us_url_root ?>app/cars/form.php' class="d-inline me-2">
                                     <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
                                     <input type="hidden" name="action" value="updateCar" />
-                                    <input type="hidden" name="car_id" value="<?= $car->data()->id ?>" />
+                                    <input type="hidden" name="car_id" value="<?= $carData->id ?>" />
                                     <button class="btn btn-light btn-lg" type="submit">
                                         <i class="fas fa-edit"></i> Update Car
                                     </button>
                                 </form>
-                                <a class="btn btn-outline-light btn-lg" role="button" href="<?= $us_url_root ?>app/cars/details.php?car_id=<?= $car->data()->id ?>">
+                                <a class="btn btn-outline-light btn-lg" role="button" href="<?= $us_url_root ?>app/cars/details.php?car_id=<?= $carData->id ?>">
                                     <i class="fas fa-eye"></i> View Details
                                 </a>
                             </div>
@@ -122,23 +124,23 @@ $cars = Car::findByOwner($user_id);
                                     <dt class="col-sm-4 text-muted">
                                         <i class="fas fa-calendar text-primary"></i> Model Year
                                     </dt>
-                                    <dd class="col-sm-8"><?= $car->data()->year ?: '<em class="text-muted">Not specified</em>' ?></dd>
+                                    <dd class="col-sm-8"><?= $carData->year ? htmlspecialchars((string)$carData->year, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></dd>
                                     
                                     <dt class="col-sm-4 text-muted">
                                         <i class="fas fa-list text-primary"></i> Series
                                     </dt>
-                                    <dd class="col-sm-8"><?= $car->data()->series ?: '<em class="text-muted">Not specified</em>' ?></dd>
+                                    <dd class="col-sm-8"><?= $carData->series ? htmlspecialchars($carData->series, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></dd>
                                     
                                     <dt class="col-sm-4 text-muted">
                                         <i class="fas fa-tag text-primary"></i> Type
                                     </dt>
-                                    <dd class="col-sm-8"><?= $car->data()->type ?: '<em class="text-muted">Not specified</em>' ?></dd>
+                                    <dd class="col-sm-8"><?= $carData->type ? htmlspecialchars($carData->type, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></dd>
                                     
                                     <dt class="col-sm-4 text-muted">
                                         <i class="fas fa-barcode text-primary"></i> Chassis
                                     </dt>
                                     <dd class="col-sm-8">
-                                        <strong><?= $car->data()->chassis ?: '<em class="text-muted">Not specified</em>' ?></strong>
+                                        <strong><?= $carData->chassis ? htmlspecialchars($carData->chassis, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></strong>
                                     </dd>
                                 </dl>
 
@@ -149,42 +151,42 @@ $cars = Car::findByOwner($user_id);
                                 </h6>
                                 <dl class="row mb-4">
                                     <dt class="col-sm-4 text-muted">Color</dt>
-                                    <dd class="col-sm-8"><?= $car->data()->color ?: '<em class="text-muted">Not specified</em>' ?></dd>
+                                    <dd class="col-sm-8"><?= $carData->color ? htmlspecialchars($carData->color, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></dd>
                                     
                                     <dt class="col-sm-4 text-muted">Engine</dt>
-                                    <dd class="col-sm-8"><?= $car->data()->engine ?: '<em class="text-muted">Not specified</em>' ?></dd>
+                                    <dd class="col-sm-8"><?= $carData->engine ? htmlspecialchars($carData->engine, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></dd>
                                 </dl>
 
-                                <?php if (!empty($car->data()->purchasedate) || !empty($car->data()->solddate) || !empty($car->data()->website)) { ?>
+                                <?php if (!empty($carData->purchasedate) || !empty($carData->solddate) || !empty($carData->website)) { ?>
                                 <hr>
                                 <h6 class="text-muted mb-3">
                                     <i class="fas fa-history text-secondary"></i> Ownership & History
                                 </h6>
                                 <dl class="row mb-4">
-                                    <?php if (!empty($car->data()->purchasedate)) { ?>
+                                    <?php if (!empty($carData->purchasedate)) { ?>
                                     <dt class="col-sm-4 text-muted">Purchase Date</dt>
                                     <dd class="col-sm-8">
                                         <?php 
-                                        $purchaseDate = new DateTime($car->data()->purchasedate);
+                                        $purchaseDate = new DateTime($carData->purchasedate);
                                         echo $purchaseDate->format('F j, Y');
                                         ?>
                                     </dd>
                                     <?php } ?>
                                     
-                                    <?php if (!empty($car->data()->solddate)) { ?>
+                                    <?php if (!empty($carData->solddate)) { ?>
                                     <dt class="col-sm-4 text-muted">Sold Date</dt>
                                     <dd class="col-sm-8">
                                         <?php 
-                                        $soldDate = new DateTime($car->data()->solddate);
+                                        $soldDate = new DateTime($carData->solddate);
                                         echo $soldDate->format('F j, Y');
                                         ?>
                                     </dd>
                                     <?php } ?>
                                     
-                                    <?php if (!empty($car->data()->website)) { ?>
+                                    <?php if (!empty($carData->website) && in_array(strtolower((string)parse_url($carData->website, PHP_URL_SCHEME)), ['http', 'https'], true)) { ?>
                                     <dt class="col-sm-4 text-muted">Website</dt>
                                     <dd class="col-sm-8">
-                                        <a href="<?= $car->data()->website ?>" target="_blank" rel="noopener" class="btn btn-outline-primary btn-sm">
+                                        <a href="<?= htmlspecialchars($carData->website, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">
                                             <i class="fas fa-external-link-alt"></i> Visit Website
                                         </a>
                                     </dd>
@@ -192,13 +194,13 @@ $cars = Car::findByOwner($user_id);
                                 </dl>
                                 <?php } ?>
 
-                                <?php if (!empty($car->data()->comments)) { ?>
+                                <?php if (!empty($carData->comments)) { ?>
                                 <hr>
                                 <h6 class="text-muted mb-3">
                                     <i class="fas fa-comment text-secondary"></i> Your Comments
                                 </h6>
                                 <div class="bg-light p-3 rounded">
-                                    <?= nl2br(htmlspecialchars($car->data()->comments)) ?>
+                                    <?= nl2br(htmlspecialchars($carData->comments)) ?>
                                 </div>
                                 <?php } ?>
 
@@ -210,7 +212,7 @@ $cars = Car::findByOwner($user_id);
                                         <small class="text-muted d-block">Added to Registry</small>
                                         <strong>
                                             <?php 
-                                            $createdDate = new DateTime($car->data()->ctime);
+                                            $createdDate = new DateTime($carData->ctime);
                                             echo $createdDate->format('M j, Y');
                                             ?>
                                         </strong>
@@ -220,7 +222,7 @@ $cars = Car::findByOwner($user_id);
                                         <small class="text-muted d-block">Last Updated</small>
                                         <strong>
                                             <?php 
-                                            $modifiedDate = new DateTime($car->data()->mtime);
+                                            $modifiedDate = new DateTime($carData->mtime);
                                             echo $modifiedDate->format('M j, Y');
                                             ?>
                                         </strong>
@@ -241,7 +243,7 @@ $cars = Car::findByOwner($user_id);
                             </div>
                         </div>
                         <!-- Factory Data Card -->
-                        <?php if (!is_null($car->factory())) { ?>
+                        <?php if (!is_null($factoryData)) { ?>
                         <div class="card registry-card">
                             <div class="card-header">
                                 <h4 class="mb-0">
@@ -257,41 +259,41 @@ $cars = Car::findByOwner($user_id);
                                 
                                 <dl class="row">
                                     <dt class="col-sm-5 text-muted">Production Year</dt>
-                                    <dd class="col-sm-7"><?= $car->factory()->year ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                    <dd class="col-sm-7"><?= $factoryData->year ? htmlspecialchars((string)$factoryData->year, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                     
                                     <dt class="col-sm-5 text-muted">Production Month</dt>
-                                    <dd class="col-sm-7"><?= $car->factory()->month ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                    <dd class="col-sm-7"><?= $factoryData->month ? htmlspecialchars((string)$factoryData->month, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                     
                                     <dt class="col-sm-5 text-muted">Production Batch</dt>
-                                    <dd class="col-sm-7"><?= $car->factory()->batch ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                    <dd class="col-sm-7"><?= $factoryData->batch ? htmlspecialchars((string)$factoryData->batch, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                     
                                     <dt class="col-sm-5 text-muted">Factory Type</dt>
-                                    <dd class="col-sm-7"><?= $car->factory()->type ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                    <dd class="col-sm-7"><?= $factoryData->type ? htmlspecialchars((string)$factoryData->type, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                     
                                     <dt class="col-sm-5 text-muted">Factory Chassis</dt>
                                     <dd class="col-sm-7">
-                                        <strong><?= $car->factory()->serial ?: '<em class="text-muted">Unknown</em>' ?></strong>
+                                        <strong><?= $factoryData->serial ? htmlspecialchars((string)$factoryData->serial, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></strong>
                                     </dd>
                                     
                                     <dt class="col-sm-5 text-muted">Chassis Suffix</dt>
-                                    <dd class="col-sm-7"><?= $car->factory()->suffix ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                    <dd class="col-sm-7"><?= $factoryData->suffix ? htmlspecialchars((string)$factoryData->suffix, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                     
                                     <dt class="col-sm-5 text-muted">Factory Engine</dt>
                                     <dd class="col-sm-7">
-                                        <?= $car->factory()->engineletter ?><?= $car->factory()->enginenumber ?>
+                                        <?= htmlspecialchars((string)($factoryData->engineletter ?? ''), ENT_QUOTES, 'UTF-8') ?><?= htmlspecialchars((string)($factoryData->enginenumber ?? ''), ENT_QUOTES, 'UTF-8') ?>
                                     </dd>
                                     
                                     <dt class="col-sm-5 text-muted">Gearbox</dt>
-                                    <dd class="col-sm-7"><?= $car->factory()->gearbox ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                    <dd class="col-sm-7"><?= $factoryData->gearbox ? htmlspecialchars((string)$factoryData->gearbox, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                     
                                     <dt class="col-sm-5 text-muted">Factory Color</dt>
-                                    <dd class="col-sm-7"><?= $car->factory()->color ?: '<em class="text-muted">Unknown</em>' ?></dd>
+                                    <dd class="col-sm-7"><?= $factoryData->color ? htmlspecialchars((string)$factoryData->color, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
                                     
                                     <dt class="col-sm-5 text-muted">Build Date</dt>
                                     <dd class="col-sm-7">
                                         <?php 
-                                        if ($car->factory()->builddate) {
-                                            $buildDate = new DateTime($car->factory()->builddate);
+                                        if ($factoryData->builddate) {
+                                            $buildDate = new DateTime($factoryData->builddate);
                                             echo $buildDate->format('F j, Y');
                                         } else {
                                             echo '<em class="text-muted">Unknown</em>';
@@ -299,9 +301,9 @@ $cars = Car::findByOwner($user_id);
                                         ?>
                                     </dd>
                                     
-                                    <?php if (!empty($car->factory()->note)) { ?>
+                                    <?php if (!empty($factoryData->note)) { ?>
                                     <dt class="col-sm-5 text-muted">Notes</dt>
-                                    <dd class="col-sm-7"><?= htmlspecialchars($car->factory()->note) ?></dd>
+                                    <dd class="col-sm-7"><?= htmlspecialchars($factoryData->note) ?></dd>
                                     <?php } ?>
                                 </dl>
                             </div>

--- a/usersc/plugins/hooker/hooks/account_bottom_hook.php
+++ b/usersc/plugins/hooker/hooks/account_bottom_hook.php
@@ -200,7 +200,7 @@ $cars = Car::findByOwner($user_id);
                                     <i class="fas fa-comment text-secondary"></i> Your Comments
                                 </h6>
                                 <div class="bg-light p-3 rounded">
-                                    <?= nl2br(htmlspecialchars($carData->comments)) ?>
+                                    <?= nl2br(htmlspecialchars($carData->comments, ENT_QUOTES, 'UTF-8')) ?>
                                 </div>
                                 <?php } ?>
 
@@ -303,7 +303,7 @@ $cars = Car::findByOwner($user_id);
                                     
                                     <?php if (!empty($factoryData->note)) { ?>
                                     <dt class="col-sm-5 text-muted">Notes</dt>
-                                    <dd class="col-sm-7"><?= htmlspecialchars($factoryData->note) ?></dd>
+                                    <dd class="col-sm-7"><?= htmlspecialchars($factoryData->note, ENT_QUOTES, 'UTF-8') ?></dd>
                                     <?php } ?>
                                 </dl>
                             </div>


### PR DESCRIPTION
## Summary

- Apply `htmlspecialchars(…, ENT_QUOTES, 'UTF-8')` to all previously unescaped car and factory data output points in `app/cars/details.php` and `usersc/plugins/hooker/hooks/account_bottom_hook.php` (~23 output points each)
- Split ternaries where the fallback contains intentional HTML markup (`<em class="text-muted">…</em>`) so the `<em>` is preserved unescaped
- Harden website `href` with `http`/`https` protocol allowlist via `parse_url` + `in_array`; add `rel="noopener noreferrer"` on `target="_blank"` links
- Cache `$car->data()` and `$car->factory()` per loop iteration in `account_bottom_hook.php` for clarity (matches `details.php` pattern)
- Add Playwright regression test `tests/playwright/car-details-output-escaping.test.js`

## Bug Escape Analysis

**Root cause:** Incomplete migration to encode-at-output during v2.23.0 reform. `details.php` already escaped `comments` and `factoryData->note`, creating false confidence that all fields were handled. The remaining ~23 output points were "accidentally safe" because `Input::sanitize()` pre-encoded values at storage time — once #838 corrects storage to plain text, every unescaped point becomes an XSS vector.

**Testing gap:** Existing tests covered navigation, UI consistency, CSP, and maps but none verified `htmlspecialchars()` at render time.

**Prevention:** Playwright smoke test added; comprehensive fixture-based special-character tests belong to issue #844.

## Test plan

- [ ] Load car details page — verify no double-encoding of plain ASCII values
- [ ] Run `composer check:php` — PHPStan and phpcs pass
- [ ] Run `npm run playwright:test` — new test passes
- [ ] Visually inspect details page — fields render identically to before

Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)