### PR TITLE
fix: strip CR/LF from email header fields and add regression tests (#660, #661)

### DIFF
--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -107,11 +107,12 @@ if (Input::exists('post')) {
                     }
                 }
 
-                // Prepare email data
-                $toEmail = $ownerData->email;
+                // Prepare email data — strip CR/LF from all header-bound values (#660)
+                $toEmail = preg_replace('/[\r\n\t]/', '', $ownerData->email);
                 $toName = trim($ownerData->fname . ' ' . $ownerData->lname);
-                $fromEmail = $adminData->email;
+                $fromEmail = preg_replace('/[\r\n\t]/', '', $adminData->email);
                 $fromName = trim($adminData->fname . ' ' . $adminData->lname);
+                $qualityIssue = preg_replace('/[\r\n\t]/', '', (string)($qualityIssue ?? ''));
 
                 // Email subject
                 $subject = '[ELANREGISTRY] Administrator Message';
@@ -155,22 +156,19 @@ if (Input::exists('post')) {
                 }
 
                 // Send email
-                $result      = email($toEmail, $subject, $body);
-                $safeFromLog = preg_replace('/[\r\n\t]/', '', $fromEmail);
-                $safeToLog   = preg_replace('/[\r\n\t]/', '', $toEmail);
-                $safeIssue   = preg_replace('/[\r\n\t]/', '', (string)($qualityIssue ?? ''));
+                $result = email($toEmail, $subject, $body);
 
                 if ($result !== true) {
                     $resultStr = is_string($result) ? preg_replace('/[\r\n\t]/', '', $result) : 'unknown delivery error';
                     $errors[] = 'Failed to send email. Please try again.';
-                    logger($user->data()->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Admin contact SEND FAILED to {$safeToLog}: {$resultStr}");
+                    logger($user->data()->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Admin contact SEND FAILED to {$toEmail}: {$resultStr}");
                 } else {
                     if ($ownerId === 'Multiple') {
                         $successes[] = 'Administrator message sent successfully to duplicate accounts at ' . $toEmail;
                     } else {
                         $successes[] = 'Administrator message sent successfully to ' . $toName;
                     }
-                    logger($user->data()->id, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Admin contact sent - Admin: {$safeFromLog}, Owner: {$safeToLog}, Car: {$carId}, Issue: {$safeIssue}");
+                    logger($user->data()->id, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Admin contact sent - Admin: {$fromEmail}, Owner: {$toEmail}, Car: {$carId}, Issue: {$qualityIssue}");
                 }
 
             } catch (AdminContactException $e) {

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -1,0 +1,51 @@
+# Elan Registry v2.25.0 Release Notes
+
+**Release Date:** TBD
+**Type:** Minor Release - Security & Data Integrity
+
+## Required Actions After Deployment
+
+_To be filled in as issues are completed. Expected: SQL migrations for new `chassis_override` column on `cars`, `cars_hist` trigger updates, and `car_user_hist` triggers/indexes (#915, #592)._
+
+## User-Facing Changes
+
+### Improvements
+
+- **Website Field URL Handling** ([#851](https://github.com/unibrain1/elanregistry/issues/851)): Website links now display correctly when the URL is missing the http/https scheme.
+- **Statistics Page Stability** ([#731](https://github.com/unibrain1/elanregistry/issues/731)): Fixed runtime errors on the statistics page for edge-case DOM states.
+- **Registration Error Messages** ([#873](https://github.com/unibrain1/elanregistry/issues/873)): Registration failures now show a clean, generic error message; full exception details are logged for admin review only.
+
+## Admin-Facing Changes
+
+### New Features
+
+- **Car Sharing Audit Trail** ([#609](https://github.com/unibrain1/elanregistry/issues/609)): Share and unshare events are now logged to the application audit trail.
+- **Schema Validation Script** ([#594](https://github.com/unibrain1/elanregistry/issues/594)): New maintenance script to verify trigger/history-table sync after schema changes.
+
+### Improvements
+
+- **Chassis Override Persistence** ([#915](https://github.com/unibrain1/elanregistry/issues/915)): Chassis validation override now persists correctly via a dedicated DB column; includes UI indicator and backfill script for existing records.
+- **Date Range Validation** ([#903](https://github.com/unibrain1/elanregistry/issues/903)): Server-side validation added for car purchase/sold date ranges.
+- **Admin Contact Security** ([#660](https://github.com/unibrain1/elanregistry/issues/660), [#661](https://github.com/unibrain1/elanregistry/issues/661)): Fixed email header injection and unvalidated recipient address in the admin multi-user contact path.
+- **Verification Email Escaping** ([#854](https://github.com/unibrain1/elanregistry/issues/854)): All fields in the admin verification email template are now properly escaped.
+- **Car Verification via Car Class** ([#624](https://github.com/unibrain1/elanregistry/issues/624)): `verify_car.php` now uses Car class methods instead of direct DB writes.
+- **Audit Trail for Car Deletion** ([#593](https://github.com/unibrain1/elanregistry/issues/593)): Eliminated duplicate history row written on car deletion.
+- **car_user_hist Triggers and Indexes** ([#592](https://github.com/unibrain1/elanregistry/issues/592)): Added DB triggers and indexes to `car_user_hist` for full audit coverage.
+- **Car Class Transaction Wrapper** ([#259](https://github.com/unibrain1/elanregistry/issues/259)): Added public transaction wrapper method to Car class for consistent DB consistency.
+
+## Issues Resolved
+
+- [#259](https://github.com/unibrain1/elanregistry/issues/259) — ENHANCE: Add transaction wrapper method to Car class for consistency
+- [#592](https://github.com/unibrain1/elanregistry/issues/592) — Add database triggers and indexes for car_user_hist table
+- [#593](https://github.com/unibrain1/elanregistry/issues/593) — Remove duplicate history row on car deletion
+- [#594](https://github.com/unibrain1/elanregistry/issues/594) — Add schema validation script for trigger/history table sync
+- [#609](https://github.com/unibrain1/elanregistry/issues/609) — security: add application-layer audit logging for car sharing operations
+- [#624](https://github.com/unibrain1/elanregistry/issues/624) — refactor: verify_car.php should use Car class methods instead of direct DB updates
+- [#660](https://github.com/unibrain1/elanregistry/issues/660) — bug: email header injection via $qualityIssue in admin contact subject line
+- [#661](https://github.com/unibrain1/elanregistry/issues/661) — bug: `target_email` unvalidated in admin contact multiple-user path
+- [#731](https://github.com/unibrain1/elanregistry/issues/731) — fix: statistics.js null safety — canvas getContext and href.substring(1)
+- [#851](https://github.com/unibrain1/elanregistry/issues/851) — bug: website field silently hidden when URL lacks http/https scheme
+- [#854](https://github.com/unibrain1/elanregistry/issues/854) — fix: escape remaining unescaped fields in admin verification email template
+- [#873](https://github.com/unibrain1/elanregistry/issues/873) — security: registration failure exposes raw exception message to user (usersc/join.php)
+- [#903](https://github.com/unibrain1/elanregistry/issues/903) — harden: server-side validation for car purchase/sold date ranges
+- [#915](https://github.com/unibrain1/elanregistry/issues/915) — fix: chassis override flag — fix client-side bug, persist to DB column, UI indicator, and admin fix script

--- a/tests/unit/admin/AdminContactSanitizationTest.php
+++ b/tests/unit/admin/AdminContactSanitizationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Admin;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for admin contact sanitization bugs.
+ *
+ * #660: CR/LF stripping on $qualityIssue before use in SMTP subject line.
+ * #661: filter_var validation on target_email in the Multiple-owner path.
+ *
+ * The action file (process-admin-contact.php) cannot be unit-tested directly
+ * (requires full framework bootstrap), so these tests validate the sanitization
+ * and validation patterns in isolation.
+ */
+class AdminContactSanitizationTest extends TestCase
+{
+    /**
+     * Mirrors the CR/LF-stripping pattern used in process-admin-contact.php
+     * for header-bound values ($toEmail, $fromEmail, $qualityIssue).
+     */
+    private function stripHeaderChars(?string $value): string
+    {
+        return preg_replace('/[\r\n\t]/', '', (string) $value);
+    }
+
+    // -------------------------------------------------------------------------
+    // #660 — CR/LF stripping on $qualityIssue
+    // -------------------------------------------------------------------------
+
+    public function testQualityIssueCarriageReturnStripped(): void
+    {
+        $sanitized = $this->stripHeaderChars("Missing documents\rX-Injected: evil");
+        $this->assertStringNotContainsString("\r", $sanitized);
+        $this->assertSame('Missing documentsX-Injected: evil', $sanitized);
+    }
+
+    public function testQualityIssueLineFeedStripped(): void
+    {
+        $sanitized = $this->stripHeaderChars("Missing documents\nBcc: attacker@example.com");
+        $this->assertStringNotContainsString("\n", $sanitized);
+        $this->assertSame('Missing documentsBcc: attacker@example.com', $sanitized);
+    }
+
+    public function testQualityIssueCombinedInjectionStripped(): void
+    {
+        $sanitized = $this->stripHeaderChars("Scratch\r\nBcc: attacker@example.com");
+        $this->assertStringNotContainsString("\r", $sanitized);
+        $this->assertStringNotContainsString("\n", $sanitized);
+        $this->assertSame('ScratchBcc: attacker@example.com', $sanitized);
+    }
+
+    public function testQualityIssueTabStripped(): void
+    {
+        $sanitized = $this->stripHeaderChars("Missing\tdocuments");
+        $this->assertStringNotContainsString("\t", $sanitized);
+        $this->assertSame('Missingdocuments', $sanitized);
+    }
+
+    public function testQualityIssueCleanValueUnchanged(): void
+    {
+        $raw = 'Missing registration documents';
+        $this->assertSame($raw, $this->stripHeaderChars($raw));
+    }
+
+    public function testQualityIssueNullHandledSafely(): void
+    {
+        $this->assertSame('', $this->stripHeaderChars(null));
+    }
+
+    // -------------------------------------------------------------------------
+    // #661 — filter_var validation on target_email
+    // -------------------------------------------------------------------------
+
+    public function testTargetEmailValidAccepted(): void
+    {
+        $email = 'owner@example.com';
+        $result = filter_var($email, FILTER_VALIDATE_EMAIL);
+        $this->assertSame($email, $result);
+    }
+
+    public function testTargetEmailInvalidRejected(): void
+    {
+        $email = 'not-an-email';
+        $result = filter_var($email, FILTER_VALIDATE_EMAIL);
+        $this->assertFalse($result);
+    }
+
+    public function testTargetEmailInjectionAttemptRejected(): void
+    {
+        $email = "victim@example.com\r\nBcc: attacker@evil.com";
+        $result = filter_var($email, FILTER_VALIDATE_EMAIL);
+        $this->assertFalse($result);
+    }
+
+    public function testTargetEmailEmptyRejected(): void
+    {
+        $result = filter_var('', FILTER_VALIDATE_EMAIL);
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
## Summary

- Strips CR/LF and tab characters from `$toEmail`, `$fromEmail`, and `$qualityIssue` before any use as SMTP headers, preventing email header injection via the admin contact form (`#660`)
- Confirms `target_email` in the Multiple-owner path is already validated via `filter_var(FILTER_VALIDATE_EMAIL)` — fix was present from a prior PR; this PR closes the issue with regression tests (`#661`)
- Removes redundant re-sanitization on the log path (values are already clean upstream)
- Adds `AdminContactSanitizationTest` with 10 regression tests covering both issues

## Bug Escape Analysis

**Root cause:** Security properties were applied inconsistently — the logging path already stripped CR/LF (`$safeIssue`, `$safeFromLog`, `$safeToLog`) but the email subject and header assignments used the raw values. Discovered during security review, not by automated tests.

**Testing gap:** The action file mixes HTTP handling with business logic and cannot be unit-tested directly (requires full framework bootstrap). No unit tests existed for the sanitization patterns in this file.

**Preventive:** `AdminContactSanitizationTest` now covers the regex and `filter_var` patterns in isolation. These run in `composer test:quick` (unit suite).

## Pre-existing issue deferred

Security review flagged `clean_string()` (denylist-based body sanitization, case-sensitive, no CR/LF stripping) as a separate concern requiring template audit. Tracked as [#917](https://github.com/unibrain1/elanregistry/issues/917).

## Test plan

- [x] `composer test:quick` — 863/863 tests pass
- [x] PHPStan — no errors
- [x] phpcs — no blocking issues
- [x] Security review — all Critical/High/Medium findings addressed

Closes #660, Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)