### PR TITLE
fix: resolve collation mismatch in migration script Step 5 re-sync

### DIFF
--- a/app/admin/scripts/fix/03-Decode-All-HTML-Encoded-Fields.php
+++ b/app/admin/scripts/fix/03-Decode-All-HTML-Encoded-Fields.php
@@ -398,13 +398,15 @@ $isProcessing = ($method === 'POST' && isset($_POST['start']));
                             logProgress("STEP {$stepNum}: Re-sync denormalised cars.fname/lname/city/state/country", 'step');
                             logProgress(SECTION_SEPARATOR, 'step');
 
+                            // COLLATE clause resolves utf8mb4_unicode_ci vs utf8mb4_general_ci
+                            // mismatch when cars/users/profiles have different default collations.
                             $resyncWhere = 'c.user_id IS NOT NULL
                                 AND NOT (
-                                    c.fname   <=> u.fname
-                                    AND c.lname   <=> u.lname
-                                    AND c.city    <=> p.city
-                                    AND c.state   <=> p.state
-                                    AND c.country <=> p.country
+                                    c.fname   COLLATE utf8mb4_unicode_ci <=> u.fname   COLLATE utf8mb4_unicode_ci
+                                    AND c.lname   COLLATE utf8mb4_unicode_ci <=> u.lname   COLLATE utf8mb4_unicode_ci
+                                    AND c.city    COLLATE utf8mb4_unicode_ci <=> p.city    COLLATE utf8mb4_unicode_ci
+                                    AND c.state   COLLATE utf8mb4_unicode_ci <=> p.state   COLLATE utf8mb4_unicode_ci
+                                    AND c.country COLLATE utf8mb4_unicode_ci <=> p.country COLLATE utf8mb4_unicode_ci
                                 )';
 
                             $resyncSelectSql = 'SELECT COUNT(*) AS cnt


### PR DESCRIPTION
## Problem

Running `03-Decode-All-HTML-Encoded-Fields.php` on the test environment fails at Step 5 with:

```
FATAL ERROR (RuntimeException): DB error counting rows to re-sync:
ERROR #HY000: Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT)
and (utf8mb4_general_ci,IMPLICIT) for operation '<=>'
```

The `<=>` (NULL-safe equals) comparisons in the `$resyncWhere` clause join `cars`, `users`, and `profiles` columns. When those tables have different default collations, MySQL cannot resolve the mismatch implicitly.

Steps 1–4 (decode cars, users, profiles) completed successfully — **no data was lost**. The backup from Step 1 is intact. Only the Step 5 re-sync count query fails, so the data is clean but the denormalized columns haven't been synced yet.

## Fix

Added `COLLATE utf8mb4_unicode_ci` to both sides of each `<=>` comparison in `$resyncWhere`. This forces a consistent collation for the comparison without altering any data.

## After merging

1. Deploy to test (`git push test main`)
2. Re-run the migration script — Steps 1–4 will report 0 rows (already clean), Step 5 will complete the re-sync
3. Deploy to prod and repeat

Closes #847 (partially — the script itself; the issue remains open until prod migration completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)