### PR TITLE
fix: remove stale Brevo reply_name workaround comments (#812)

### DIFF
--- a/app/contact/send-feedback.php
+++ b/app/contact/send-feedback.php
@@ -116,7 +116,6 @@ if ($post_attempted) {
 
     if (empty($errors)) {
         // Reply-to is set to the submitter so the admin can reply directly.
-        // reply_name is a no-op until the Brevo override.php is updated to forward it.
         $result = email($email_to, $email_subject, $body, ['replyTo' => $email_from, 'reply_name' => $name]);
 
         if ($result !== true) {

--- a/app/contact/send-owner-email.php
+++ b/app/contact/send-owner-email.php
@@ -95,7 +95,6 @@ if (Input::exists('post')) {
                 if (!$fromEmailValid) {
                     logger($user->data()->id, LogCategories::LOG_CATEGORY_ELAN_REGISTRY, "contact_owner_email.php invalid fromEmail for reply-to: " . preg_replace('/[\r\n\t]/', '', $fromEmail));
                 }
-                // reply_name is a no-op until the Brevo override.php is updated to forward it.
                 $replyOpts = $fromEmailValid ? ['replyTo' => $fromEmail, 'reply_name' => $fromName] : [];
 
                 $result = email($toEmail, $subject, $body, $replyOpts);

--- a/docs/releases/RELEASE_NOTES_v2.24.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.24.0.md
@@ -5,7 +5,21 @@
 
 ## Required Actions After Deployment
 
-None.
+### Activate updated Brevo email override on each server
+
+The Brevo plugin (v1.6.0) ships an updated `override.RENAME.php` that fixes
+the `reply_name` forwarding gap (issue #812). Because the plugin directory is
+not managed by git, this file must be activated manually on each server:
+
+```bash
+cd /path/to/usersc/plugins/sendinblue/
+cp override.php override.php.bak   # keep a rollback copy
+cp override.RENAME.php override.php
+```
+
+After activating, send a test feedback email from the site and confirm the
+reply-to name appears correctly in the received message. If anything is wrong,
+restore the backup: `cp override.php.bak override.php`.
 
 ## User-Facing Changes
 
@@ -35,13 +49,15 @@ None.
 
 ## Technical Changes
 
-- **UserSpice 6.1.0 upgrade** ([#874](https://github.com/unibrain1/elanregistry/issues/874)): Framework upgraded to UserSpice 6.1.0.
+- **UserSpice 6.1.0 upgrade** ([#874](https://github.com/unibrain1/elanregistry/issues/874)): Framework upgraded to UserSpice 6.1.0; navigation.php upstream bug resolved (#734).
+- **Brevo plugin `reply_name` forwarding** ([#812](https://github.com/unibrain1/elanregistry/issues/812)): Brevo plugin v1.6.0 now correctly forwards `reply_name` to the API. Stale workaround comments removed from `send-feedback.php` and `send-owner-email.php`. Requires activating the updated `override.RENAME.php` → `override.php` on each server (see Required Actions).
 - **MarkdownParser replaced with league/commonmark** ([#815](https://github.com/unibrain1/elanregistry/issues/815)): Custom MarkdownParser class replaced with the league/commonmark library.
 - **ESLint no-implicit-globals fixed in statistics.js** ([#871](https://github.com/unibrain1/elanregistry/issues/871)): ESLint warnings resolved in app/assets/js/statistics.js.
 
 ## Issues Resolved
 
 - [#734](https://github.com/unibrain1/elanregistry/issues/734) — Stop tracking navigation.php when upstream bug is fixed
+- [#812](https://github.com/unibrain1/elanregistry/issues/812) — Track upstream fix: Brevo plugin override.php signature mismatch (bugs.userspice.com/2334)
 - [#757](https://github.com/unibrain1/elanregistry/issues/757) — ux: establish CSS custom property color system with Lotus green as primary
 - [#758](https://github.com/unibrain1/elanregistry/issues/758) — ux: nav active state indicator and Register as CTA button
 - [#759](https://github.com/unibrain1/elanregistry/issues/759) — ux: login page branded background and clarify password vs magic-link paths


### PR DESCRIPTION
## Summary

Brevo plugin v1.6.0 (shipped with the UserSpice 6.1.0 upgrade in PR #879) now correctly forwards `reply_name` to the Brevo API in `override.RENAME.php`. The workaround comments added in #601 are no longer accurate and have been removed.

## Changes

- `app/contact/send-feedback.php` — removed stale comment `// reply_name is a no-op until the Brevo override.php is updated to forward it.`
- `app/contact/send-owner-email.php` — same comment removed
- `docs/releases/RELEASE_NOTES_v2.24.0.md` — added #812 entry to Technical Changes and Issues Resolved; added "Required Actions After Deployment" section documenting the manual server-side activation step (`override.RENAME.php` → `override.php`)

## Verification

Manually verified `reply_name` forwarding works end-to-end after activating the updated override on the test server.

## Post-deployment step (required on each server)

```bash
cd /path/to/usersc/plugins/sendinblue/
cp override.php override.php.bak
cp override.RENAME.php override.php
```

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)