### PR TITLE
harden: server-side date range validation for car purchase/sold dates (#903)

### DIFF
--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -133,6 +133,88 @@ final class CarValidatorTest extends TestCase
         $this->validator->validateAndSanitizeFields($fields, false);
     }
 
+    /**
+     * @param array<string, string> $fields
+     */
+    #[DataProvider('dateOutOfRangeProvider')]
+    public function testDateOutOfRangeIsRejected(array $fields, string $expectedPattern): void
+    {
+        $this->expectException(CarValidationException::class);
+        $this->expectExceptionMessageMatches($expectedPattern);
+        $this->validator->validateAndSanitizeFields($fields, false);
+    }
+
+    /**
+     * @return array<string, array{0: array<string, string>, 1: string}>
+     */
+    public static function dateOutOfRangeProvider(): array
+    {
+        $tomorrow = (new \DateTime('tomorrow'))->format('Y-m-d');
+
+        return [
+            'purchasedate before min'  => [['purchasedate' => '1956-12-31'], '/Purchase date must be between/'],
+            'purchasedate in future'   => [['purchasedate' => $tomorrow],    '/Purchase date must be between/'],
+            'solddate before min'      => [['solddate'     => '1900-01-01'], '/Sold date must be between/'],
+            'solddate in future'       => [['solddate'     => $tomorrow],    '/Sold date must be between/'],
+        ];
+    }
+
+    public function testMinBoundaryDateIsAccepted(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['purchasedate' => '1957-01-01'], false);
+        $this->assertEquals('1957-01-01', $result['purchasedate']);
+    }
+
+    public function testSolddateMinBoundaryIsAccepted(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['solddate' => '1957-01-01'], false);
+        $this->assertEquals('1957-01-01', $result['solddate']);
+    }
+
+    public function testTodayIsAccepted(): void
+    {
+        $today = (new \DateTime('today'))->format('Y-m-d');
+        $result = $this->validator->validateAndSanitizeFields(['purchasedate' => $today], false);
+        $this->assertEquals($today, $result['purchasedate']);
+    }
+
+    public function testSolddateTodayIsAccepted(): void
+    {
+        $today = (new \DateTime('today'))->format('Y-m-d');
+        $result = $this->validator->validateAndSanitizeFields(['solddate' => $today], false);
+        $this->assertEquals($today, $result['solddate']);
+    }
+
+    public function testBothDatesValidWithCorrectOrderingIsAccepted(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields([
+            'purchasedate' => '1970-03-01',
+            'solddate'     => '1985-06-15',
+        ], false);
+        $this->assertEquals('1970-03-01', $result['purchasedate']);
+        $this->assertEquals('1985-06-15', $result['solddate']);
+    }
+
+    public function testSolddateBeforePurchasedateIsRejected(): void
+    {
+        $this->expectException(CarValidationException::class);
+        $this->expectExceptionMessage('Sold date cannot be before purchase date');
+        $this->validator->validateAndSanitizeFields([
+            'purchasedate' => '1980-06-01',
+            'solddate'     => '1979-12-31',
+        ], false);
+    }
+
+    public function testSolddateEqualsPurchasedateIsAccepted(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields([
+            'purchasedate' => '1975-03-15',
+            'solddate'     => '1975-03-15',
+        ], false);
+        $this->assertEquals('1975-03-15', $result['purchasedate']);
+        $this->assertEquals('1975-03-15', $result['solddate']);
+    }
+
     public function testValidateAndSanitizeFieldsValidatesCoordinates(): void
     {
         $fields = ['lat' => '51.5', 'lon' => '-0.1'];

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -20,6 +20,8 @@ use DateTime;
  */
 class CarValidator
 {
+    public const MIN_CAR_DATE = '1957-01-01';
+
     /**
      * Validate that required fields are present and not empty
      *
@@ -132,6 +134,16 @@ class CarValidator
                         if (!$date || $date->format('Y-m-d') !== $value) {
                             throw new CarValidationException("Invalid date format for {$key}. Use YYYY-MM-DD format");
                         }
+                        $date->setTime(0, 0, 0);
+                        $min = new DateTime(self::MIN_CAR_DATE);
+                        $max = new DateTime('today');
+                        if ($date < $min || $date > $max) {
+                            $label = ($key === 'purchasedate') ? 'Purchase date' : 'Sold date';
+                            throw new CarValidationException(
+                                "{$label} must be between " . self::MIN_CAR_DATE
+                                . " and " . $max->format('Y-m-d')
+                            );
+                        }
                         $validatedFields[$key] = $value;
                     }
                     break;
@@ -192,6 +204,14 @@ class CarValidator
                 default:
                     $validatedFields[$key] = $value;
                     break;
+            }
+        }
+
+        if (isset($validatedFields['purchasedate'], $validatedFields['solddate'])) {
+            $purchase = new DateTime($validatedFields['purchasedate']);
+            $sold     = new DateTime($validatedFields['solddate']);
+            if ($sold < $purchase) {
+                throw new CarValidationException('Sold date cannot be before purchase date');
             }
         }
 


### PR DESCRIPTION
## Summary

- Add `MIN_CAR_DATE = '1957-01-01'` constant to `CarValidator` matching the HTML form `min` attribute
- Extend `purchasedate`/`solddate` validation: reject dates before 1957-01-01 or after today; normalize parsed DateTime to midnight to avoid same-day false rejections
- Add cross-field check after the per-field loop: reject when sold date precedes purchase date (enforced when both fields are present in the same request)
- 11 new unit tests covering boundary values, out-of-range rejection (DataProvider), cross-field ordering, and positive cases; 882 total passing

## Bug Escape Analysis

- **Root Cause:** `CarValidator` was written with format-only validation; range bounds were never added when the HTML `min`/`max` attributes were added to the form
- **Testing Gap:** No PHPUnit tests existed for date range bounds — only format validity was covered
- **Preventive:** New tests pin each rejection path and boundary value, so any relaxation of the validator immediately breaks the suite

## Known Limitation

The cross-field ordering check only fires when both `purchasedate` and `solddate` are present in the same request. A direct API POST that sends only `solddate` (leaving `purchasedate` absent) skips the check — `Car::update()` only writes fields present in the validated output, so the existing DB `purchasedate` is retained but unchecked against the new `solddate`. The form always co-submits both fields, so this gap only affects direct API access. Fully resolving it requires loading the persisted counterpart before validation (out of scope for this issue).

## Test plan

- [x] `composer test:quick` — 882 tests passing
- [x] PHPStan — 0 errors on changed files
- [x] Security review — 0 findings
- [x] Manual: direct POST with `purchasedate=1956-12-31` → validation error
- [x] Manual: direct POST with `purchasedate=9999-01-01` → validation error
- [x] Manual: direct POST with `purchasedate=1980-01-01&solddate=1979-12-31` → cross-field error
- [x] Manual: form submit with valid dates → saves correctly

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)