### PR TITLE
fix: escape remaining unescaped output in admin verification email (#854)

### DIFF
--- a/app/admin/verify/_email_template.php
+++ b/app/admin/verify/_email_template.php
@@ -208,7 +208,7 @@
             </tr>
             <tr>
                 <td>Date Added</td>
-                <td><?= $car->ctime ?>
+                <td><?= htmlspecialchars((string)($car->ctime ?? ''), ENT_QUOTES, 'UTF-8') ?>
                 </td>
             </tr>
         </table>

--- a/app/admin/verify/send_email.php
+++ b/app/admin/verify/send_email.php
@@ -31,7 +31,7 @@ foreach ($carData as $car) {
 
 
     if ($car->image && file_exists($abs_us_root . $us_url_root . $settings->elan_image_dir . $car->image)) {
-        $image = '<img src="' . $base_url . $us_url_root . $settings->elan_image_dir . $car->image . '">';
+        $image = '<img src="' . htmlspecialchars($base_url . $us_url_root . $settings->elan_image_dir . (string)$car->image, ENT_QUOTES, 'UTF-8') . '">';
     } else {
         $image = 'No image';
     }


### PR DESCRIPTION
## Summary

- Escapes `$car->ctime` in `app/admin/verify/_email_template.php` — the last bare field after the v2.23.0 deep-review cleanup
- Escapes the assembled `<img src>` URL in `app/admin/verify/send_email.php` — `$car->image` was interpolated raw into an HTML attribute

## Bug Escape Analysis

**Root cause:** Issue #841 escaped four fields in this template; the remaining fields were swept up in v2.23.0 cleanup commits (`0eb69c56`, `565ca209`) — but `$car->ctime` was missed. The `$image` interpolation in `send_email.php` was outside that scope. Both are defense-in-depth escaping; the fields are low-risk (admin-only flow, constrained values) but should follow the encode-at-output pattern consistently.

**Testing gap:** No tests assert HTML-escaping on the verification email template. The template is rendered via `ob_start()` + `include` and is exercisable by PHPUnit but not currently covered. Adding a render test with a `<script>` payload is a future hardening task.

**Preventive:** The escaping additions are themselves the fix.

## Verification

- `composer check:php` — 0 errors on the changed files
- `composer test:quick` — 863 tests, 3915 assertions, OK

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)