### PR TITLE
ux: fix Add/Edit Car form — premature validation icons, date inputs, checkbox layout (#772)

### DIFF
--- a/app/cars/form.php
+++ b/app/cars/form.php
@@ -56,8 +56,6 @@ $cardetails['image']        = null;
 $carprompt['chassis']       = 'Enter Chassis Number';
 $carprompt['color']         = 'Enter the current color of the car';
 $carprompt['engine']        = 'Enter Engine number - LPAxxxxx';
-$carprompt['purchasedate']  = 'YYYY-MM-DD';
-$carprompt['solddate']      = 'YYYY-MM-DD';
 $carprompt['comments']      = 'Please give a brief history of your car and anything special';
 $carprompt['website']       = 'Website URL';
 
@@ -424,8 +422,6 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
 <script src="<?=$us_url_root?>usersc/js/filepond-plugin-image-transform.min.js"></script>
 <link rel="stylesheet" href="<?=$us_url_root?>usersc/css/filepond.min.css">
 <link rel="stylesheet" href="<?=$us_url_root?>usersc/css/filepond-plugin-image-preview.min.css">
-<script src="<?=$us_url_root?>usersc/js/flatpickr.min.js"></script>
-<link rel="stylesheet" href="<?=$us_url_root?>usersc/css/flatpickr.min.css">
 
 <!-- Dynamic model loading from database -->
 <script src='<?= $us_url_root ?>app/assets/js/model-loader.min.js'></script>
@@ -435,8 +431,6 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
     const car_id = $('#car_id').val();
 
     $(document).ready(function() {
-        flatpickr('#purchasedate', { dateFormat: 'Y-m-d', allowInput: true });
-        const solddatePicker = flatpickr('#solddate', { dateFormat: 'Y-m-d', allowInput: true });
         const solddateRow = document.getElementById('solddate-row');
         const solddateInput = document.getElementById('solddate');
 
@@ -444,11 +438,11 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
             if (this.checked) {
                 solddateRow.classList.remove('d-none');
                 if (!solddateInput.value) {
-                    solddatePicker.setDate(new Date());
+                    solddateInput.value = new Date().toISOString().split('T')[0];
                 }
             } else {
                 solddateRow.classList.add('d-none');
-                solddatePicker.clear();
+                solddateInput.value = '';
             }
         });
 

--- a/app/views/_edit_car_1.php
+++ b/app/views/_edit_car_1.php
@@ -33,7 +33,7 @@
                         <option value="1973">1973</option>
                         <option value="1974">1974</option>
                     </select>
-                    <span class='input-group-text'><i id="year_icon" aria-hidden='true' class="fas fa-thumbs-down"></i></span>
+                    <span class='input-group-text'><i id="year_icon" aria-hidden='true' class="fas"></i></span>
                 </div>
             </div>
         </div>
@@ -47,7 +47,7 @@
                     <select disabled class="form-select" name="model" id="model">
                         <option value="">--Please Select Model--</option>
                     </select>
-                    <span class='input-group-text'><i id="model_icon" aria-hidden='true' class="fas fa-thumbs-down "></i></span>
+                    <span class='input-group-text'><i id="model_icon" aria-hidden='true' class="fas"></i></span>
                 </div>
             </div>
         </div>
@@ -60,7 +60,7 @@
                 <div class="input-group">
                     <span class="input-group-text"><i aria-hidden="true" class="fas fa-barcode"></i></span>
                     <input data-lpignore="true" disabled class="form-control" type="text" name="chassis" id="chassis" placeholder="<?= htmlspecialchars($carprompt['chassis'], ENT_QUOTES, 'UTF-8') ?>" value="<?= htmlspecialchars((string)($cardetails['chassis'] ?? ''), ENT_QUOTES, 'UTF-8') ?>" />
-                    <span class='input-group-text'><i id="chassis_icon" aria-hidden='true' class="fas fa-thumbs-down "></i></span>
+                    <span class='input-group-text'><i id="chassis_icon" aria-hidden='true' class="fas"></i></span>
                 </div>
 
 

--- a/app/views/_edit_car_2.php
+++ b/app/views/_edit_car_2.php
@@ -16,14 +16,14 @@
     <div class='col-12 col-sm-9'>
         <div class='input-group'>
             <span class='input-group-text'><i aria-hidden='true' class='fas fa-calendar'></i></span>
-            <input class='form-control' name='purchasedate' id='purchasedate' value='<?= htmlspecialchars((string)($cardetails['purchasedate'] ?? ''), ENT_QUOTES, 'UTF-8') ?>' type='text' placeholder='YYYY-MM-DD' pattern='\d{4}-\d{2}-\d{2}' inputmode='numeric' />
+            <input class='form-control' name='purchasedate' id='purchasedate' value='<?= htmlspecialchars((string)($cardetails['purchasedate'] ?? ''), ENT_QUOTES, 'UTF-8') ?>' type='date' min='1957-01-01' max='<?= date('Y-m-d') ?>' />
         </div>
-        <small id='purchasedateHelp' class='form-text text-muted'>Approximate date you purchased the car. Use <strong>YYYY-MM-DD</strong> format (e.g. 1973-06-15).</small>
+        <small id='purchasedateHelp' class='form-text text-muted'>Approximate date you purchased the car.</small>
     </div>
 </div>
 
 <!-- Sold Date toggle -->
-<div class='mb-3 row'>
+<div class='mb-3 mt-3 row'>
     <div class='col-md-3 col-12'></div>
     <div class='col-12 col-sm-9'>
         <div class='form-check'>
@@ -39,9 +39,9 @@
     <div class='col-12 col-sm-9'>
         <div class='input-group'>
             <span class='input-group-text'><i aria-hidden='true' class='fas fa-calendar'></i></span>
-            <input class='form-control' name='solddate' id='solddate' value='<?= htmlspecialchars((string)($cardetails['solddate'] ?? ''), ENT_QUOTES, 'UTF-8') ?>' type='text' placeholder='YYYY-MM-DD' pattern='\d{4}-\d{2}-\d{2}' inputmode='numeric' />
+            <input class='form-control' name='solddate' id='solddate' value='<?= htmlspecialchars((string)($cardetails['solddate'] ?? ''), ENT_QUOTES, 'UTF-8') ?>' type='date' min='1957-01-01' max='<?= date('Y-m-d') ?>' />
         </div>
-        <small id='solddateHelp' class='form-text text-muted'>Approximate date you sold the car. Use <strong>YYYY-MM-DD</strong> format (e.g. 1985-03-01).</small>
+        <small id='solddateHelp' class='form-text text-muted'>Approximate date you sold the car.</small>
     </div>
 </div>
 
@@ -50,7 +50,7 @@
     <label for='website' class='col-md-3 col-12 col-form-label'>Website</label>
     <div class='col-12 col-sm-9'>
         <div class='input-group'>
-            <span class='input-group-text'><i aria-hidden='true' class='fas fa-palette'></i></span>
+            <span class='input-group-text'><i aria-hidden='true' class='fas fa-globe'></i></span>
             <input class='form-control' type='url' name='website' id='website' placeholder='<?= htmlspecialchars($carprompt['website'], ENT_QUOTES, 'UTF-8') ?>' value='<?= htmlspecialchars((string)($cardetails['website'] ?? ''), ENT_QUOTES, 'UTF-8') ?>' />
         </div>
     </div>

--- a/docs/releases/RELEASE_NOTES_v2.24.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.24.0.md
@@ -41,8 +41,11 @@ reply-to name appears correctly in the received message.
   Amber alert for unverified factory records; introductory context paragraph added.
 - **Paint colors page** ([#769](https://github.com/unibrain1/elanregistry/issues/769)):
   Larger colour swatches, more prominent filter tabs, Car Stories second CTA added.
-- **Add/Edit Car form** ([#772](https://github.com/unibrain1/elanregistry/issues/772)):
-  Fixed premature validation icons, Purchase Date input, and checkbox layout.
+- **Add/Edit Car form UX fixes** ([#772](https://github.com/unibrain1/elanregistry/issues/772)):
+  Required fields (Year, Model, Chassis) no longer show a red invalid indicator before the user
+  has interacted with them. Purchase Date and Sold Date fields replaced with native date pickers
+  (no more manual YYYY-MM-DD entry). "I no longer own this car" checkbox given clear visual
+  separation from the date field. Website field icon corrected to a globe.
 - **Identification guide two-column layout** ([#834](https://github.com/unibrain1/elanregistry/issues/834)):
   Every car-model entry is now its own card with a Lotus-green model header
   and image-left / specs-right two-column body. Previously photoless models

--- a/tests/playwright/bs5-migration.test.js
+++ b/tests/playwright/bs5-migration.test.js
@@ -1,7 +1,7 @@
 // tests/playwright/bs5-migration.test.js
 //
 // Behavioral regression tests for Bootstrap 5 JS API migration (PR #730).
-// Covers: Flatpickr date pickers, Statistics page ElanRegistryAPI availability,
+// Covers: Date picker fields, Statistics page ElanRegistryAPI availability,
 // and the nav dropdown firstChild patch in footer.php.
 //
 // Requires local MAMP at http://localhost:9999/elan_registry
@@ -9,11 +9,9 @@
 const { test, expect } = require('@playwright/test');
 const { ensureLoggedIn, navigateAndWait } = require('./auth-helper.js');
 
-// ---------------------------------------------------------------------------
-// Area 1: Flatpickr date pickers (app/cars/form.php, Car Details section)
-// ---------------------------------------------------------------------------
+// Date field inputs — native <input type="date"> (converted from Flatpickr in #772)
 
-test.describe('BS5 Migration — Flatpickr date pickers', () => {
+test.describe('Date picker fields (Purchase Date, Sold Date)', () => {
   test.beforeEach(async ({ page }) => {
     await ensureLoggedIn(page);
     await page.goto('/app/cars/form.php', { waitUntil: 'networkidle' });
@@ -21,9 +19,9 @@ test.describe('BS5 Migration — Flatpickr date pickers', () => {
     await expect(page.locator('#section1')).toBeVisible({ timeout: 5000 });
   });
 
-  test('purchase date field opens flatpickr calendar', async ({ page }) => {
-    await page.locator('#purchasedate').click();
-    await expect(page.locator('.flatpickr-calendar')).toBeVisible();
+  test('purchase date input is native date type', async ({ page }) => {
+    await expect(page.locator('#purchasedate')).toHaveAttribute('type', 'date');
+    await expect(page.locator('#purchasedate')).toHaveAttribute('min', '1957-01-01');
   });
 
   test('purchase date stores value in YYYY-MM-DD format', async ({ page }) => {

--- a/tests/playwright/functionality.test.js
+++ b/tests/playwright/functionality.test.js
@@ -125,15 +125,45 @@ test.describe('Core Functionality After Refactoring', () => {
       '/app/cars/actions/check-chassis.php',
       '/app/cars/mapmarkers.xml.php'
     ];
-    
+
     for (const endpoint of endpoints) {
       const response = await page.request.post(endpoint, {
         data: { test: 'true' }
       });
-      
+
       // Should not return 404 or 500 errors
       expect(response.status()).not.toBe(404);
       expect(response.status()).not.toBe(500);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Premature validation icons — required fields should be neutral on page load
+// ---------------------------------------------------------------------------
+
+test.describe('Add Car form — no premature validation on page load', () => {
+  test.beforeEach(async ({ page }) => {
+    await ensureLoggedIn(page);
+    await page.goto('/app/cars/form.php', { waitUntil: 'networkidle' });
+  });
+
+  test('Year, Model, and Chassis icons are neutral (no thumbs-down) on load', async ({ page }) => {
+    // On initial page load for add mode, no field has been touched yet.
+    // Icons should not show the invalid/thumbs-down state.
+    await expect(page.locator('#year_icon')).not.toHaveClass(/fa-thumbs-down/);
+    await expect(page.locator('#model_icon')).not.toHaveClass(/fa-thumbs-down/);
+    await expect(page.locator('#chassis_icon')).not.toHaveClass(/fa-thumbs-down/);
+
+    // Also verify no is-invalid class on the icons themselves
+    await expect(page.locator('#year_icon')).not.toHaveClass(/is-invalid/);
+    await expect(page.locator('#model_icon')).not.toHaveClass(/is-invalid/);
+    await expect(page.locator('#chassis_icon')).not.toHaveClass(/is-invalid/);
+  });
+
+  test('Year, Model, and Chassis fields have no invalid border on load', async ({ page }) => {
+    await expect(page.locator('#year')).not.toHaveClass(/is-invalid/);
+    await expect(page.locator('#model')).not.toHaveClass(/is-invalid/);
+    await expect(page.locator('#chassis')).not.toHaveClass(/is-invalid/);
   });
 });


### PR DESCRIPTION
## Summary

- Required fields (Year, Model, Chassis) no longer show a red invalid indicator on a pristine form before the user has interacted with them — icons start neutral and JS applies valid/invalid state on blur/change
- Purchase Date and Sold Date replaced with native `<input type="date">` (min 1957-01-01, max today); Flatpickr dependency removed entirely
- "I no longer own this car" checkbox row given clear visual separation (`mt-3`) from the Purchase Date field
- Website field icon corrected from `fa-palette` → `fa-globe`
- Playwright tests updated: Flatpickr calendar test replaced with native date type assertion; two new tests verify no premature invalid state on page load

## Test plan

- [ ] Run `npm run playwright:test` locally against MAMP — all tests pass
- [ ] Visually confirm blank add-car form shows no thumbs-down icons before interaction
- [ ] Confirm native date picker appears for Purchase Date and Sold Date
- [ ] Confirm "I no longer own this car" checkbox is clearly separated from the date field
- [ ] Confirm Website field shows a globe icon
- [ ] Confirm edit-car form still hydrates Year/Model/Chassis icons correctly from existing data

Closes #772

🤖 Generated with [Claude Code](https://claude.ai/claude-code)