### PR TITLE
ux: paint colors — larger swatches, prominent filter tabs, Car Stories second CTA (#769)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ tests/playwright/.auth/
 usersc/plugins/sendinblue_backup_*/
 @backup*
 backup/
+db-backups/
 usupdate.zip
 # Backup directory - ignore all backup files but keep directory structure
 backups/**/

--- a/docs/car-stories.php
+++ b/docs/car-stories.php
@@ -63,6 +63,19 @@ $storyCards = [
     ],
 ];
 
+$shareYourStory = static function (string $alertVariant, string $rowClasses = 'mt-4') use ($us_url_root): void { ?>
+        <div class="row <?= $rowClasses ?>">
+            <div class="col-12">
+                <div class="alert alert-<?= $alertVariant ?>">
+                    <i class="fas fa-pen-alt"></i>
+                    <strong>Share Your Story:</strong>
+                    Have a story about your Elan? We'd love to feature it here!
+                    <a href="<?= $us_url_root ?>app/contact/" class="alert-link">Contact us</a>
+                    to share your car's unique history.
+                </div>
+            </div>
+        </div>
+<?php };
 ?>
 <div class="page-wrapper">
     <div class="container">
@@ -73,19 +86,11 @@ $storyCards = [
             'description' => 'Individual car histories, owner stories, and community articles',
         ]) ?>
 
-        <div class="row mt-4">
-            <div class="col-12">
-                <div class="alert alert-success">
-                    <i class="fas fa-pen-alt"></i>
-                    <strong>Share Your Story:</strong>
-                    Have a story about your Elan? We'd love to feature it here!
-                    <a href="<?= $us_url_root ?>app/contact/" class="alert-link">Contact us</a>
-                    to share your car's unique history.
-                </div>
-            </div>
-        </div>
+        <?php $shareYourStory('success') ?>
 
         <?= DocumentPortalTemplate::renderDocumentCardGrid($storyCards) ?>
+
+        <?php $shareYourStory('warning', 'mt-5') ?>
 
     </div>
 </div>

--- a/docs/reference/paint-colors.php
+++ b/docs/reference/paint-colors.php
@@ -192,13 +192,13 @@ function renderChip(string $chipFile, string $altText, string $basePath): string
         <div class="row mt-3">
             <div class="col-12">
                 <div class="card registry-card">
-                    <div class="card-body py-2">
+                    <div class="card-body py-3 d-flex flex-wrap gap-2 align-items-center">
                         <strong>Jump to:</strong>
-                        <a href="#early-colors" class="btn btn-outline-primary btn-sm mx-1">Early Colors</a>
-                        <a href="#official-colors" class="btn btn-outline-primary btn-sm mx-1">Official Colors (L01&ndash;L26)</a>
-                        <a href="#special-finishes" class="btn btn-outline-primary btn-sm mx-1">Special Finishes</a>
-                        <a href="#paint-suppliers" class="btn btn-outline-primary btn-sm mx-1">Paint Suppliers</a>
-                        <a href="#paint-codes" class="btn btn-outline-primary btn-sm mx-1">Paint Code Reference</a>
+                        <a href="#early-colors" data-section="early-colors" class="btn btn-outline-primary rounded-pill">Early Colors</a>
+                        <a href="#official-colors" data-section="official-colors" class="btn btn-outline-primary rounded-pill">Official Colors (L01&ndash;L26)</a>
+                        <a href="#special-finishes" data-section="special-finishes" class="btn btn-outline-primary rounded-pill">Special Finishes</a>
+                        <a href="#paint-suppliers" data-section="paint-suppliers" class="btn btn-outline-primary rounded-pill">Paint Suppliers</a>
+                        <a href="#paint-codes" data-section="paint-codes" class="btn btn-outline-primary rounded-pill">Paint Code Reference</a>
                     </div>
                 </div>
             </div>
@@ -398,12 +398,28 @@ function renderChip(string $chipFile, string $altText, string $basePath): string
 
 <style>
     .paint-chip {
-        max-width: 80px;
-        max-height: 80px;
+        min-width: 48px;
+        min-height: 48px;
         border: 1px solid #dee2e6;
         border-radius: 4px;
     }
 </style>
+<script nonce="<?= htmlspecialchars($userspice_nonce ?? '', ENT_QUOTES, 'UTF-8') ?>">
+(function () {
+    const tabs = document.querySelectorAll('[data-section]');
+    if (!tabs.length) return;
+    const setActive = (id) => tabs.forEach(t => t.classList.toggle('active', t.dataset.section === id));
+    if (location.hash) setActive(location.hash.slice(1));
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(e => { if (e.isIntersecting) setActive(e.target.id); });
+    }, { rootMargin: '-20% 0px -70% 0px', threshold: 0 });
+    tabs.forEach(t => {
+        const el = document.getElementById(t.dataset.section);
+        if (el) observer.observe(el);
+    });
+    tabs.forEach(t => t.addEventListener('click', () => setActive(t.dataset.section)));
+})();
+</script>
 
 <?php
 require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php';


### PR DESCRIPTION
## Summary

- **Paint color swatches** (`docs/reference/paint-colors.php`): Added `min-width/height: 48px` floor so small chip images are clearly visible; images larger than 48px continue to display at their natural size.
- **Filter tabs** (`docs/reference/paint-colors.php`): Upgraded from `btn-sm` outline links to full-size `rounded-pill` buttons with `d-flex flex-wrap gap-2` for mobile wrapping. Added `IntersectionObserver` JS (with CSP nonce) that highlights the active pill as sections scroll into view, with fallback for direct hash navigation.
- **Car Stories second CTA** (`docs/car-stories.php`): Added a second "Share Your Story" banner below the story card grid using `alert-warning` (amber) to stand out from the green top banner. CTA markup extracted into a `$shareYourStory` closure to eliminate duplication.

## Test plan

- [ ] Paint Colors page: swatches are visibly larger (≥48px) across all tab sections
- [ ] Paint Colors page: filter tab buttons are full-size pills, wrap cleanly on mobile
- [ ] Paint Colors page: scrolling highlights the correct active tab; clicking a tab highlights it immediately; direct hash URL (e.g. `#official-colors`) pre-highlights the correct tab on load
- [ ] Car Stories page: "Share Your Story" banner appears at top (green) and bottom (amber) of the page
- [ ] No regressions on other pages

Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)