### PR TITLE
fix: prevent double-encoding of owner comments on save (#838)

### DIFF
--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -516,8 +516,9 @@ function updateComments(array &$cardetails): void
     global $successes, $chassis_override_used;
     
     // Update 'comments'
-    if (Input::get('comments')) {
-        $cardetails['comments'] = Input::get('comments');
+    $comments = \ElanRegistry\Input::raw('comments');
+    if ($comments !== null && $comments !== '') {
+        $cardetails['comments'] = $comments;
         $successes[] = 'Comments: Updated';
     } else {
         $cardetails['comments'] = null;

--- a/tests/playwright/car-edit-text-save.test.js
+++ b/tests/playwright/car-edit-text-save.test.js
@@ -498,6 +498,234 @@ test.describe('Car edit form — text-only save (regression #796)', () => {
     });
 
     // -----------------------------------------------------------------------
+    // Regression test for issue #838: owner comments double-encoded on save.
+    //
+    // Before the fix, updateComments() called \Input::get('comments') which
+    // runs htmlspecialchars() on the raw POST value.  Special characters like
+    // é, ´, &, ñ were stored as &eacute;, &#039;, &amp;, &ntilde; in the DB.
+    // The display layer then ran htmlspecialchars() again at render time,
+    // producing literal entity text visible to users.
+    //
+    // After the fix, updateComments() calls ElanRegistry\Input::raw('comments')
+    // which returns the decoded POST value without any HTML encoding.
+    //
+    // This test verifies two things:
+    //   A. The captured POST body `comments` field equals the raw Unicode string
+    //      (no HTML entities in what is transmitted to the server).
+    //   B. When the server responds with the same plain-text value (simulating
+    //      the stored and then returned DB row), the textarea displays the
+    //      unencoded Unicode characters — not entity strings like &amp;#180;s.
+    // -----------------------------------------------------------------------
+    test('comments with special characters save and reload as plain text', async ({ page }) => {
+        const SPECIAL_CHARS_INPUT = "it´s original registration — é & ñ";
+
+        // ------------------------------------------------------------------
+        // 1. Mock fetchImages (empty pond — not relevant to this test) and
+        //    capture the form-submit POST.
+        // ------------------------------------------------------------------
+        await page.route('**/app/cars/actions/edit.php', async (route, request) => {
+            const postData = request.postData() || '';
+            if (postData.includes('action=fetchImages')) {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ success: true, images: [] })
+                });
+                return;
+            }
+            await route.fallback();
+        });
+
+        // ------------------------------------------------------------------
+        // 2. Navigate to the car edit form (car 650 from the bug report).
+        //    The PHP page renders server-side; we only mock the JS API calls.
+        // ------------------------------------------------------------------
+        await page.goto('app/cars/form.php?car_id=650', { waitUntil: 'domcontentloaded' });
+
+        const currentUrl = page.url();
+        if (currentUrl.includes('login') || currentUrl.includes('Please Log In')) {
+            test.skip('Session not established — skipping special-characters regression test');
+            return;
+        }
+
+        // Wait for FilePond to initialise (confirms the full form JS has loaded)
+        await page.waitForFunction(
+            () => typeof window.FilePond !== 'undefined' && document.querySelector('.filepond--root') !== null,
+            { timeout: 15000 }
+        );
+
+        // Verify the comments textarea rendered in the DOM
+        const commentsTextarea = page.locator('#comments');
+        const textareaVisible = await commentsTextarea.isVisible().catch(() => false);
+        if (!textareaVisible) {
+            test.skip('Comments textarea not found — form did not render (DB unavailable or car not found)');
+            return;
+        }
+
+        // ------------------------------------------------------------------
+        // 3. Fill the comments textarea with the special-character string and
+        //    register a higher-priority route (LIFO) that:
+        //      - Captures the raw POST body for Assertion A
+        //      - Returns a mocked cardetails response that echoes the same
+        //        plain-text value back (simulating the fixed DB round-trip)
+        //        for Assertion B.
+        // ------------------------------------------------------------------
+        await commentsTextarea.fill(SPECIAL_CHARS_INPUT);
+
+        let capturedComments = null;
+
+        await page.route('**/app/cars/actions/edit.php', async (route, request) => {
+            if (request.method() === 'POST') {
+                const postData = request.postData() || '';
+                if (!postData.includes('action=fetchImages') && !postData.includes('action=removeImages')) {
+                    // Parse multipart to extract the comments text field.
+                    // Fail loudly if Content-Type or postDataBuffer() is unexpected —
+                    // silent nulls here would produce a misleading 8s timeout below.
+                    const contentType = request.headers()['content-type'] || '';
+                    const boundaryMatch = contentType.match(/boundary=([^\s;]+)/);
+                    if (!boundaryMatch) {
+                        throw new Error(
+                            `[car-edit-text-save #838] Expected multipart/form-data but got: "${contentType}". ` +
+                            'Did the JS submit mechanism change?'
+                        );
+                    }
+                    const bodyBuffer = request.postDataBuffer();
+                    if (!bodyBuffer) {
+                        throw new Error(
+                            '[car-edit-text-save #838] request.postDataBuffer() returned null — ' +
+                            'Playwright could not retain the POST body.'
+                        );
+                    }
+                    const fields = parseMultipart(bodyBuffer, boundaryMatch[1]);
+                    const commentsEntries = fields.get('comments');
+                    if (commentsEntries && commentsEntries.length > 0) {
+                        capturedComments = commentsEntries[0].value;
+                    }
+
+                    // Return a mocked success response that echoes the unencoded
+                    // plain-text comments back as the server would after the fix.
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify({
+                            success: true,
+                            cardetails: {
+                                id: 650,
+                                comments: SPECIAL_CHARS_INPUT
+                            }
+                        })
+                    });
+                    return;
+                }
+            }
+            await route.fallback();
+        });
+
+        // ------------------------------------------------------------------
+        // 4. Click submit to trigger the form save.
+        // ------------------------------------------------------------------
+        const submitBtn = page.locator('#submit');
+        const submitVisible = await submitBtn.isVisible().catch(() => false);
+        if (!submitVisible) {
+            test.skip('Submit button not found — form did not render');
+            return;
+        }
+
+        await submitBtn.click();
+
+        // Poll for the captured POST body (up to 8 seconds)
+        const deadline = Date.now() + 8000;
+        while (capturedComments === null && Date.now() < deadline) {
+            await page.waitForTimeout(100);
+        }
+
+        // ------------------------------------------------------------------
+        // 5. Assertion A: the POST body transmitted the raw Unicode string,
+        //    not HTML-encoded entities.
+        //    Before the fix the browser FormData would still send the raw
+        //    value (encoding happens server-side), so this assertion confirms
+        //    the client is not pre-encoding the value.  It also serves as a
+        //    baseline that our multipart parser correctly reads text fields.
+        // ------------------------------------------------------------------
+        expect(
+            capturedComments,
+            'POST body must contain the comments field — was the form submitted?'
+        ).not.toBeNull();
+
+        // Ensure none of the common entity patterns produced by htmlspecialchars()
+        // appear in the transmitted value.  If they do, something is encoding
+        // before the POST (not the expected server-side regression, but still wrong).
+        expect(
+            capturedComments,
+            'POST comments must not contain HTML entity &amp; — value should be raw Unicode'
+        ).not.toContain('&amp;');
+
+        expect(
+            capturedComments,
+            'POST comments must not contain HTML entity &#039; — value should be raw Unicode'
+        ).not.toContain('&#039;');
+
+        expect(
+            capturedComments,
+            'POST comments must not contain HTML entity &eacute; — value should be raw Unicode'
+        ).not.toContain('&eacute;');
+
+        expect(
+            capturedComments,
+            'POST comments must not contain HTML entity &ntilde; — value should be raw Unicode'
+        ).not.toContain('&ntilde;');
+
+        // The exact raw Unicode string must be present
+        expect(
+            capturedComments,
+            'POST comments must equal the raw Unicode input exactly (regression #838)'
+        ).toBe(SPECIAL_CHARS_INPUT);
+
+        // ------------------------------------------------------------------
+        // 6. Assertion B: after the mocked server response, submitCarForm()
+        //    calls $('#comments').val(data.cardetails.comments) with the
+        //    plain-text value returned by the server.  The textarea must show
+        //    the same unencoded string — not entity-escaped text like
+        //    "it&amp;#180;s..." that would appear if the server returned a
+        //    double-encoded value and jQuery set it verbatim into the DOM.
+        // ------------------------------------------------------------------
+
+        // Wait for submitCarForm() to process the mock response and update the textarea.
+        // The JS path is: fetch → response.json() → $('#comments').val(data.cardetails.comments).
+        // We poll the textarea value until it changes or the timeout expires.
+        await page.waitForFunction(
+            (expected) => {
+                const el = document.getElementById('comments');
+                return el && el.value === expected;
+            },
+            SPECIAL_CHARS_INPUT,
+            { timeout: 5000 }
+        ).catch((err) => {
+            // Only swallow TimeoutError — the assertion below produces the clear failure message.
+            // Any other error (navigation, crashed page) should propagate immediately.
+            if (err.constructor.name !== 'TimeoutError') { throw err; }
+        });
+
+        const textareaValue = await commentsTextarea.inputValue();
+
+        expect(
+            textareaValue,
+            'Textarea must NOT display HTML entities after reload ' +
+            '(regression #838: double-encoding would show &amp;#180;s instead of ´s)'
+        ).not.toContain('&amp;');
+
+        expect(
+            textareaValue,
+            'Textarea must NOT display the HTML entity &#039; after reload (regression #838)'
+        ).not.toContain('&#039;');
+
+        expect(
+            textareaValue,
+            'Textarea must display the raw Unicode string after mock server response (regression #838)'
+        ).toBe(SPECIAL_CHARS_INPUT);
+    });
+
+    // -----------------------------------------------------------------------
     // Mixed scenario: one existing (LOCAL) image + one new upload.
     // This is the most common real-world path: adding a photo to a car that
     // already has images. Verifies that:

--- a/tests/regression/Issue838RegressionTest.php
+++ b/tests/regression/Issue838RegressionTest.php
@@ -72,6 +72,24 @@ final class Issue838RegressionTest extends TestCase
     }
 
     /**
+     * A comment consisting solely of "0" must not be silently discarded.
+     *
+     * The fix changed the empty-value guard from a truthy check (where PHP treats
+     * "0" as falsy) to an explicit !== null && !== '' check. This verifies "0"
+     * is preserved as a non-empty comment value.
+     */
+    public function testLiteralZeroCommentIsNotDiscarded(): void
+    {
+        $_POST['comments'] = '0';
+
+        $result = Input::raw('comments');
+
+        $this->assertSame('0', $result, 'Input::raw() must return "0" unchanged');
+        $this->assertNotNull($result, '"0" must not be treated as absent');
+        $this->assertNotSame('', $result, '"0" must pass the !== "" guard in updateComments()');
+    }
+
+    /**
      * Re-saving a value retrieved via Input::raw() must not accumulate encoding.
      *
      * The upstream \Input::get() bug caused double-encoding: first save wrote

--- a/tests/regression/Issue838RegressionTest.php
+++ b/tests/regression/Issue838RegressionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use ElanRegistry\Input;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for Issue #838: owner comments double-encoded on save
+ *
+ * Ensures ElanRegistry\Input::raw() returns unencoded values so that special
+ * characters stored via updateComments() are not HTML-encoded in the database,
+ * preventing double-encoding at the display layer.
+ *
+ * @issue 838
+ * @link https://github.com/unibrain1/elanregistry/issues/838
+ * @category regression
+ *
+ * Root cause: updateComments() previously called \Input::get('comments') (upstream
+ * UserSpice), which applies htmlspecialchars() before returning. The database
+ * therefore stored already-encoded text. details.php:308 re-applied
+ * htmlspecialchars() at render time, producing visible entity strings like
+ * &amp;amp; for users.
+ *
+ * Fix: switched to \ElanRegistry\Input::raw('comments'), which returns the
+ * unencoded scalar value. htmlspecialchars() is applied only at the output
+ * (display) layer, where it belongs.
+ */
+final class Issue838RegressionTest extends TestCase
+{
+    /** @var array<string, mixed> Original $_POST state saved before each test */
+    private array $originalPost = [];
+
+    /** @var array<string, mixed> Original $_GET state saved before each test */
+    private array $originalGet = [];
+
+    protected function setUp(): void
+    {
+        $this->originalPost = $_POST;
+        $this->originalGet  = $_GET;
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST = $this->originalPost;
+        $_GET  = $this->originalGet;
+    }
+
+    /**
+     * Input::raw() must return the literal value without HTML-encoding any characters.
+     *
+     * Verifies that the fix (using Input::raw() instead of \Input::get()) prevents
+     * htmlspecialchars() from being applied to data before it reaches the database.
+     */
+    public function testRawInputDoesNotEncodeSpecialCharacters(): void
+    {
+        $original = "O'Brien & Co élan ñoño";
+
+        $_POST['comments'] = $original;
+
+        $result = Input::raw('comments');
+
+        $this->assertSame(
+            $original,
+            $result,
+            'Input::raw() must return the value unchanged — no &amp; or &#039; encoding'
+        );
+
+        // Confirm the two entities htmlspecialchars() would produce for & and ' are absent
+        $this->assertStringNotContainsString('&amp;', (string) $result, 'Ampersand must not be entity-encoded');
+        $this->assertStringNotContainsString('&#039;', (string) $result, 'Single-quote must not be entity-encoded');
+    }
+
+    /**
+     * Re-saving a value retrieved via Input::raw() must not accumulate encoding.
+     *
+     * The upstream \Input::get() bug caused double-encoding: first save wrote
+     * "&amp;" to the database; a second save (read → store → read) would then
+     * write "&amp;amp;". Input::raw() must be idempotent across round-trips.
+     */
+    public function testRawInputIsIdempotentOnResave(): void
+    {
+        $original = "Tom & Jerry's café — \"special\" édition";
+
+        // First save: simulate user submitting the form
+        $_POST['comments'] = $original;
+        $firstSave = Input::raw('comments');
+
+        // Second save: simulate re-saving the stored value (e.g. edit-without-change)
+        $_POST['comments'] = $firstSave;
+        $secondSave = Input::raw('comments');
+
+        $this->assertSame(
+            $firstSave,
+            $secondSave,
+            'Input::raw() must be idempotent — no additional encoding accumulates on re-save'
+        );
+
+        // Both round-trips must also equal the original input
+        $this->assertSame($original, $firstSave, 'First save must equal original input');
+        $this->assertSame($original, $secondSave, 'Second save must equal original input');
+    }
+
+    /**
+     * XSS vectors stored via Input::raw() are properly escaped only at render time.
+     *
+     * Demonstrates the correct single-encoding pattern: store raw in the database,
+     * apply htmlspecialchars() at the HTML output layer. A <script> tag must reach
+     * the database intact but be neutralised when rendered.
+     */
+    public function testXssInputEscapedCorrectlyAtDisplayLayer(): void
+    {
+        $xssPayload = '<script>alert(1)</script>';
+
+        $_POST['comments'] = $xssPayload;
+        $stored = Input::raw('comments');
+
+        // The raw stored value must still contain the tag (not pre-encoded)
+        $this->assertSame(
+            $xssPayload,
+            $stored,
+            'Input::raw() must not encode the payload before storage'
+        );
+
+        // Display layer applies htmlspecialchars() exactly once
+        $rendered = htmlspecialchars((string) $stored, ENT_QUOTES, 'UTF-8');
+
+        $this->assertStringNotContainsString(
+            '<script>',
+            $rendered,
+            'Rendered output must not contain a literal <script> tag'
+        );
+
+        $this->assertStringContainsString(
+            '&lt;script&gt;',
+            $rendered,
+            'Rendered output must contain the properly escaped entity &lt;script&gt;'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Switches `updateComments()` in `app/cars/actions/edit.php` from upstream `\Input::get('comments')` (which applies `htmlspecialchars()` before returning) to `\ElanRegistry\Input::raw('comments')`, so the database receives unencoded plain text.
- Tightens the empty-value guard from a truthy check to `!== null && !== ''` so a literal `"0"` comment is not silently nulled out.
- Adds PHPUnit regression test (`tests/regression/Issue838RegressionTest.php`) with three cases: encode-correctness, idempotent re-save, and XSS-at-display-layer.
- Extends `tests/playwright/car-edit-text-save.test.js` with a special-character round-trip test for car 650 (the known triple-encoded record).

## Bug escape analysis

- **Root cause:** `updateComments()` used `\Input::get()` which was established before `ElanRegistry\Input::raw()` existed (introduced in #843). No enforcement mechanism required the raw reader for DB writes.
- **Testing gap:** No round-trip integration test existed for the comments field; the Playwright test covered file uploads only.
- **Preventive:** PHPUnit regression test covers idempotent re-save (prevents `&amp;amp;` accumulation) and XSS-at-display-layer contract; Playwright test verifies the browser-level round-trip with accented characters and symbols.

## Out of scope

- Other car text fields (model, chassis, color, engine, website, dates) — covered by #841.
- Data migration for existing triple-encoded rows — handled by #847.
- `users/classes/input.php` (upstream UserSpice) — never modified.

## Test plan

- [x] `composer test:quick` — 901 tests pass
- [ ] Playwright test requires local MAMP at `localhost:9999`; skips gracefully when DB unavailable
- [ ] After #847 migration: verify `SELECT comments FROM cars WHERE id = 650` shows decoded plain text
- [ ] Manual: save a car with `é`, `'`, `&` in comments → reload → confirm textarea shows plain text, not `&eacute;` or `&#039;`

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)