### PR TITLE
feat: car details and homepage mobile UX improvements (#760)

### DIFF
--- a/app/cars/details.php
+++ b/app/cars/details.php
@@ -198,10 +198,11 @@ if (!empty($_GET)) {
                                             </form>
                                     <?php
                                         }
-                                    } else {
-                                        echo "<div class='text-white-50'><i class='fas fa-sign-in-alt'></i> Log in to contact owner</div>";
-                                        echo "<input type='hidden' name='car_id' id='car_id' value='" . htmlspecialchars((string)$carData->id, ENT_QUOTES, 'UTF-8') . "' />";
-                                    }
+                                    } else { ?>
+                                        <a href="<?= htmlspecialchars($us_url_root . 'users/login.php', ENT_QUOTES, 'UTF-8') ?>" class="btn btn-outline-light btn-sm">
+                                            <i class="fas fa-sign-in-alt me-1"></i> Log in to contact owner
+                                        </a>
+                                    <?php }
                                     ?>
                                 </div>
                             </div>
@@ -211,7 +212,7 @@ if (!empty($_GET)) {
             </div>
 
             <div class="row">
-                <div class="col-lg-6 mb-4">
+                <div class="col-lg-6 mb-4 order-last order-lg-first">
                     <!-- Vehicle Information Card -->
                     <div class="card registry-card mb-4">
                         <div class="card-header">
@@ -402,7 +403,7 @@ if (!empty($_GET)) {
                     </div>
                 </div>
                 
-                <div class="col-lg-6 mb-4">
+                <div class="col-lg-6 mb-4 order-first order-lg-last">
                     <!-- Car Images -->
                     <div class="card registry-card mb-4">
                         <div class="card-header">

--- a/docs/releases/RELEASE_NOTES_v2.24.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.24.0.md
@@ -25,7 +25,7 @@ reply-to name appears correctly in the received message.
 
 - **Lotus-green color system** ([#757](https://github.com/unibrain1/elanregistry/issues/757)): Site-wide CSS custom property color system with Lotus green as primary — consistent brand color across all pages.
 - **Navigation active state and Register CTA** ([#758](https://github.com/unibrain1/elanregistry/issues/758)): Active nav item now visually indicated; Register button promoted as a CTA for unauthenticated visitors.
-- **Car details hero banner** ([#760](https://github.com/unibrain1/elanregistry/issues/760)): Lotus-green hero banner on car detail pages; Contact Owner button more prominent; mobile layout shows photo first.
+- **Car details and homepage mobile UX** ([#760](https://github.com/unibrain1/elanregistry/issues/760)): Lotus-green hero banner on car detail pages; "Log in to contact owner" promoted to a visible outline button linking to login; photo renders above spec table on mobile on both the car detail page and the homepage.
 - **Statistics overview** ([#761](https://github.com/unibrain1/elanregistry/issues/761)): Timeline charts moved above the fold; stat card colors unified.
 - **Statistics chart color consistency** ([#762](https://github.com/unibrain1/elanregistry/issues/762)): Geographic, Production, and Colors tabs now use a consistent color palette.
 - **Car list refinements** ([#763](https://github.com/unibrain1/elanregistry/issues/763)): Series

--- a/index.php
+++ b/index.php
@@ -82,7 +82,7 @@ $yearsSince = (int) (new DateTime())->diff(new DateTime('2003-01-01'))->y;
 <div class="page-wrapper">
 	<div class='container'>
 		<div class='row'>
-			<div class='col-lg-5'>
+			<div class='col-lg-5 order-last order-lg-first'>
 				<div class='card registry-card'>
 					<div class='card-header card-header-er-primary'>
 						<h1 class='mb-0 card-header-er-primary-text'><i class='fas fa-car'></i> <?php echo htmlspecialchars($settings->site_name ?? 'Lotus Elan Registry', ENT_QUOTES, 'UTF-8'); ?></h1>
@@ -140,7 +140,7 @@ $yearsSince = (int) (new DateTime())->diff(new DateTime('2003-01-01'))->y;
 				</div>
 
 			</div>
-			<div class='col-lg-7'>
+			<div class='col-lg-7 order-first order-lg-last'>
 				<div class='card registry-card'>
 					<div class='card-header card-header-er-primary'>
 						<h2 class='mb-0 card-header-er-primary-text'><i class='fas fa-star'></i> One of the Cars</h2>
@@ -180,7 +180,11 @@ $yearsSince = (int) (new DateTime())->diff(new DateTime('2003-01-01'))->y;
 						?>
 					</div>
 				</div>
-				<div class='card registry-card mt-4'>
+			</div>
+		</div>
+		<div class="row mt-4">
+			<div class="col-12">
+				<div class='card registry-card'>
 					<div class='card-header card-header-er-primary'>
 						<h2 class='mb-0 card-header-er-primary-text'><i class='fas fa-heart'></i> Thanks</h2>
 					</div>


### PR DESCRIPTION
## Summary

- Promotes the logged-out "Log in to contact owner" element from dim `text-white-50` text to a visible `btn-outline-light btn-sm` anchor linking to the login page; removes an orphaned hidden `car_id` input that had no parent form
- On car detail pages, photos column renders above the spec table on mobile viewports (<992px); desktop two-column layout unchanged
- On the homepage, "One of the Cars" photo card renders first on mobile; "Thanks" card moved out of the right column into its own full-width row so it renders last on all viewports

Mobile order on homepage: **Photo → Lotus Elan Registry → How are we doing? → Thanks**

Hero banner color (Lotus green) was already handled by #757's CSS token cascade — no code change needed.

## Test plan

- [ ] Car detail page (logged out): "Log in to contact owner" appears as a visible outline button; clicking navigates to login page
- [ ] Car detail page (logged in as owner): "Update Car" button unchanged
- [ ] Car detail page (logged in as non-owner): "Contact Owner" button unchanged
- [ ] Car detail page mobile (<992px): Photos render above spec table
- [ ] Car detail page desktop (≥992px): Two-column layout unchanged
- [ ] Homepage mobile (<992px): Photo → Registry intro → How are we doing? → Thanks
- [ ] Homepage desktop (≥992px): Left col (intro + stats) | Right col (photo), Thanks full-width below

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)