### PR TITLE
fix: extend Input::raw() storage fix to all car text fields (#841)

### DIFF
--- a/app/admin/verify/_email_template.php
+++ b/app/admin/verify/_email_template.php
@@ -155,7 +155,7 @@
             </tr>
             <tr>
                 <td>Chassis</td>
-                <td><?= $car->chassis ?>
+                <td><?= htmlspecialchars((string)($car->chassis ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>
@@ -170,7 +170,7 @@
             </tr>
             <tr>
                 <td>Color</td>
-                <td><?= $car->color ?>
+                <td><?= htmlspecialchars((string)($car->color ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>
@@ -185,7 +185,7 @@
             </tr>
             <tr>
                 <td>Comment</td>
-                <td><?= $car->comments ?>
+                <td><?= htmlspecialchars((string)($car->comments ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>
@@ -197,7 +197,7 @@
                 <td>Website</td>
                 <?php
                 if (!empty($car->website)) {
-                    echo '<td> <a target="_blank" href="' . $car->website . '">Website</a></td>';
+                    echo '<td> <a target="_blank" href="' . htmlspecialchars((string)$car->website, ENT_QUOTES, 'UTF-8') . '">Website</a></td>';
                 } else {
                     echo "<td></td>";
                 }

--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -375,13 +375,12 @@ function updateChassis(array &$cardetails): void
     
     // Check if validation override is enabled
     // Checkbox only sends value when checked, so check if parameter exists and has value '1'
-    $chassisOverrideRaw = Input::get('chassis_override');
+    $chassisOverrideRaw = \ElanRegistry\Input::raw('chassis_override');
     $chassisOverride = ($chassisOverrideRaw === '1');
-    
-    // Update 'chassis'
-    if (Input::get('chassis')) {
-        $cardetails['chassis'] = Input::get('chassis');
-        $chassis = $cardetails['chassis'];
+
+    $chassis = \ElanRegistry\Input::raw('chassis');
+    if ($chassis !== null && $chassis !== '') {
+        $cardetails['chassis'] = $chassis;
         $year = (int)$cardetails['year'];
         $model = $cardetails['model']; // Contains series|variant|type format
         
@@ -401,13 +400,17 @@ function updateChassis(array &$cardetails): void
         } catch (ElanRegistryException $e) {
             $errors[] = 'Chassis validation error: ' . $e->getUserMessage();
             return;
+        } catch (\Throwable $e) {
+            logger($user->data()->id, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Unexpected ChassisValidator error for chassis "' . $chassis . '": ' . $e->getMessage());
+            $errors[] = 'An unexpected error occurred validating the chassis number. Please try again.';
+            return;
         }
         
         // Handle validation result
         if ($result['valid'] && !$result['override_used']) {
-            $successes[] = 'Chassis: ' . $cardetails['chassis'];
+            $successes[] = 'Chassis: ' . htmlspecialchars($cardetails['chassis'], ENT_QUOTES, 'UTF-8');
         } elseif ($result['valid'] && $result['override_used']) {
-            $successes[] = 'Chassis: ' . $cardetails['chassis'] . ' (Override used)';
+            $successes[] = 'Chassis: ' . htmlspecialchars($cardetails['chassis'], ENT_QUOTES, 'UTF-8') . ' (Override used)';
             $chassis_override_used = true; // Track that override was used for comments
         } else {
             $errors[] = '<strong>ERROR:</strong> Chassis Validation Failed: ' . $result['error_reason'];
@@ -425,10 +428,10 @@ function updateChassis(array &$cardetails): void
  */
 function updateColor(array &$cardetails): void
 {
-    // Update 'color'
-    if (Input::get('color')) {
-        $cardetails['color'] = Input::get('color');
-        $successes[] = 'Color: ' . $cardetails['color'];
+    $color = \ElanRegistry\Input::raw('color');
+    if ($color !== null && $color !== '') {
+        $cardetails['color'] = $color;
+        $successes[] = 'Color: ' . htmlspecialchars($color, ENT_QUOTES, 'UTF-8');
     } else {
         $cardetails['color'] = null;
     }
@@ -442,11 +445,10 @@ function updateColor(array &$cardetails): void
  */
 function updateEngine(array &$cardetails): void
 {
-    // Update 'engine'
-    if (Input::get('engine')) {
-        $cardetails['engine'] = Input::get('engine');
-        $cardetails['engine'] = str_replace(" ", "", strtoupper(trim($cardetails['engine'])));
-        $successes[] = 'Engine: ' . $cardetails['engine'];
+    $engine = \ElanRegistry\Input::raw('engine');
+    if ($engine !== null && $engine !== '') {
+        $cardetails['engine'] = str_replace(" ", "", strtoupper(trim($engine)));
+        $successes[] = 'Engine: ' . htmlspecialchars($cardetails['engine'], ENT_QUOTES, 'UTF-8');
     } else {
         $cardetails['engine'] = null;
     }
@@ -496,10 +498,10 @@ function updateSolddate(array &$cardetails): void
  */
 function updateWebsite(array &$cardetails): void
 {
-    // Update 'website'
-    if (Input::get('website')) {
-        $cardetails['website'] = Input::get('website');
-        $successes[] = 'Website: ' . $cardetails['website'];
+    $website = \ElanRegistry\Input::raw('website');
+    if ($website !== null && $website !== '') {
+        $cardetails['website'] = $website;
+        $successes[] = 'Website: ' . htmlspecialchars($website, ENT_QUOTES, 'UTF-8');
     } else {
         $cardetails['website'] = null;
     }

--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -401,7 +401,7 @@ function updateChassis(array &$cardetails): void
             $errors[] = 'Chassis validation error: ' . $e->getUserMessage();
             return;
         } catch (\Throwable $e) {
-            logger($user->data()->id, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Unexpected ChassisValidator error for chassis "' . $chassis . '": ' . $e->getMessage());
+            logger($user->data()->id, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Unexpected ChassisValidator error for chassis "' . htmlspecialchars($chassis, ENT_QUOTES, 'UTF-8') . '": ' . $e->getMessage());
             $errors[] = 'An unexpected error occurred validating the chassis number. Please try again.';
             return;
         }

--- a/tests/regression/Issue841RegressionTest.php
+++ b/tests/regression/Issue841RegressionTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+use ElanRegistry\Input;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for Issue #841: car text fields double-encoded on save
+ *
+ * Extends the coverage from Issue838RegressionTest (comments field) to the
+ * remaining four free-text car fields: color, engine, website, and chassis.
+ * All four were previously stored via \Input::get(), which applies htmlspecialchars()
+ * before returning. This PR switched them to \ElanRegistry\Input::raw() so that
+ * special characters are preserved in the database and escaped only at render time.
+ *
+ * @issue 841
+ * @link https://github.com/unibrain1/elanregistry/issues/841
+ * @category regression
+ *
+ * Root cause: updateColor(), updateEngine(), updateWebsite(), and updateChassis()
+ * in app/cars/actions/edit.php called \Input::get() (upstream UserSpice), which
+ * applies htmlspecialchars() before returning. Values like "O'Brien Blue" were
+ * stored as "O&#039;Brien Blue", and re-saved values accumulated additional encoding.
+ *
+ * Fix: switched all four functions to \ElanRegistry\Input::raw(), which returns
+ * the unencoded scalar value. htmlspecialchars() is applied only at the output
+ * (display) layer, where it belongs.
+ */
+final class Issue841RegressionTest extends TestCase
+{
+    /** @var array<string, mixed> Original $_POST state saved before each test */
+    private array $originalPost = [];
+
+    /** @var array<string, mixed> Original $_GET state saved before each test */
+    private array $originalGet = [];
+
+    protected function setUp(): void
+    {
+        $this->originalPost = $_POST;
+        $this->originalGet  = $_GET;
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST = $this->originalPost;
+        $_GET  = $this->originalGet;
+    }
+
+    /**
+     * Input::raw() must return literal values for all four fields without HTML-encoding.
+     *
+     * @dataProvider specialCharacterFieldProvider
+     */
+    public function testRawInputDoesNotEncodeSpecialCharacters(string $field, string $value): void
+    {
+        $_POST[$field] = $value;
+
+        $result = Input::raw($field);
+
+        $this->assertSame(
+            $value,
+            $result,
+            "Input::raw('{$field}') must return the value unchanged — no &amp; or &#039; encoding"
+        );
+
+        $this->assertStringNotContainsString('&amp;', (string) $result, "Ampersand in {$field} must not be entity-encoded");
+        $this->assertStringNotContainsString('&#039;', (string) $result, "Single-quote in {$field} must not be entity-encoded");
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function specialCharacterFieldProvider(): array
+    {
+        return [
+            'color with apostrophe'  => ['color',   "O'Brien Blue"],
+            'color with ampersand'   => ['color',   "Lagoon Blue & Grey"],
+            'engine with ampersand'  => ['engine',  "Twin Cam & 1558cc"],
+            'engine with angle bracket' => ['engine', "1558cc <rebuilt>"],
+            'website with ampersand' => ['website', "https://example.com/cars?a=1&b=2"],
+            'chassis with angle bracket' => ['chassis', "26R<001"],
+        ];
+    }
+
+    /**
+     * A literal "0" value must not be silently discarded for any of the four fields.
+     *
+     * The updater functions changed from a truthy guard (where PHP treats "0" as falsy)
+     * to an explicit !== null && !== '' check. This verifies "0" is treated as a valid value.
+     *
+     * @dataProvider zeroValueFieldProvider
+     */
+    public function testLiteralZeroIsNotDiscarded(string $field): void
+    {
+        $_POST[$field] = '0';
+
+        $result = Input::raw($field);
+
+        $this->assertSame('0', $result, "Input::raw('{$field}') must return \"0\" unchanged");
+        $this->assertNotNull($result, '"0" must not be treated as absent');
+        $this->assertNotSame('', $result, "\"0\" must pass the !== \"\" guard in update" . ucfirst($field) . "()");
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function zeroValueFieldProvider(): array
+    {
+        return [
+            'color'   => ['color'],
+            'engine'  => ['engine'],
+            'website' => ['website'],
+            'chassis' => ['chassis'],
+        ];
+    }
+
+    /**
+     * Re-saving a value retrieved via Input::raw() must not accumulate encoding.
+     *
+     * @dataProvider idempotencyFieldProvider
+     */
+    public function testRawInputIsIdempotentOnResave(string $field, string $value): void
+    {
+        $_POST[$field] = $value;
+        $firstSave = Input::raw($field);
+
+        $_POST[$field] = $firstSave;
+        $secondSave = Input::raw($field);
+
+        $this->assertSame(
+            $firstSave,
+            $secondSave,
+            "Input::raw('{$field}') must be idempotent — no additional encoding accumulates on re-save"
+        );
+        $this->assertSame($value, $firstSave, "First save of {$field} must equal original input");
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function idempotencyFieldProvider(): array
+    {
+        return [
+            'color'   => ['color',   "O'Brien Blue & something"],
+            'engine'  => ['engine',  "Twin Cam & 1558cc"],
+            'website' => ['website', "https://example.com/cars?a=1&b=2"],
+            'chassis' => ['chassis', "26R<001"],
+        ];
+    }
+
+    /**
+     * XSS vectors stored via Input::raw() must be escaped only at render time.
+     *
+     * @dataProvider xssFieldProvider
+     */
+    public function testXssInputEscapedCorrectlyAtDisplayLayer(string $field): void
+    {
+        $xssPayload = '<script>alert(1)</script>';
+
+        $_POST[$field] = $xssPayload;
+        $stored = Input::raw($field);
+
+        $this->assertSame(
+            $xssPayload,
+            $stored,
+            "Input::raw('{$field}') must not encode the payload before storage"
+        );
+
+        $rendered = htmlspecialchars((string) $stored, ENT_QUOTES, 'UTF-8');
+
+        $this->assertStringNotContainsString('<script>', $rendered, "Rendered {$field} must not contain a literal <script> tag");
+        $this->assertStringContainsString('&lt;script&gt;', $rendered, "Rendered {$field} must contain the properly escaped entity &lt;script&gt;");
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function xssFieldProvider(): array
+    {
+        return [
+            'color'   => ['color'],
+            'engine'  => ['engine'],
+            'website' => ['website'],
+            'chassis' => ['chassis'],
+        ];
+    }
+}

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -57,9 +57,23 @@ final class CarValidatorTest extends TestCase
 
     public function testValidateAndSanitizeFieldsSanitizesChassis(): void
     {
-        $fields = ['chassis' => '<script>ABC123</script>'];
+        $fields = ['chassis' => '  ABC123  '];
         $result = $this->validator->validateAndSanitizeFields($fields, false);
         $this->assertEquals('ABC123', $result['chassis']);
+    }
+
+    public function testValidateAndSanitizeFieldsPreservesSpecialCharsInColor(): void
+    {
+        $fields = ['color' => "Lagoon Blue & Grey"];
+        $result = $this->validator->validateAndSanitizeFields($fields, false);
+        $this->assertSame("Lagoon Blue & Grey", $result['color']);
+    }
+
+    public function testValidateAndSanitizeFieldsPreservesSpecialCharsInEngine(): void
+    {
+        $fields = ['engine' => 'Twin-Cam <36>'];
+        $result = $this->validator->validateAndSanitizeFields($fields, false);
+        $this->assertSame('Twin-Cam <36>', $result['engine']);
     }
 
     public function testValidateAndSanitizeFieldsRejectShortChassis(): void
@@ -303,24 +317,30 @@ final class CarValidatorTest extends TestCase
     }
 
     // ============================================================
-    // sanitizeString tests
+    // normalizeString tests
     // ============================================================
 
-    public function testSanitizeStringStripsHtml(): void
+    public function testNormalizeStringPreservesHtml(): void
     {
-        $result = $this->validator->sanitizeString('<b>Bold</b> text', 100);
-        $this->assertEquals('Bold text', $result);
+        $result = $this->validator->normalizeString('<b>Bold</b> text', 100);
+        $this->assertEquals('<b>Bold</b> text', $result);
     }
 
-    public function testSanitizeStringTrimsWhitespace(): void
+    public function testNormalizeStringPreservesSpecialCharacters(): void
     {
-        $result = $this->validator->sanitizeString('  hello  ', 100);
+        $result = $this->validator->normalizeString('clearance <2cm & engine "Twin Cam"', 100);
+        $this->assertEquals('clearance <2cm & engine "Twin Cam"', $result);
+    }
+
+    public function testNormalizeStringTrimsWhitespace(): void
+    {
+        $result = $this->validator->normalizeString('  hello  ', 100);
         $this->assertEquals('hello', $result);
     }
 
-    public function testSanitizeStringTruncates(): void
+    public function testNormalizeStringTruncates(): void
     {
-        $result = $this->validator->sanitizeString('Long string here', 4);
+        $result = $this->validator->normalizeString('Long string here', 4);
         $this->assertEquals('Long', $result);
     }
 

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -53,7 +53,7 @@ class CarValidator
             switch ($key) {
                 case 'chassis':
                     if (!empty($value)) {
-                        $validatedFields[$key] = $this->sanitizeString($value, 50);
+                        $validatedFields[$key] = $this->normalizeString($value, 50);
                         if (strlen($validatedFields[$key]) < 3) {
                             throw new CarValidationException('Chassis number must be at least 3 characters long');
                         }
@@ -65,7 +65,7 @@ class CarValidator
                 case 'model':
                     if (!empty($value)) {
                         // Sanitize input
-                        $validatedFields[$key] = $this->sanitizeString($value, 100);
+                        $validatedFields[$key] = $this->normalizeString($value, 100);
 
                         // Validate format: "series|variant|type"
                         $parts = explode('|', $validatedFields[$key]);
@@ -115,13 +115,13 @@ class CarValidator
                 case 'color':
                 case 'engine':
                     if (!empty($value)) {
-                        $validatedFields[$key] = $this->sanitizeString($value, 100);
+                        $validatedFields[$key] = $this->normalizeString($value, 100);
                     }
                     break;
 
                 case 'comments':
                     if (!empty($value)) {
-                        $validatedFields[$key] = $this->sanitizeString($value, 5000);
+                        $validatedFields[$key] = $this->normalizeString($value, 5000);
                     }
                     break;
 
@@ -167,7 +167,7 @@ class CarValidator
                 case 'state':
                 case 'country':
                     if (!empty($value)) {
-                        $validatedFields[$key] = $this->sanitizeString($value, 100);
+                        $validatedFields[$key] = $this->normalizeString($value, 100);
                     }
                     break;
 
@@ -191,15 +191,16 @@ class CarValidator
     }
 
     /**
-     * Sanitize string input
+     * Normalize string input by trimming whitespace and enforcing a maximum length.
+     * HTML tags and special characters are preserved; output escaping is the caller's responsibility.
      *
-     * @param string $input Input string to sanitize
+     * @param string $input Input string to normalize
      * @param int $maxLength Maximum allowed length
-     * @return string Sanitized string
+     * @return string Normalized string
      */
-    public function sanitizeString(string $input, int $maxLength): string
+    public function normalizeString(string $input, int $maxLength): string
     {
-        $sanitized = trim(strip_tags($input));
+        $sanitized = trim($input);
 
         if (strlen($sanitized) > $maxLength) {
             $sanitized = substr($sanitized, 0, $maxLength);

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -192,11 +192,16 @@ class CarValidator
 
     /**
      * Normalize string input by trimming whitespace and enforcing a maximum length.
-     * HTML tags and special characters are preserved; output escaping is the caller's responsibility.
+     *
+     * IMPORTANT: HTML tags and special characters are preserved as part of the
+     * encode-at-output pattern. The caller MUST apply htmlspecialchars() at the
+     * output context (HTML templates, emails) to prevent XSS vulnerabilities.
      *
      * @param string $input Input string to normalize
      * @param int $maxLength Maximum allowed length
-     * @return string Normalized string
+     * @return string Normalized string with preserved HTML entities
+     * @since v2.23.0 Renamed from sanitizeString() - no longer strips HTML tags
+     * @see https://github.com/unibrain1/elanregistry/issues/841
      */
     public function normalizeString(string $input, int $maxLength): string
     {


### PR DESCRIPTION
## Summary

- Replaces `\Input::get()` with `\ElanRegistry\Input::raw()` in `updateColor()`, `updateEngine()`, `updateWebsite()`, and `updateChassis()` — extending the encode-at-output pattern established in #838 for `comments`
- Removes `strip_tags()` from `CarValidator::normalizeString()` (renamed from `sanitizeString`) as redundant when output is always escaped at render time
- Adds `htmlspecialchars()` to `chassis`, `color`, `comments`, and `website` in the admin verification email template
- Escapes raw field values in `$successes[]` messages before passing to `usSuccess()`
- Adds `catch (\Throwable)` to the `ChassisValidator` call to surface unexpected errors that would otherwise propagate uncaught

## Bug Escape Analysis

**Root cause:** `\Input::get()` (upstream UserSpice) applies `htmlspecialchars()` before returning. The #838 fix corrected `updateComments()` but the other four field updaters were not in scope for that PR.

**Testing gap:** No unit or integration tests existed for `updateColor/Engine/Website/Chassis()`. The only regression test (#838) covered only the `comments` field. `CarValidator::sanitizeString()` also had a test (`testSanitizeStringStripsHtml`) that verified the `strip_tags()` behaviour being removed — updated to verify the new contract.

**Preventive measures:**
- `Issue841RegressionTest.php` added — 16 tests covering no-encoding, `"0"` not discarded, idempotency, and XSS-escaped-at-render for all four fields
- `validateAndSanitizeFields` tests added for special chars in `color` and `engine`
- `normalizeString()` PHPDoc now explicitly states callers are responsible for output escaping

## Test plan

- [ ] 904 unit + regression tests pass (`composer test:quick`)
- [ ] Save a car with `color = "O'Brien Blue"` — verify DB stores `O'Brien Blue` (no `&#039;`)
- [ ] Save a car with `engine = "Twin Cam & 1558cc"` — verify DB stores `Twin Cam & 1558cc` (no `&amp;`)
- [ ] Save a car with `chassis` containing `<` — verify full string stored and displayed
- [ ] Trigger admin verification email — verify chassis and color render correctly

## Related

- Depends on #843 (`Input::raw()` class) — already merged
- Depends on #840 (output escaping) — already merged
- Data migration for existing encoded values: #847
- Tracking issue for remaining unescaped email template fields: #854

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)