### PR TITLE
editorial: replace em dashes and simplify parentheticals in user-facing UI text (#895)

### DIFF
--- a/app/admin/includes/tab-settings.php
+++ b/app/admin/includes/tab-settings.php
@@ -282,7 +282,7 @@ $autoCreationMessages = processSettingsAutoCreation();
                                    value="<?= $settings->elan_image_upload_max_size ?? '2.00' ?>">
                             <span class="input-group-text">MB</span>
                         </div>
-                        <small class="form-text text-muted">Maximum file size for individual photo uploads (0.5-10 MB)</small>
+                        <small class="form-text text-muted">Maximum file size for individual photo uploads. Accepted range: 0.5–10 MB.</small>
                     </div>
                 </div>
             </div>

--- a/app/cars/factory.php
+++ b/app/cars/factory.php
@@ -29,7 +29,7 @@ if (!securePage($php_self)) {
             <div class="card-body">
               <div class="alert alert-warning">
                 <i class="fas fa-exclamation-triangle me-1"></i>
-                <strong>WARNING</strong> — This information has not been verified against the Lotus archives.
+                <strong>WARNING:</strong> This information has not been verified against the Lotus archives.
               </div>
               <table id="cartable" class="table table-striped table-bordered table-sm w-100 registry-table" aria-describedby="card-header">
                 <thead>

--- a/app/cars/form.php
+++ b/app/cars/form.php
@@ -204,7 +204,7 @@ function updateCarDetails(array &$car): void
                 <div class="row mb-4">
                     <div class="col-md-4">
                         <div class="text-center p-3 border rounded bg-light">
-                            <h6 class="text-primary mb-2">Pre-1970 (1963-1969)</h6>
+                            <h6 class="text-primary mb-2">1963–1969</h6>
                             <code class="d-block mb-2">1234</code>
                             <small class="text-muted">4 digits only</small>
                         </div>
@@ -219,7 +219,7 @@ function updateCarDetails(array &$car): void
                     </div>
                     <div class="col-md-4">
                         <div class="text-center p-3 border rounded bg-light">
-                            <h6 class="text-success mb-2">Post-1970 (1971-1974)</h6>
+                            <h6 class="text-success mb-2">1971–1974</h6>
                             <code class="d-block mb-2">7301019999B</code>
                             <small class="text-muted">11 characters YYMMBBXXXXC</small>
                         </div>
@@ -235,7 +235,7 @@ function updateCarDetails(array &$car): void
                             </div>
                             <div class="card-body">
                                 <p><strong>Valid codes:</strong> A, B, C, D, E, F, G, H, J, K</p>
-                                <p class="text-danger mb-0"><strong>Invalid:</strong> I (never used)</p>
+                                <p class="text-danger mb-0"><strong>Invalid:</strong> I — not used</p>
                             </div>
                         </div>
                     </div>
@@ -477,7 +477,7 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
             imageResizeMode: 'downscale',
             credits: false,
             labelIdle: 'Drop photos here or <span class="filepond--label-action">Browse</span>',
-            labelFileTypeNotAllowed: 'Invalid file type — only images are allowed',
+            labelFileTypeNotAllowed: 'Invalid file type. Only images are allowed.',
             fileValidateTypeLabelExpectedTypes: 'Expects {allTypes}',
             labelMaxFileSizeExceeded: 'Photo is too large',
             labelMaxFileSize: 'Maximum size is {filesize}',

--- a/app/views/_edit_car_2.php
+++ b/app/views/_edit_car_2.php
@@ -18,7 +18,7 @@
             <span class='input-group-text'><i aria-hidden='true' class='fas fa-calendar'></i></span>
             <input class='form-control' name='purchasedate' id='purchasedate' value='<?= htmlspecialchars((string)($cardetails['purchasedate'] ?? ''), ENT_QUOTES, 'UTF-8') ?>' type='text' placeholder='YYYY-MM-DD' pattern='\d{4}-\d{2}-\d{2}' inputmode='numeric' />
         </div>
-        <small id='purchasedateHelp' class='form-text text-muted'>Approximate date you purchased the car &mdash; use <strong>YYYY-MM-DD</strong> format (e.g. 1973-06-15).</small>
+        <small id='purchasedateHelp' class='form-text text-muted'>Approximate date you purchased the car. Use <strong>YYYY-MM-DD</strong> format (e.g. 1973-06-15).</small>
     </div>
 </div>
 
@@ -41,7 +41,7 @@
             <span class='input-group-text'><i aria-hidden='true' class='fas fa-calendar'></i></span>
             <input class='form-control' name='solddate' id='solddate' value='<?= htmlspecialchars((string)($cardetails['solddate'] ?? ''), ENT_QUOTES, 'UTF-8') ?>' type='text' placeholder='YYYY-MM-DD' pattern='\d{4}-\d{2}-\d{2}' inputmode='numeric' />
         </div>
-        <small id='solddateHelp' class='form-text text-muted'>Approximate date you sold the car &mdash; use <strong>YYYY-MM-DD</strong> format (e.g. 1985-03-01).</small>
+        <small id='solddateHelp' class='form-text text-muted'>Approximate date you sold the car. Use <strong>YYYY-MM-DD</strong> format (e.g. 1985-03-01).</small>
     </div>
 </div>
 

--- a/docs/reference/identification-guide.php
+++ b/docs/reference/identification-guide.php
@@ -41,7 +41,7 @@ $placeholder = $us_url_root . 'app/assets/img/elan-placeholder.svg';
                     <div class="card-body">
                         <div class="alert alert-primary mb-0">
                             <i class="fas fa-info-circle"></i>
-                            <strong>Note:</strong> This is not a comprehensive list of differences between the cars — it is a quick identification guide. Lotus made many undocumented running changes throughout production. If in doubt, post a question to the <a href="http://www.lotuselan.net/forums/" target="_blank" rel="noopener">LotusElan.net forum</a> and ask.
+                            <strong>Note:</strong> This is not a comprehensive list of differences between the cars; it is a quick identification guide. Lotus made many undocumented running changes throughout production. If in doubt, post a question to the <a href="http://www.lotuselan.net/forums/" target="_blank" rel="noopener">LotusElan.net forum</a> and ask.
                         </div>
                     </div>
                 </div>
@@ -250,7 +250,7 @@ $placeholder = $us_url_root . 'app/assets/img/elan-placeholder.svg';
                                             <li>Doors with fixed window frames</li>
                                             <li>Square tail lights</li>
                                             <li>Badged as Sprint</li>
-                                            <li>Unique two-tone paint (could be deleted as option)</li>
+                                            <li>Unique two-tone paint; could be deleted as a factory option</li>
                                             <li>Square-profile wheelarches</li>
                                             <li><a href="http://www.lotuselansprint.com" target="_blank" rel="noopener">Complete Sprint Details</a></li>
                                         </ul>
@@ -403,7 +403,7 @@ $placeholder = $us_url_root . 'app/assets/img/elan-placeholder.svg';
                                             <li>Doors with fixed window frames</li>
                                             <li>Square tail lights</li>
                                             <li>Badged as Sprint</li>
-                                            <li>Unique two-tone paint (could be deleted as option)</li>
+                                            <li>Unique two-tone paint; could be deleted as a factory option</li>
                                             <li>Square-profile wheelarches</li>
                                             <li><a href="http://www.lotuselansprint.com" target="_blank" rel="noopener">Complete Sprint Details</a></li>
                                         </ul>
@@ -494,8 +494,8 @@ $placeholder = $us_url_root . 'app/assets/img/elan-placeholder.svg';
                                     <div class="col-md-8">
                                         <ul class="mb-0">
                                             <li>VIN/Chassis number starts with <strong>50/0001</strong></li>
-                                            <li>2 large gauges &mdash; Speedometer, Tachometer</li>
-                                            <li>4 small gauges &mdash; Water Temp, Oil Pressure, Ammeter, Fuel</li>
+                                            <li>2 large gauges: Speedometer, Tachometer</li>
+                                            <li>4 small gauges: Water Temp, Oil Pressure, Ammeter, Fuel</li>
                                         </ul>
                                     </div>
                                 </div>
@@ -514,8 +514,8 @@ $placeholder = $us_url_root . 'app/assets/img/elan-placeholder.svg';
                                     <div class="col-md-8">
                                         <ul class="mb-0">
                                             <li>VIN/Chassis number starts with <strong>50/0857</strong> (US); <strong>50/0929</strong> (all markets)</li>
-                                            <li>2 large gauges &mdash; Speedometer, Tachometer</li>
-                                            <li>4 small gauges &mdash; Water Temp, Oil Pressure, Ammeter, Fuel</li>
+                                            <li>2 large gauges: Speedometer, Tachometer</li>
+                                            <li>4 small gauges: Water Temp, Oil Pressure, Ammeter, Fuel</li>
                                             <li>Remote boot release, flush interior door handles, modified exhaust</li>
                                         </ul>
                                     </div>
@@ -536,8 +536,8 @@ $placeholder = $us_url_root . 'app/assets/img/elan-placeholder.svg';
                                     <div class="col-md-8">
                                         <ul class="mb-0">
                                             <li>VIN/Chassis number starts with <strong>50/1593</strong></li>
-                                            <li>2 large gauges &mdash; Speedometer, Tachometer</li>
-                                            <li>6 small gauges &mdash; Oil, Water Temp, Battery Condition, Temp, Fuel, Clock</li>
+                                            <li>2 large gauges: Speedometer, Tachometer</li>
+                                            <li>6 small gauges: Oil, Water Temp, Battery Condition, Temp, Fuel, Clock</li>
                                             <li>4 warning lights in centre of dash (Hazard, Parking Brake, Brake Fail, Rear Screen)</li>
                                             <li>New luxury interior including revised seats and centre console</li>
                                             <li>Fog/driving lamps below the bumper</li>
@@ -559,8 +559,8 @@ $placeholder = $us_url_root . 'app/assets/img/elan-placeholder.svg';
                                     <div class="col-md-8">
                                         <ul class="mb-0">
                                             <li>VIN/Chassis number starts with <strong>50/2447</strong></li>
-                                            <li>2 large gauges &mdash; Speedometer, Tachometer</li>
-                                            <li>6 small gauges &mdash; Oil, Water Temp, Battery Condition, Temp, Fuel, Clock</li>
+                                            <li>2 large gauges: Speedometer, Tachometer</li>
+                                            <li>6 small gauges: Oil, Water Temp, Battery Condition, Temp, Fuel, Clock</li>
                                             <li>4 warning lights in centre of dash (Hazard, Parking Brake, Brake Fail, Rear Screen)</li>
                                             <li>Luxury interior including revised seats and centre console</li>
                                             <li>Fog/driving lamps below the bumper</li>
@@ -586,8 +586,8 @@ $placeholder = $us_url_root . 'app/assets/img/elan-placeholder.svg';
                                     <div class="col-md-6">
                                         <ul class="mb-0">
                                             <li>VIN/Chassis number starts with <strong>71.01&hellip;0001</strong></li>
-                                            <li>2 large gauges &mdash; Speedometer, Tachometer</li>
-                                            <li>6 small gauges &mdash; Oil, Water Temp, Battery Condition, Temp, Fuel, Clock</li>
+                                            <li>2 large gauges: Speedometer, Tachometer</li>
+                                            <li>6 small gauges: Oil, Water Temp, Battery Condition, Temp, Fuel, Clock</li>
                                             <li>3 warning lights in centre of dash (Hazard, Park/Brake Fail, Rear Screen)</li>
                                             <li>Luxury interior including revised seats and centre console</li>
                                             <li>Big Valve engine</li>

--- a/docs/reference/paint-colors.php
+++ b/docs/reference/paint-colors.php
@@ -326,8 +326,8 @@ function renderChip(string $chipFile, string $altText, string $basePath): string
                     <div class="card-body">
                         <p>The Lotus &ldquo;L&rdquo; prefix codes indicate nitro-cellulose paint. Two suppliers originally provided paint to the Lotus factory:</p>
                         <ul>
-                            <li><strong>Pinchin, Johnson</strong> &mdash; Later taken over by Courtaulds and merged into International Paint.</li>
-                            <li><strong>ICI</strong> &mdash; ICI Paints was taken over by Nexa Autocolor, which is now a brand of PPG.</li>
+                            <li><strong>Pinchin, Johnson:</strong> Later taken over by Courtaulds and merged into International Paint.</li>
+                            <li><strong>ICI:</strong> ICI Paints was taken over by Nexa Autocolor, which is now a brand of PPG.</li>
                         </ul>
                         <h4>Modern Paint Matching Services</h4>
                         <div class="table-responsive">


### PR DESCRIPTION
## Summary

- Replace em dashes (`—` / `&mdash;`) with contextually appropriate punctuation (colon, period, semicolon) across six files
- Simplify parenthetical asides to inline plain text or remove redundant era labels

## Changes by file

- **`app/cars/factory.php`**: `WARNING` + em dash → `WARNING:`
- **`app/cars/form.php`**: `Pre-1970 (1963-1969)` → `1963–1969`; `Post-1970 (1971-1974)` → `1971–1974`; `I (never used)` → `I — not used`; file type error string em dash → period
- **`app/views/_edit_car_2.php`**: Both date help texts `&mdash; use` → `. Use`
- **`app/admin/includes/tab-settings.php`**: Upload size help text parenthetical → sentence form
- **`docs/reference/identification-guide.php`**: Note em dash → semicolon; 2× two-tone paint parenthetical → semicolon inline; 5 gauge list `&mdash;` → colons
- **`docs/reference/paint-colors.php`**: Pinchin Johnson and ICI supplier items — em dash moved to colon on bold label

No functional changes. No DB migrations. No test updates required.

## Test plan

- [ ] Visual inspection of changed pages: factory records, car add/edit form, identification guide, paint colors, admin settings
- [ ] Confirm "no data" `&mdash;` placeholders in paint-colors table cells are unchanged

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)