### PR TITLE
feat: nav active state indicator and Register CTA button (#758)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ working with code in this repository.
 **Essential reading:**
 
 - `CLAUDE.md` (this file) - Overview and quick reference
+- `docs/development/UI_STANDARDS.md` - **UI component standards** (color tokens, card hierarchy, component patterns) — read before any UI change
 - `docs/development/EMAIL_SYSTEM.md` - Brevo email plugin setup and configuration
 - `docs/development/CODING_STANDARDS.md` - Code quality requirements
 - `docs/development/QUICK_REFERENCE.md` - Common tasks lookup

--- a/app/admin/color-preview.php
+++ b/app/admin/color-preview.php
@@ -374,7 +374,35 @@ $pageTitle = 'Color Preview — Elan Registry Token System';
         </div>
     </div>
 
-    <!-- 10. Token reference table -->
+    <!-- 10. Navigation patterns -->
+    <div class="er-section-heading">Navigation</div>
+    <div class="card mb-2">
+        <div class="card-body p-0">
+            <ul class="us_menu dark" style="margin:0; padding: 0.75rem 1.25rem; display:flex; gap:1.5rem; list-style:none; align-items:center;">
+                <li><a href="#" style="color:#fff; text-decoration:none;">List Cars</a></li>
+                <li class="active"><a href="#" style="color:#fff; text-decoration:none;">Statistics</a></li>
+                <li><a href="#" style="color:#fff; text-decoration:none;">Reference</a></li>
+                <li style="margin-left:auto;">
+                    <a href="#" class="btn btn-er-yellow btn-sm">
+                        <i class="fa fa-plus-square"></i> Register
+                    </a>
+                </li>
+                <li><a href="#" style="color:#fff; text-decoration:none;">Log In</a></li>
+            </ul>
+        </div>
+    </div>
+    <p class="text-muted small mb-3">
+        Active section carries a 3px Lotus Yellow underline (<code>--er-accent</code>)
+        and bolder weight; matching is by path prefix so detail pages still
+        highlight their parent section. Public-nav Register uses
+        <code>btn btn-er-yellow btn-sm</code> &mdash; solid Lotus Yellow with
+        <code>--er-on-accent</code> text for maximum CTA visibility on the dark
+        nav, hover darkens to <code>--er-accent-dark</code>. Distinct from the
+        logged-in <code>btn-primary</code> Add Car so the two states read as
+        separate calls to action.
+    </p>
+
+    <!-- 11. Token reference table -->
     <div class="er-section-heading">Token reference</div>
     <div class="table-responsive">
         <table class="table table-sm er-token-table">
@@ -398,7 +426,7 @@ $pageTitle = 'Color Preview — Elan Registry Token System';
                 <tr><td><span class="er-token-swatch" style="background: #073763;"></span></td><td><code>--er-link-hover</code></td><td>#073763</td><td>11.4:1 AAA</td><td>Link hover / visited</td></tr>
                 <tr><td><span class="er-token-swatch" style="background: #6C757D;"></span></td><td><code>--er-neutral</code></td><td>#6C757D</td><td>4.7:1 AA</td><td>Muted text, secondary UI</td></tr>
                 <tr><td><span class="er-token-swatch" style="background: #F4F5F3;"></span></td><td><code>--er-neutral-light</code></td><td>#F4F5F3</td><td>1.05:1 (bg)</td><td>Page bg tint, table stripes</td></tr>
-                <tr><td><span class="er-token-swatch" style="background: #1F2421;"></span></td><td><code>--er-neutral-dark</code></td><td>#1F2421</td><td>15.7:1 AAA</td><td>Hero banners, dark sections</td></tr>
+                <tr><td><span class="er-token-swatch" style="background: #3B413D;"></span></td><td><code>--er-neutral-dark</code></td><td>#3B413D</td><td>9.4:1 AAA</td><td>Hero banners, dark sections</td></tr>
                 <tr><td><span class="er-token-swatch" style="background: #010101;"></span></td><td><code>--er-true-black</code></td><td>#010101</td><td>20.9:1 AAA</td><td>Authentic Lotus black &mdash; text on yellow</td></tr>
             </tbody>
         </table>

--- a/docs/development/UI_STANDARDS.md
+++ b/docs/development/UI_STANDARDS.md
@@ -1,0 +1,299 @@
+# UI Standards — Elan Registry
+
+**Live reference:** [`/app/admin/color-preview.php`](../../app/admin/color-preview.php) —
+renders every token, card level, and component pattern in context. Admin-only page.
+
+**Token source:** [`usersc/templates/customizer.css`](../../usersc/templates/customizer.css) —
+the single source of truth for all `--er-*` tokens and global utility classes.
+
+---
+
+## The Golden Rule
+
+> **Every new UI component or token must be demonstrated in `color-preview.php` before it is used elsewhere on the site.**
+
+When you introduce a new pattern — a new CSS class, a new token, a new component — add a section
+to `color-preview.php` showing it in context first. This keeps the reference page authoritative
+and ensures the pattern is visually validated before being applied site-wide.
+
+---
+
+## Color Token System
+
+All colors are defined as CSS custom properties in `customizer.css`. Never use Bootstrap's default
+palette or hardcoded hex values in project-owned PHP, CSS, or JS files.
+
+### Token Reference
+
+| Token | Hex | WCAG vs white | Use |
+| --- | --- | --- | --- |
+| `--er-primary` | `#00563F` | 8.4:1 AAA | Primary buttons, card headers, brand anchor |
+| `--er-primary-dark` | `#003D2C` | 12.1:1 AAA | Hover, active states, focus rings |
+| `--er-primary-light` | `#E6EFEC` | 1.1:1 (bg) | Subtle tints, table hover |
+| `--er-primary-rgb` | `0, 86, 63` | — | `rgba()` calculations: `rgba(var(--er-primary-rgb), 0.1)` |
+| `--er-accent` | `#FFF200` | 1.07:1 ❌ | Lotus Yellow — **graphic/border/fill ONLY**, never text on white |
+| `--er-warning` | `#B8860B` | 4.6:1 AA | Warnings, "Unverified" badge — replaces Bootstrap `#ffc107` |
+| `--er-warning-rgb` | `184, 134, 11` | — | `rgba()` calculations |
+| `--er-danger` | `#A52218` | 6.4:1 AA | Destructive actions only |
+| `--er-danger-rgb` | `165, 34, 24` | — | `rgba()` calculations |
+| `--er-link` | `#0B5394` | 8.6:1 AAA | Hyperlinks **only** — not buttons, not headings |
+| `--er-link-hover` | `#073763` | 11.4:1 AAA | Link hover / visited |
+| `--er-neutral` | `#6C757D` | 4.7:1 AA | Muted text, secondary UI (`text-muted`) |
+| `--er-neutral-light` | `#F4F5F3` | 1.05:1 (bg) | Page background tint, table stripes, L3 card headers |
+| `--er-neutral-dark` | `#1F2421` | 15.7:1 AAA | Dark sections, hero banners, `--er-neutral-dark` |
+| `--er-true-black` | `#010101` | 20.9:1 AAA | Authentic Lotus black — text on yellow |
+
+### Bootstrap Cascade
+
+The tokens override Bootstrap's defaults in `:root` — most Bootstrap utilities (`bg-primary`, `text-primary`, `btn-primary`, `alert-primary`) inherit automatically:
+
+```css
+--bs-primary: var(--er-primary);        /* cascades to bg-primary, text-primary */
+--bs-link-color: var(--er-link);        /* cascades to all <a> tags */
+--bs-warning: var(--er-warning);        /* cascades to alert-warning, badge-warning */
+--bs-secondary-color: var(--er-neutral); /* cascades to .text-muted */
+```
+
+Per-component overrides in `customizer.css` handle `.btn-primary`, `.btn-warning`, `.btn-info`
+(Bootstrap hardcodes these at component scope and they don't inherit `--bs-primary`).
+
+### Email Templates — Special Rule
+
+CSS custom properties **do not work in email clients**. `EmailTemplate.php` and any other email-related code must use **literal hex values**:
+
+```php
+// ✓ Correct for email
+'background-color: #00563F'
+
+// ✗ Wrong — CSS vars are stripped by email clients
+'background-color: var(--er-primary)'
+```
+
+The current hex values in `EmailTemplate.php` must stay in sync with `--er-primary` in `customizer.css`. Update both when the brand color changes.
+
+### Color Anti-Patterns
+
+| ❌ Don't use | ✓ Use instead | Why |
+| --- | --- | --- |
+| `bg-info` / `btn-info` | `bg-primary` / `btn-primary` | info = Bootstrap cyan; we retired cyan |
+| `bg-success` / `btn-success` as primary CTA | `btn-primary` | success green ≠ BRG; reserve for genuine success states |
+| `bg-warning text-dark` on card headers | `card-header-er-primary` | Inconsistent with hierarchy; warning color is semantic |
+| `bg-dark` on card headers | `card-header-er-primary` or `card-header-er-dark` | Use token classes, not Bootstrap bg utilities |
+| `#007bff`, `#28a745`, `#17a2b8`, `#ffc107` | `var(--er-primary)`, `var(--er-warning)` etc. | Hardcoded Bootstrap 4 values; bypass the token system |
+| `text-white` on `card-header-er-primary` headings | `card-header-er-primary-text` | `text-white` is `#fff` at full opacity; the token class uses `rgba(255,255,255,0.75)` for the correct visual weight |
+| `text-primary` on icons inside BRG card headers | Remove the class | `text-primary` resolves to `--er-primary` (green on green = invisible) |
+| `btn-close` on BRG modal headers | `btn-close btn-close-white` | Bootstrap's default close icon is a black SVG — invisible on dark backgrounds |
+
+---
+
+## Card Hierarchy (L1–L4)
+
+Use nested card levels whenever cards are embedded within other cards. Each level reduces visual weight while keeping the BRG brand anchor at the outermost level.
+
+### The Four Levels
+
+| Level | Class | Visual treatment | When to use |
+| --- | --- | --- | --- |
+| **L1** | `card-header-er-primary` | BRG green + 5px Lotus Yellow stripe, white text | Top-level page section card, tab pane anchor |
+| **L2** | `card-header-er-l2` | `#e8f0ed` (solid light BRG tint) + 4px BRG left border, dark text | Group or subsection within L1 |
+| **L3** | `card-header-er-l3` | `--er-neutral-light` bg + 3px grey left border, dark text | Individual record or item within L2 |
+| **L4** | `card-header-er-l4` | White bg + hairline bottom divider, small uppercase label | Detail panel or supplementary info within L3 |
+
+For heading text inside each level:
+
+| Level | Text class | Use on |
+| --- | --- | --- |
+| L1 | `card-header-er-primary-text` | `h1`–`h6`, `p`, `small` inside `card-header-er-primary` |
+| L2 | `card-header-er-l2-text` | Headings and button text inside `card-header-er-l2` |
+| L3 | `card-header-er-l3-text` | Headings inside `card-header-er-l3` |
+| L4 | `card-header-er-l4-text` | Uppercase label text inside `card-header-er-l4` |
+
+### Nesting Rules
+
+- **Never nest L1 inside L1.** One L1 card per page section or tab pane.
+- L2 groups sit directly inside an L1 card body (e.g., duplicate groups, report categories).
+- L3 items sit inside an L2 group (e.g., individual records, comparison cards).
+- L4 is optional — skip it if the L3 content is simple prose.
+- The **CSS specificity firewall** in `customizer.css` uses `(0,4,0)` selectors to override the
+  UserSpice-generated Bootstrap rule
+  `.card.border-primary .card-header { background: var(--bs-primary) !important }` at `(0,3,0)`.
+  Do not remove these rules.
+
+### Semantic Exceptions
+
+- **Permanent deletion / destructive danger cards** inside a hierarchy may keep `bg-danger` with
+  explicit `text-white` on the heading element — semantic red communicates the action's severity
+  more clearly than following the level system.
+- **Card heroes** (e.g., the car hero section on the account page) use `bg-primary` with inline
+  `border-top: 5px solid var(--er-accent)` — they are visual showcases, not structural hierarchy
+  nodes, so they intentionally look like L1 without being anchors.
+
+---
+
+## Component Patterns
+
+### Buttons
+
+```html
+<!-- Primary action — use for the main CTA -->
+<button class="btn btn-primary">Save</button>
+
+<!-- Secondary action — use for less-prominent confirmations -->
+<button class="btn btn-secondary">Cancel</button>
+
+<!-- Destructive action — deletions, permanent changes only -->
+<button class="btn btn-danger">Delete</button>
+
+<!-- Outline — navigation links, non-primary actions within cards -->
+<a class="btn btn-outline-primary">View Details</a>
+
+<!-- Warning — administrative use, unverified data actions -->
+<button class="btn btn-warning">Override</button>
+```
+
+**Do not use `btn-success` as a generic primary CTA.** Reserve it for genuine approval/completion states (e.g., "Approve transfer request").
+
+### Badges
+
+```html
+<span class="badge text-bg-primary">Verified</span>
+<span class="badge text-bg-warning">Unverified</span>   <!-- dark goldenrod, WCAG AA -->
+<span class="badge text-bg-secondary">Archived</span>
+<span class="badge text-bg-danger">Removed</span>
+<!-- Lotus Yellow badge — text must be --er-true-black, NEVER white -->
+<span class="badge er-badge-yellow">Featured</span>
+```
+
+### Alerts
+
+```html
+<!-- Informational — replaces alert-info (Bootstrap cyan retired) -->
+<div class="alert alert-primary">...</div>
+
+<!-- Warning — data quality issues, unverified content -->
+<div class="alert alert-warning">...</div>
+
+<!-- Danger — destructive actions, irreversible operations -->
+<div class="alert alert-danger">...</div>
+
+<!-- Compact variant (defined globally in customizer.css) -->
+<div class="alert alert-primary alert-sm">...</div>
+```
+
+### Stat Tiles
+
+Use `.er-stat-tile` for header dashboard counters. Dark background, Lotus Yellow accent number, yellow top stripe.
+
+```html
+<div class="er-stat-tile">
+    <div class="er-stat-number">1,245</div>
+    <div class="er-stat-label">Total Cars</div>
+</div>
+```
+
+Do **not** mix stat tiles with colored Bootstrap cards (`bg-primary`, `bg-success`) for the same metric on the same page — pick one pattern and use it consistently.
+
+### Modal Headers
+
+All modal headers that use `card-header-er-primary` (BRG) or `card-header-er-dark` **must** use `btn-close-white` on the close button:
+
+```html
+<div class="modal-header card-header-er-primary">
+    <h5 class="modal-title card-header-er-primary-text">Title</h5>
+    <button type="button" class="btn-close btn-close-white"
+            data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+```
+
+### Form Section Headings
+
+```html
+<!-- Defined globally in customizer.css -->
+<div class="form-section-heading">Vehicle Details</div>
+```
+
+---
+
+## Page Structure Conventions
+
+### Standard Page Wrapper
+
+Every app page wraps its content in `.page-wrapper` (global, defined in `customizer.css`):
+
+```html
+<div class="page-wrapper">
+    <div class="container">
+        <!-- page content -->
+    </div>
+</div>
+```
+
+### Registry Card
+
+All content cards use `.registry-card` (no border, subtle box shadow, defined globally):
+
+```html
+<div class="card registry-card">
+    <div class="card-header card-header-er-primary">
+        <h4 class="mb-0 card-header-er-primary-text">
+            <i class="fas fa-car"></i> Section Title
+        </h4>
+    </div>
+    <div class="card-body">...</div>
+</div>
+```
+
+### Tab Layouts
+
+Nav-tab brand styling (BRG active underline, hover tint, mobile horizontal scroll) is global in `customizer.css`. No per-page overrides needed:
+
+```html
+<ul class="nav nav-tabs" role="tablist">
+    <li class="nav-item">
+        <button class="nav-link active" data-bs-toggle="tab"
+                data-bs-target="#pane-id" type="button">
+            <i class="fas fa-icon"></i> Tab Label
+        </button>
+    </li>
+</ul>
+<div class="tab-content">
+    <div class="tab-pane fade show active" id="pane-id" role="tabpanel">
+        <!-- tab content -->
+    </div>
+</div>
+```
+
+### Page-Specific CSS Files
+
+Three first-party CSS source files (compiled to `.min.css` by `npm run build`):
+
+| File | Loaded by | Contains |
+| --- | --- | --- |
+| `app/admin/assets/manage-consolidated.css` | `manage-consolidated.php` | Admin comparison cards, field-match/differ, timestamp display |
+| `app/assets/css/edit_car.css` | `app/cars/form.php` | FilePond overrides, `#editCar` focus, card z-index for drag-drop |
+| `app/assets/css/location-picker.css` | `app/cars/form.php` | `.location-picker-container`-scoped styles |
+
+**Everything else is global in `customizer.css`.** If you find yourself writing a style in a page
+file that could apply to multiple pages, move it to `customizer.css` instead. Each rule retained
+in a page-specific file should have a comment explaining why it is not global.
+
+---
+
+## Adding New UI Patterns
+
+When introducing a new component, token, or pattern:
+
+1. **Add a demo to `color-preview.php`** showing the pattern in context with a label and usage note. This is mandatory — it is the visual contract for the pattern.
+2. **Add the CSS to `customizer.css`** if it is globally applicable, or to the relevant page-specific file with a scope comment if not.
+3. **Document it in this file** under the appropriate section, including any anti-patterns it replaces.
+4. **Run `npm run build`** if you edited a source CSS file other than `customizer.css` (which is served directly without a build step).
+5. If the pattern involves PHP class rendering (e.g., `DocumentPortalTemplate`), **add unit tests** pinning the new class names so regressions are caught automatically.
+
+---
+
+## See Also
+
+- [`docs/development/CODING_STANDARDS.md`](CODING_STANDARDS.md) — PHP coding standards
+- [`docs/development/CSS_AND_ASSETS.md`](CSS_AND_ASSETS.md) — asset pipeline, build process, ADR-015
+- [`app/admin/color-preview.php`](../../app/admin/color-preview.php) — live token and component reference
+- [`usersc/templates/customizer.css`](../../usersc/templates/customizer.css) — token definitions and global CSS

--- a/docs/development/UI_STANDARDS.md
+++ b/docs/development/UI_STANDARDS.md
@@ -40,7 +40,7 @@ palette or hardcoded hex values in project-owned PHP, CSS, or JS files.
 | `--er-link-hover` | `#073763` | 11.4:1 AAA | Link hover / visited |
 | `--er-neutral` | `#6C757D` | 4.7:1 AA | Muted text, secondary UI (`text-muted`) |
 | `--er-neutral-light` | `#F4F5F3` | 1.05:1 (bg) | Page background tint, table stripes, L3 card headers |
-| `--er-neutral-dark` | `#1F2421` | 15.7:1 AAA | Dark sections, hero banners, `--er-neutral-dark` |
+| `--er-neutral-dark` | `#3B413D` | 9.4:1 AAA | Dark sections, hero banners, `--er-neutral-dark` |
 | `--er-true-black` | `#010101` | 20.9:1 AAA | Authentic Lotus black — text on yellow |
 
 ### Bootstrap Cascade
@@ -149,6 +149,11 @@ For heading text inside each level:
 
 <!-- Warning — administrative use, unverified data actions -->
 <button class="btn btn-warning">Override</button>
+
+<!-- Lotus Yellow CTA — high-contrast filled button for loud CTAs that must pop
+     on dark backgrounds (e.g. public-nav Register link). Yellow + --er-on-accent
+     text, NEVER white text. -->
+<a class="btn btn-er-yellow btn-sm">Register</a>
 ```
 
 **Do not use `btn-success` as a generic primary CTA.** Reserve it for genuine approval/completion states (e.g., "Approve transfer request").

--- a/docs/guide-viewer.php
+++ b/docs/guide-viewer.php
@@ -14,9 +14,17 @@ declare(strict_types=1);
  */
 
 require_once '../users/init.php';
+require_once $abs_us_root . $us_url_root . 'usersc/classes/DocumentConfig.php';
+
+// Hint for the nav active-state matcher (see usersc/templates/customizer/file_nav_custom.php).
+// Must be set before elanregistry_prep.php, which triggers the nav render. Falls back to
+// 'guides' if the doc is unknown — the request will fail validation below regardless.
+$nav_section = (\ElanRegistry\Documentation\DocumentConfig::validateDocument($_GET['doc'] ?? '')['category'] ?? 'guides') === 'admin'
+    ? 'admin'
+    : 'guides';
+
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 require_once $abs_us_root . $us_url_root . 'usersc/classes/MarkdownParser.php';
-require_once $abs_us_root . $us_url_root . 'usersc/classes/DocumentConfig.php';
 
 use ElanRegistry\Documentation\MarkdownParser;
 use ElanRegistry\Documentation\DocumentConfig;

--- a/docs/pdf-viewer.php
+++ b/docs/pdf-viewer.php
@@ -9,6 +9,11 @@ declare(strict_types=1);
  * Requires authentication and uses Bootstrap for layout.
  */
 require_once '../users/init.php';
+
+// Hint for the nav active-state matcher (see usersc/templates/customizer/file_nav_custom.php).
+// Must be set before elanregistry_prep.php, which triggers the nav render.
+$nav_section = (($_GET['subdir'] ?? '') === 'stories') ? 'stories' : 'reference';
+
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 if (!securePage($php_self)) {

--- a/usersc/templates/customizer.css
+++ b/usersc/templates/customizer.css
@@ -39,7 +39,7 @@
   /* Neutrals */
   --er-neutral: #6c757d;
   --er-neutral-light: #f4f5f3;
-  --er-neutral-dark: #1f2421;
+  --er-neutral-dark: #3b413d;
   --er-true-black: #010101;
 
   /* On-color text */
@@ -439,6 +439,31 @@ ul.us_menu.dark .us_sub-menu li,
 ul.us_menu.dark li:hover,
 ul.us_menu.dark ul.us_sub-menu {
   background-color: var(--er-neutral-dark) !important;
+}
+
+/* Active nav section — 3px Lotus Yellow underline echoes the L1 card stripe. */
+ul.us_menu.dark > li.active > a {
+  box-shadow: inset 0 -3px 0 var(--er-accent);
+  font-weight: 600;
+}
+
+/* Lotus Yellow CTA button — high-contrast filled button for loud CTAs that
+   must pop on dark backgrounds (currently the public-nav Register link).
+   Yellow + true-black mirrors the er-badge-yellow rule: never white text.
+   !important on color overrides upstream menu.css's
+   `ul.us_menu.dark a { color: rgba(255,255,255,.55) }` which otherwise wins
+   on specificity when the button is rendered inside the nav. */
+.btn-er-yellow {
+  background-color: var(--er-accent);
+  border-color: var(--er-accent);
+  color: var(--er-on-accent) !important;
+  font-weight: 600;
+}
+.btn-er-yellow:hover,
+.btn-er-yellow:focus-visible {
+  background-color: var(--er-accent-dark);
+  border-color: var(--er-accent-dark);
+  color: var(--er-on-accent) !important;
 }
 
 /* Form focus — Bootstrap hardcodes #86b7fe focus border at component scope;

--- a/usersc/templates/customizer/file_nav_custom.php
+++ b/usersc/templates/customizer/file_nav_custom.php
@@ -1,3 +1,50 @@
+<?php
+/**
+ * Active-state matcher. Each top-level item declares the paths it "owns";
+ * the first match wins, so more-specific entries (Add Car) precede broader
+ * prefixes (List Cars). Trailing '/' marks a prefix; bare paths are exact.
+ * $php_self is normalized against $us_url_root so subfolder installs (e.g.
+ * MAMP at /elan-registry/) match the same patterns as production at /.
+ *
+ * Generic viewer pages (pdf-viewer.php, guide-viewer.php) can't be classified
+ * by path alone — they set $nav_section before this template renders and we
+ * honor it directly.
+ */
+$navActive = $nav_section ?? '';
+if ($navActive === '') {
+    $navActive = (static function (string $current, string $root): string {
+    if ($root !== '' && $root !== '/' && str_starts_with($current, $root)) {
+        $current = '/' . ltrim(substr($current, strlen($root)), '/');
+    }
+    // Order matters: exact paths and more-specific entries first so they win
+    // over broader prefixes (e.g. factory.php beats the /app/cars/ prefix).
+    $sections = [
+        'add_car'    => ['/app/cars/form.php'],
+        'reference'  => ['/app/cars/factory.php', '/docs/reference/'],
+        'list_cars'  => ['/app/cars/'],
+        'statistics' => ['/app/reports/statistics.php'],
+        'stories'    => ['/docs/car-stories.php', '/docs/stories/'],
+        'guides'     => ['/docs/guides/'],
+        'register'   => ['/users/join.php', '/usersc/join.php'],
+        'login'      => ['/users/login.php', '/usersc/login.php'],
+        'admin'      => ['/app/admin/', '/docs/admin/', '/users/admin.php'],
+        'account'    => ['/users/account.php', '/app/contact/', '/users/logout.php'],
+    ];
+    foreach ($sections as $key => $patterns) {
+        foreach ($patterns as $p) {
+            if (substr($p, -1) === '/') {
+                if (str_starts_with($current, $p)) {
+                    return $key;
+                }
+            } elseif ($p === $current) {
+                return $key;
+            }
+        }
+    }
+    return '';
+    })($php_self ?? '/', $us_url_root ?? '/');
+}
+?>
 <!-- ElanRegistry navigation menu using the Customizer us_menu CSS class system. -->
 <ul class='us_menu horizontal dark' style=' z-index: 50;' id='us_menu_1_638b71f2ed026'>
   <div class='us_brand full_screen'>
@@ -19,7 +66,7 @@
     </div>
   </div>
 
-  <li class=''>
+  <li class='<?= $navActive === 'list_cars' ? 'active' : '' ?>'>
     <a class='' href='<?= $us_url_root ?>app/cars/index.php'>
       <i class='fa fa-car'></i>
       <span class='labelText'>List Cars</span>
@@ -27,7 +74,7 @@
   </li>
 
   <?php if (isset($user) && $user->isLoggedIn()): ?>
-    <li class=''>
+    <li class='<?= $navActive === 'add_car' ? 'active' : '' ?>'>
       <a class='btn btn-primary btn-sm ms-1' href='<?= $us_url_root ?>app/cars/form.php'>
         <i class='fa fa-plus'></i>
         <span class='labelText'>Add Car</span>
@@ -35,14 +82,14 @@
     </li>
   <?php endif; ?>
 
-  <li class=''>
+  <li class='<?= $navActive === 'statistics' ? 'active' : '' ?>'>
     <a class='' href='<?= $us_url_root ?>app/reports/statistics.php'>
       <i class='fa fa-pie-chart'></i>
       <span class='labelText'>Statistics</span>
     </a>
   </li>
 
-  <li class='dropdown'>
+  <li class='dropdown <?= $navActive === 'reference' ? 'active' : '' ?>'>
     <a class='sub-toggle' href='#' id='menu_1_638b71f2ed026_dropdown_reference' role='button' aria-haspopup='true' aria-expanded='false' data-target='#menu_1_638b71f2ed026_dropdown_reference'>
       <i class='fa fa-book'></i>
       <span class='labelText'>Reference</span>
@@ -82,14 +129,14 @@
     </ul>
   </li>
 
-  <li class=''>
+  <li class='<?= $navActive === 'stories' ? 'active' : '' ?>'>
     <a class='' href='<?= $us_url_root ?>docs/car-stories.php'>
       <i class='fa fa-book-open'></i>
       <span class='labelText'>Car Stories</span>
     </a>
   </li>
 
-  <li class=''>
+  <li class='<?= $navActive === 'guides' ? 'active' : '' ?>'>
     <a class='' href='<?= $us_url_root ?>docs/guides/index.php'>
       <i class='fa fa-question-circle'></i>
       <span class='labelText'>Guides</span>
@@ -108,7 +155,7 @@
     <?php endif; ?>
 
     <?php if (isRegistryAdmin($user->data()->id)): ?>
-      <li class='dropdown'>
+      <li class='dropdown <?= $navActive === 'admin' ? 'active' : '' ?>'>
         <a class='sub-toggle' href='#' id='menu_1_638b71f2ed026_dropdown_admin' role='button' aria-haspopup='true' aria-expanded='false' data-target='#menu_1_638b71f2ed026_dropdown_admin'>
           <i class='fa fa-cogs'></i>
           <span class='labelText'>Admin</span>
@@ -148,7 +195,7 @@
       </li>
     <?php endif; ?>
 
-    <li class='dropdown'>
+    <li class='dropdown <?= $navActive === 'account' ? 'active' : '' ?>'>
       <a class='sub-toggle' href='#' id='menu_1_638b71f2ed026_dropdown_account' role='button' aria-haspopup='true' aria-expanded='false' data-target='#menu_1_638b71f2ed026_dropdown_account'>
         <i class='fa fa-user'></i>
         <span class='labelText'><?= echousername($user->data()->id); ?></span>
@@ -180,15 +227,15 @@
   <?php else: ?>
 
     <?php if ($settings->registration == 1): ?>
-      <li class=''>
-        <a class='' href='<?= $us_url_root ?>users/join.php'>
+      <li class='<?= $navActive === 'register' ? 'active' : '' ?>'>
+        <a class='btn btn-er-yellow btn-sm ms-1' href='<?= $us_url_root ?>users/join.php'>
           <i class='fa fa-plus-square'></i>
           <span class='labelText'>Register</span>
         </a>
       </li>
     <?php endif; ?>
 
-    <li class=''>
+    <li class='<?= $navActive === 'login' ? 'active' : '' ?>'>
       <a class='' href='<?= $us_url_root ?>users/login.php'>
         <i class='fa fa-sign-in'></i>
         <span class='labelText'>Log In</span>


### PR DESCRIPTION
## Summary

- Public nav now signals the current section with a 3px Lotus Yellow underline; matching is by path prefix so detail pages keep their parent section highlighted. Generic viewer pages (`pdf-viewer.php`, `guide-viewer.php`) set a `$nav_section` hint before the prep include so they classify correctly (subdir → stories/reference; doc category → admin/guides).
- Register link promoted to a high-contrast CTA via a new global `.btn-er-yellow` utility (solid Lotus Yellow + `--er-on-accent` text). Distinct from the logged-in `btn-primary` Add Car so the two states read as separate CTAs.
- `--er-neutral-dark` softened from `#1F2421` to `#3B413D` so dark surfaces (nav, hero banners, L1 card headers) feel less heavy site-wide. Still WCAG AAA for white text (9.4:1).
- New nav patterns and the `btn-er-yellow` utility added to `color-preview.php` and documented in `UI_STANDARDS.md` per the Golden Rule.

## Test plan

- [ ] Logged-out: `/app/cars/index.php`, `/app/reports/statistics.php`, `/docs/reference/index.php`, `/docs/car-stories.php`, `/docs/guides/index.php`, `/users/join.php`, `/users/login.php` — exactly one nav item is underlined on each.
- [ ] Logged-out: drill into a car detail page — **List Cars** stays active (section-prefix match).
- [ ] Logged-out: `pdf-viewer.php?subdir=stories&doc=…` → **Car Stories** active; `pdf-viewer.php?subdir=reference&doc=…` → **Reference** active; `guide-viewer.php?doc=ADD_CAR_GUIDE.md` → **Guides** active.
- [ ] Logged-in: Add Car still solid BRG; admin dropdown active on `/app/admin/*` and `/docs/admin/*`; account dropdown active on `/users/account.php`.
- [ ] Register button reads loud and clear on the dark nav (Lotus Yellow fill, true-black text); hover darkens to `--er-accent-dark`.
- [ ] Glance at Statistics overview, car-detail hero, and any L1 card to confirm the softer `--er-neutral-dark` reads well everywhere it surfaces.
- [ ] `/app/admin/color-preview.php` — Navigation demo section renders both patterns correctly.

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)