### PR TITLE
ci: upgrade GitHub Actions for Node.js 24 and CodeQL v4

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -98,7 +98,7 @@ jobs:
           ref: refs/pull/${{ steps.ctx.outputs.pr_number }}/head
 
       - name: Run Claude Issue-Level Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -237,7 +237,7 @@ jobs:
           cat merged-prs.txt
 
       - name: Run Claude Milestone-Level Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
@@ -388,7 +388,7 @@ jobs:
           echo "base_ref=${BASE}" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Deep Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -59,4 +59,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- Bumps `anthropics/claude-code-action@beta` → `@v1` in `claude.yml` and `claude-code-review.yml` (4 jobs) — resolves the Node.js 20 deprecation from the `@beta`-pinned bun setup action
- Bumps `github/codeql-action/{init,autobuild,analyze}@v3` → `@v4` in `codeql-analysis.yml` — clears the December 2026 CodeQL v3 deprecation and any residual Node 20 transitive dependency
- `actions/checkout@v4`, `cache@v4`, `setup-node@v4` in `static-analysis.yml` are already Node 24-compatible — no change needed

No workflow logic changes. All four workflow YAML files parse cleanly.

Closes #870

## Test plan

- [ ] Static Analysis workflow passes (PHPStan, phpcs, ESLint)
- [ ] CodeQL workflow passes (javascript analysis)
- [ ] Claude Code workflow responds to `@claude` comments
- [ ] Claude Code Review workflow triggers on PR open
- [ ] No Node.js 20 deprecation warnings in any job output

🤖 Generated with [Claude Code](https://claude.com/claude-code)