### PR TITLE
fix: replace die($e->getMessage()) with safe error handling in join.php

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -1,0 +1,51 @@
+# Elan Registry v2.25.0 Release Notes
+
+**Release Date:** TBD
+**Type:** Minor Release - Security & Data Integrity
+
+## Required Actions After Deployment
+
+_To be filled in as issues are completed. Expected: SQL migrations for new `chassis_override` column on `cars`, `cars_hist` trigger updates, and `car_user_hist` triggers/indexes (#915, #592)._
+
+## User-Facing Changes
+
+### Improvements
+
+- **Website Field URL Handling** ([#851](https://github.com/unibrain1/elanregistry/issues/851)): Website links now display correctly when the URL is missing the http/https scheme.
+- **Statistics Page Stability** ([#731](https://github.com/unibrain1/elanregistry/issues/731)): Fixed runtime errors on the statistics page for edge-case DOM states.
+- **Registration Error Messages** ([#873](https://github.com/unibrain1/elanregistry/issues/873)): Registration failures now show a clean, generic error message; full exception details are logged for admin review only.
+
+## Admin-Facing Changes
+
+### New Features
+
+- **Car Sharing Audit Trail** ([#609](https://github.com/unibrain1/elanregistry/issues/609)): Share and unshare events are now logged to the application audit trail.
+- **Schema Validation Script** ([#594](https://github.com/unibrain1/elanregistry/issues/594)): New maintenance script to verify trigger/history-table sync after schema changes.
+
+### Improvements
+
+- **Chassis Override Persistence** ([#915](https://github.com/unibrain1/elanregistry/issues/915)): Chassis validation override now persists correctly via a dedicated DB column; includes UI indicator and backfill script for existing records.
+- **Date Range Validation** ([#903](https://github.com/unibrain1/elanregistry/issues/903)): Server-side validation added for car purchase/sold date ranges.
+- **Admin Contact Security** ([#660](https://github.com/unibrain1/elanregistry/issues/660), [#661](https://github.com/unibrain1/elanregistry/issues/661)): Fixed email header injection and unvalidated recipient address in the admin multi-user contact path.
+- **Verification Email Escaping** ([#854](https://github.com/unibrain1/elanregistry/issues/854)): All fields in the admin verification email template are now properly escaped.
+- **Car Verification via Car Class** ([#624](https://github.com/unibrain1/elanregistry/issues/624)): `verify_car.php` now uses Car class methods instead of direct DB writes.
+- **Audit Trail for Car Deletion** ([#593](https://github.com/unibrain1/elanregistry/issues/593)): Eliminated duplicate history row written on car deletion.
+- **car_user_hist Triggers and Indexes** ([#592](https://github.com/unibrain1/elanregistry/issues/592)): Added DB triggers and indexes to `car_user_hist` for full audit coverage.
+- **Car Class Transaction Wrapper** ([#259](https://github.com/unibrain1/elanregistry/issues/259)): Added public transaction wrapper method to Car class for consistent DB consistency.
+
+## Issues Resolved
+
+- [#259](https://github.com/unibrain1/elanregistry/issues/259) — ENHANCE: Add transaction wrapper method to Car class for consistency
+- [#592](https://github.com/unibrain1/elanregistry/issues/592) — Add database triggers and indexes for car_user_hist table
+- [#593](https://github.com/unibrain1/elanregistry/issues/593) — Remove duplicate history row on car deletion
+- [#594](https://github.com/unibrain1/elanregistry/issues/594) — Add schema validation script for trigger/history table sync
+- [#609](https://github.com/unibrain1/elanregistry/issues/609) — security: add application-layer audit logging for car sharing operations
+- [#624](https://github.com/unibrain1/elanregistry/issues/624) — refactor: verify_car.php should use Car class methods instead of direct DB updates
+- [#660](https://github.com/unibrain1/elanregistry/issues/660) — bug: email header injection via $qualityIssue in admin contact subject line
+- [#661](https://github.com/unibrain1/elanregistry/issues/661) — bug: `target_email` unvalidated in admin contact multiple-user path
+- [#731](https://github.com/unibrain1/elanregistry/issues/731) — fix: statistics.js null safety — canvas getContext and href.substring(1)
+- [#851](https://github.com/unibrain1/elanregistry/issues/851) — bug: website field silently hidden when URL lacks http/https scheme
+- [#854](https://github.com/unibrain1/elanregistry/issues/854) — fix: escape remaining unescaped fields in admin verification email template
+- [#873](https://github.com/unibrain1/elanregistry/issues/873) — security: registration failure exposes raw exception message to user (usersc/join.php)
+- [#903](https://github.com/unibrain1/elanregistry/issues/903) — harden: server-side validation for car purchase/sold date ranges
+- [#915](https://github.com/unibrain1/elanregistry/issues/915) — fix: chassis override flag — fix client-side bug, persist to DB column, UI indicator, and admin fix script

--- a/usersc/join.php
+++ b/usersc/join.php
@@ -239,18 +239,30 @@ if (Input::exists()) {
                     }
                 }
             } catch (Exception $e) {
-                // Record failed registration attempt
                 handleAuthFailure('registration_attempt', null, $email, [], [
                     'username_attempted' => $username,
                     'email_attempted' => $email,
                     'error' => $e->getMessage(),
                     'user_agent' => $user_agent ?? ''
                 ]);
-                
+
                 if ($eventhooks = getMyHooks(['page' => 'joinFail'])) {
                     includeHook($eventhooks, 'body');
                 }
-                die($e->getMessage());
+
+                $safeToLog = preg_replace('/[\r\n\t]/', ' ', $e->getMessage()) ?? '[message unavailable]';
+                logger($theNewId ?? 0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR,
+                    'join.php: User creation failed — ' . get_class($e),
+                    [
+                        'exception_class' => get_class($e),
+                        'message'         => $safeToLog,
+                        'file'            => $e->getFile(),
+                        'line'            => $e->getLine(),
+                    ]);
+
+                usError('We could not complete your registration. Please try again or contact the administrator.');
+                Redirect::to(currentPage());
+                exit;
             }
             if ($form_valid == true) {
               //this allows the plugin hook to kill the post but it must delete the created user


### PR DESCRIPTION
## Summary

- Replaces `die($e->getMessage())` in `usersc/join.php` catch block with proper error handling: CRLF-sanitized `logger()` call under `LOG_CATEGORY_SYSTEM_ERROR` with full exception context (class, file, line), a generic `usError()` flash message, and `Redirect::to(currentPage()); exit;`
- `handleAuthFailure()` preserved verbatim per acceptance criteria — raw exception message retained for admin analytics
- `joinFail` event hook still fires before redirect

## Test plan

- [ ] Trigger a registration failure (e.g. temporarily force `$user->create()` to throw) and verify browser shows only the generic message
- [ ] Verify the UserSpice admin log shows a `SystemError` entry with full exception context
- [ ] Verify no exception text, DB column names, or PHP paths appear in the browser response

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)