### PR TITLE
fix: correct HTML encoding in all outbound email paths (#839)

### DIFF
--- a/app/admin/verify/_email_template.php
+++ b/app/admin/verify/_email_template.php
@@ -71,7 +71,7 @@
 
         <!-- pre-header end -->
         <!-- header -->
-        <p>Hello <?= ucfirst($car->fname) ?>,
+        <p>Hello <?= htmlspecialchars(ucfirst((string)($car->fname ?? '')), ENT_QUOTES, 'UTF-8') ?>,
         </p>
         <p>It's been awhile since you created or updated the information in the Lotus Elan Registry.
             Please review the information below and let me know if the information is current, if you've sold the car,
@@ -100,32 +100,32 @@
             </tr>
             <tr>
                 <td>First Name</td>
-                <td><?= $car->fname ?>
+                <td><?= htmlspecialchars((string)($car->fname ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>
                 <td>Last Name</td>
-                <td><?= $car->lname ?>
+                <td><?= htmlspecialchars((string)($car->lname ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>
                 <td>Email</td>
-                <td><?= $car->email ?>
+                <td><?= htmlspecialchars((string)($car->email ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>
                 <td>City</td>
-                <td><?= $car->city ?>
+                <td><?= htmlspecialchars((string)($car->city ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>
                 <td>State</td>
-                <td><?= $car->state ?>
+                <td><?= htmlspecialchars((string)($car->state ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>
                 <td>Country</td>
-                <td><?= $car->country ?>
+                <td><?= htmlspecialchars((string)($car->country ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
             <tr>

--- a/app/contact/send-feedback.php
+++ b/app/contact/send-feedback.php
@@ -67,7 +67,10 @@ if ($post_attempted) {
     $comments = Input::raw('comments');
 
     // Validate required fields
-    if (empty($name) || empty($email_from) || empty($id_from) || empty($comments)) {
+    if ($name === null || $name === '' ||
+        $email_from === null || $email_from === '' ||
+        $id_from === null || $id_from === '' ||
+        $comments === null || $comments === '') {
         $errors[] = 'We are sorry, but there appears to be a problem with the form you submitted.';
     }
 

--- a/app/contact/send-feedback.php
+++ b/app/contact/send-feedback.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use ElanRegistry\Input;
+
 /**
  * send_form_email.php
  * Handles feedback form submissions and sends emails to the registry admin.
@@ -58,11 +60,11 @@ if ($post_attempted) {
     $email_to = getFeedbackEmail();
     $email_subject = "[ELANREGISTRY] Feedback";
 
-    // Get form data using secure Input::get()
-    $name = Input::get('name');
-    $email_from = Input::get('email');
-    $id_from = Input::get('id');
-    $comments = Input::get('comments');
+    // Raw values — the email view template escapes via EmailTemplate methods
+    $name = Input::raw('name');
+    $email_from = Input::raw('email');
+    $id_from = Input::raw('id');
+    $comments = Input::raw('comments');
 
     // Validate required fields
     if (empty($name) || empty($email_from) || empty($id_from) || empty($comments)) {

--- a/app/contact/send-owner-email.php
+++ b/app/contact/send-owner-email.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use ElanRegistry\Input;
+
 /**
  * contact_owner_email.php
  * Processes contact owner requests and sends emails between users.
@@ -42,8 +44,8 @@ if (Input::exists('post')) {
         $action = Input::get('action');
         if ($action === 'send_message' && Input::get('from_user_id') && Input::get('to_user_id') && Input::get('message')) {
             // Validate message input
-            $message = Input::get('message');
-            if (empty(trim($message))) {
+            $message = Input::raw('message'); // raw — _email_contact_owner.php escapes via EmailTemplate
+            if ($message === null || $message === '') {
                 $errors[] = 'Message cannot be empty';
                 include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
                 exit();


### PR DESCRIPTION
## Summary

- Add `htmlspecialchars()` to `fname`, `lname`, `email`, `city`, `state`, `country` outputs in the admin car verification email template (`_email_template.php`) — these were previously unescaped XSS vectors in HTML email
- Switch `Input::get()` → `Input::raw()` for `message` in `send-owner-email.php` and `name`/`email`/`id`/`comments` in `send-feedback.php` to prevent double-encoding — `Input::get()` HTML-encodes, and `EmailTemplate` methods apply `htmlspecialchars()` again at output
- Replace `empty(trim($message))` with explicit `$message === null || $message === ''` check to avoid calling `trim()` on the `?string` return of `Input::raw()`

Closes #839

## Bug Escape Analysis

**Root cause:** The admin verification template was never given output escaping when first written. The contact/feedback paths gained a double-encoding defect when `EmailTemplate` was refactored to escape internally, but the callers were not updated to stop pre-encoding via `Input::get()`.

**Testing gap:** No automated test existed for email body content. The issue notes that manual send-and-inspect on the test environment (after the storage migration runs) is the accepted verification approach for this milestone.

**Preventive:** The `Input::raw()` → `EmailTemplate` encoding contract is now documented in `CODING_STANDARDS.md` (via #843). New email paths should follow the same pattern.

## Test plan

- [ ] Trigger the admin car verification email on test environment and confirm owner name, location, chassis, color, and comments render as readable plain text
- [ ] Verify `O'Brien` renders as `O'Brien` (not `O&#039;Brien`) after the storage migration (#847) runs
- [ ] Send an owner-to-owner contact message with special characters (`'`, `"`, `&`) and confirm the email body renders them correctly
- [ ] Submit the feedback form with special characters in name and comments and confirm the email renders them correctly
- [ ] Verify `<b>test</b>` in any field renders as literal characters, not bold HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)