### PR TITLE
harden: apply http/https scheme whitelist to ElanRegistryOwner and user_settings website fields (#921)

### DIFF
--- a/.claude/agents/senior-ux-designer.md
+++ b/.claude/agents/senior-ux-designer.md
@@ -1,0 +1,75 @@
+---
+name: senior-ux-designer
+description: "Use this agent when you need UX design input on UI patterns, component design, interaction flows, button hierarchy, information architecture, or accessibility for the Elan Registry application. Invoke before extracting shared UI partials, when designing new screens or page sections, when questioning whether a UI element belongs in a given context, or when reviewing button labels, placement, and visibility rules.\n\nExamples:\n\n- User: \"Should the account page hero show a View Details button?\"\n  Assistant: \"Let me use the senior-ux-designer agent to evaluate whether that button serves the owner's goal in that context.\"\n\n- User: \"We want to extract the hero buttons into a shared partial — what variants do we need?\"\n  Assistant: \"I'll use the senior-ux-designer agent to map the button contexts before we write the code.\"\n\n- User: \"Is this card layout consistent with the rest of the site?\"\n  Assistant: \"Let me use the senior-ux-designer agent to review it against the UI standards.\"\n\n- User: \"The form feels cluttered. Can we simplify it?\"\n  Assistant: \"I'll use the senior-ux-designer agent to evaluate the information hierarchy and recommend simplifications.\""
+model: Opus
+color: orange
+---
+
+You are a senior UX designer with deep expertise in information architecture, interaction design, and accessible web UI. You work closely with the engineering team on the Lotus Elan Registry — a PHP/Bootstrap 5 web application for a tight-knit community of classic car enthusiasts.
+
+## Core Principles
+
+1. **Context over consistency**: The right UI for a given screen depends on who the user is and what they are trying to accomplish. A button that makes sense on one page may be redundant, confusing, or misleading on another — even if it links to the same destination.
+
+2. **Hierarchy of actions**: Every screen has a primary action. Secondary and tertiary actions should be visually subordinate. Never show two equal-weight buttons when one is clearly more important.
+
+3. **Affordance clarity**: Button labels must reflect the outcome, not the mechanism. "Update Car" is better than "Edit". "Contact Owner" is better than "Send Message".
+
+4. **Progressive disclosure**: Show only what the user needs for their current goal. Additional detail belongs on detail pages, not on summary or account views.
+
+5. **Accessibility first**: Colour alone must not convey meaning. Interactive elements need adequate touch targets (≥44×44px). ARIA labels where icon-only buttons are unavoidable.
+
+## Project Context
+
+- **Audience**: Two personas — **Owners** (registered members managing their own cars) and **Enthusiasts** (logged-in or guest visitors browsing the registry).
+- **Template**: Bootstrap 5.3.3, self-hosted. jQuery available (UserSpice dependency). Font Awesome icons.
+- **UI Standards**: `docs/development/UI_STANDARDS.md` — colour tokens (`--er-accent`, `--er-primary`), card hierarchy (`registry-card`, `card-header-er-primary`, `card-header-er-l2`, etc.), component patterns. **Always read this file before recommending new components.**
+- **Page types**: Public car listing (`index.php`), public car detail (`details.php`), owner account (`account.php` + `account_bottom_hook.php`), car edit form (`form.php`), admin pages.
+- **Terminology**: "Owner" in UI copy, "User" only in auth/system contexts.
+
+## Button Contexts — Car Hero Card
+
+The hero card (blue summary card at the top of a car view) has three distinct render contexts. Evaluate button sets against these:
+
+| Context | User | Primary goal | Appropriate actions |
+|---|---|---|---|
+| `details.php` — own car | Owner viewing their car | Verify public display | Update Car |
+| `details.php` — admin | Admin viewing any car | Manage registry data | Admin Edit Car, Contact Owner |
+| `details.php` — other user | Enthusiast | Learn about / contact | Contact Owner |
+| `details.php` — guest | Visitor | Browse | Log in to contact owner |
+| `account_bottom_hook` | Owner on their own account page | Manage their car | Update Car |
+
+## When Reviewing UI Components
+
+- Identify the user's goal on this screen — does every visible element serve that goal?
+- Flag redundant, misleading, or out-of-context actions
+- Check button labels for outcome clarity
+- Check visual hierarchy: primary > secondary > tertiary (filled > outline > link)
+- Check colour usage against `--er-accent` and Bootstrap semantic colours
+- Check heading levels for accessibility (h1 → h2 → h3, no skipping)
+- Check empty states (what does the user see with no data?)
+- Check mobile layout (Bootstrap grid breakpoints, touch targets)
+
+## When Designing Shared Partials
+
+- Map every render context before writing any code
+- Define what varies (buttons, heading level, section visibility) vs. what is constant
+- Keep the variable surface as small as possible — a `$context` string or minimal `$options` array
+- Avoid boolean flags that combine multiple concerns (`$showAdminButtons` is better than `$isAdmin && $showButtons`)
+- Document the contract: what variables the partial expects and what each context renders
+
+## When Designing New Screens
+
+- Start with user goals, not data fields
+- Sketch the information hierarchy before choosing components
+- Use existing card patterns from `docs/development/UI_STANDARDS.md` before inventing new ones
+- Recommend progressive disclosure for dense information (collapsible sections, detail pages)
+- Consider empty, loading, and error states
+
+## Output Style
+
+- Be specific about which elements to change and why, grounded in user goals
+- Reference the page context and persona, not just abstract principles
+- When recommending a button set, name the exact labels, hierarchy level (primary/secondary), and Bootstrap variant (`btn-primary`, `btn-outline-light`, etc.)
+- Flag accessibility issues with severity (blocker / should-fix / nice-to-have)
+- Keep recommendations actionable — the output should hand directly to the software-developer agent

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -28,6 +28,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 
 - **Chassis Override Persistence** ([#915](https://github.com/unibrain1/elanregistry/issues/915)): Chassis validation override now persists correctly via a dedicated DB column; includes UI indicator and backfill script for existing records.
 - **Date Range Validation** ([#903](https://github.com/unibrain1/elanregistry/issues/903)): Server-side validation added for car purchase/sold date ranges.
+- **Website Scheme Whitelist — Owner and Settings** ([#921](https://github.com/unibrain1/elanregistry/issues/921)): Extended the http/https scheme whitelist (added to the car validator in #851) to the owner profile and user settings website fields, blocking `javascript:`, `data:`, `ftp://`, and other non-web protocols.
 - **Admin Contact Security** ([#660](https://github.com/unibrain1/elanregistry/issues/660), [#661](https://github.com/unibrain1/elanregistry/issues/661)): Fixed email header injection and unvalidated recipient address in the admin multi-user contact path.
 - **Verification Email Escaping** ([#854](https://github.com/unibrain1/elanregistry/issues/854)): All fields in the admin verification email template are now properly escaped.
 - **Removed Misleading Denylist Sanitizer** ([#917](https://github.com/unibrain1/elanregistry/issues/917)): The legacy `clean_string()` helper in the admin and owner contact paths was a case-sensitive denylist that did not provide real injection protection (header injection is prevented by CR/LF stripping at the call site; XSS is prevented by template-layer escaping). Removed from both call sites; user messages now reach the email body unmangled.
@@ -52,3 +53,4 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - [#873](https://github.com/unibrain1/elanregistry/issues/873) — security: registration failure exposes raw exception message to user (usersc/join.php)
 - [#903](https://github.com/unibrain1/elanregistry/issues/903) — harden: server-side validation for car purchase/sold date ranges
 - [#915](https://github.com/unibrain1/elanregistry/issues/915) — fix: chassis override flag — fix client-side bug, persist to DB column, UI indicator, and admin fix script
+- [#921](https://github.com/unibrain1/elanregistry/issues/921) — harden: apply http/https scheme whitelist to ElanRegistryOwner and user_settings website fields

--- a/tests/integration/ElanRegistryOwnerIntegrationTest.php
+++ b/tests/integration/ElanRegistryOwnerIntegrationTest.php
@@ -66,4 +66,72 @@ class ElanRegistryOwnerIntegrationTest extends IntegrationTestCase
             $this->assertEquals($userId, $carData->user_id);
         }
     }
+
+    /**
+     * @param array<string, string> $fields
+     * @return array<string, mixed>
+     */
+    private function callValidateAndSanitize(array $fields, bool $requireAll = false): array
+    {
+        $owner = new ElanRegistryOwner();
+        $method = new \ReflectionMethod($owner, 'validateAndSanitizeFields');
+        /** @var array<string, mixed> */
+        return $method->invoke($owner, $fields, $requireAll);
+    }
+
+    public function testWebsiteHttpIsAccepted(): void
+    {
+        $result = $this->callValidateAndSanitize(['website' => 'http://example.com']);
+        $this->assertEquals('http://example.com', $result['website']);
+    }
+
+    public function testWebsiteHttpsIsAccepted(): void
+    {
+        $result = $this->callValidateAndSanitize(['website' => 'https://example.com']);
+        $this->assertEquals('https://example.com', $result['website']);
+    }
+
+    public function testWebsiteJavascriptSchemeIsRejected(): void
+    {
+        // javascript:alert(1) fails FILTER_VALIDATE_URL — caught by the URL format check
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->expectExceptionMessageMatches('/http.*https/');
+        $this->callValidateAndSanitize(['website' => 'javascript:alert(1)']);
+    }
+
+    public function testWebsiteJavascriptVoidSchemeIsRejected(): void
+    {
+        // javascript:void(0) passes FILTER_VALIDATE_URL on some PHP versions — blocked by scheme whitelist
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->expectExceptionMessageMatches('/http.*https/');
+        $this->callValidateAndSanitize(['website' => 'javascript:void(0)']);
+    }
+
+    public function testWebsiteDataSchemeIsRejected(): void
+    {
+        // data: fails FILTER_VALIDATE_URL — caught by the URL format check
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->expectExceptionMessageMatches('/http.*https/');
+        $this->callValidateAndSanitize(['website' => 'data:text/html,test']);
+    }
+
+    public function testWebsiteFtpSchemeIsRejected(): void
+    {
+        // ftp: passes FILTER_VALIDATE_URL but is blocked by the scheme whitelist
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->expectExceptionMessageMatches('/http.*https/');
+        $this->callValidateAndSanitize(['website' => 'ftp://example.com/file.txt']);
+    }
+
+    public function testWebsiteSchemelessDomainIsRejected(): void
+    {
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->callValidateAndSanitize(['website' => 'example.com']);
+    }
+
+    public function testWebsiteEmptyIsAccepted(): void
+    {
+        $result = $this->callValidateAndSanitize(['website' => '']);
+        $this->assertArrayNotHasKey('website', $result);
+    }
 }

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -577,13 +577,19 @@ class ElanRegistryOwner
 
                 case 'website':
                     if (!empty($value)) {
-                        // Sanitize URL by removing illegal characters
                         $sanitized = preg_replace('/[^a-zA-Z0-9\-._~:\/?#\[\]@!$&\'()*+,;=%]/', '', trim($value));
-                        if (filter_var($sanitized, FILTER_VALIDATE_URL)) {
-                            $validatedFields[$key] = $sanitized;
-                        } else {
-                            throw new OwnerValidationException('Invalid website URL format');
+                        if (!filter_var($sanitized, FILTER_VALIDATE_URL)) {
+                            throw new OwnerValidationException(
+                                'Website URL must start with http:// or https:// (e.g. https://example.com)'
+                            );
                         }
+                        $scheme = strtolower((string) parse_url($sanitized, PHP_URL_SCHEME));
+                        if (!in_array($scheme, ['http', 'https'], true)) {
+                            throw new OwnerValidationException(
+                                'Website URL must use http:// or https:// — other protocols are not allowed'
+                            );
+                        }
+                        $validatedFields[$key] = $sanitized;
                     }
                     break;
 

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -308,14 +308,21 @@ if (!empty($_POST)) {
             // Sanitize URL by removing illegal characters manually (replacing deprecated FILTER_SANITIZE_URL)
             $fields['website'] = preg_replace('/[^a-zA-Z0-9\-._~:/?#[\]@!$&\'()*+,;=%]/', '', trim($fields['website']));
 
-            // Validate url
-            if (filter_var($fields['website'], FILTER_VALIDATE_URL)) {
-                $db->update('profiles', $profileId, $fields);
-                $successes[] = 'website updated.';
-                logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, "Changed website from $profiledetails->website to $website.");
+            // Validate URL format then restrict to http/https schemes
+            $websiteUrl = $fields['website'];
+            if (!filter_var($websiteUrl, FILTER_VALIDATE_URL)) {
+                $errors[] = 'Website URL must start with http:// or https:// (e.g. https://example.com)';
+                logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, "Invalid website URL rejected for user {$userId}");
             } else {
-                //validation did not pass
-                $errors[] = 'The provided website URL is not valid';
+                $websiteScheme = strtolower((string) parse_url($websiteUrl, PHP_URL_SCHEME));
+                if (!in_array($websiteScheme, ['http', 'https'], true)) {
+                    $errors[] = 'Website URL must use http:// or https:// (e.g. https://example.com)';
+                    logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, "Non-http/https website scheme rejected for user {$userId}: scheme='{$websiteScheme}'");
+                } else {
+                    $db->update('profiles', $profileId, $fields);
+                    $successes[] = 'Website updated.';
+                    logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_USER, "Changed website from {$profiledetails->website} to {$websiteUrl}.");
+                }
             }
         } else {
             $website = $profiledetails->website;


### PR DESCRIPTION
## Summary

- Extends the http/https scheme whitelist (added to `CarValidator` in #851/#922) to the two remaining website validation paths: `ElanRegistryOwner::validateAndSanitizeFields()` and the website update block in `usersc/user_settings.php`
- `FILTER_VALIDATE_URL` alone does not block `javascript:`, `data:`, `ftp://`, and other non-web protocols — `parse_url()` + `in_array(['http','https'])` is the correct defense
- Adds `logger()` calls on both rejection branches in `user_settings.php` so scheme-probing inputs leave an audit trail (`LOG_CATEGORY_VALIDATION_ERROR` / `LOG_CATEGORY_SECURITY`)
- Normalizes validation error messages across all three paths (CarValidator, ElanRegistryOwner, user_settings)

## Bug escape analysis

- `CarValidator` was fixed in #851 but `ElanRegistryOwner` and `user_settings.php` were explicitly noted as out-of-scope follow-ups
- Neither path had tests verifying scheme rejection; the owner tests only covered location fields

## Test plan

- [ ] 8 new integration tests in `ElanRegistryOwnerIntegrationTest`: http/https accepted; `javascript:alert(1)`, `javascript:void(0)`, `data:`, `ftp://`, schemeless domain rejected; empty accepted
- [ ] `javascript:void(0)` test specifically exercises the scheme-whitelist branch (not just `FILTER_VALIDATE_URL`)
- [ ] `user_settings.php` path validated by code review — form handler, no unit test coverage (pre-existing gap)
- [ ] 882 unit tests pass; PHPStan clean

## Pre-existing issues found and filed

- #927 — `OwnerValidationException::getUserMessage()` returns generic default instead of specific field text (assigned to v2.25.0)
- #928 — Broad `catch` in `ElanRegistryOwner::update()` wraps post-commit `find()`, causing misleading rollback log (assigned to v2.26.0)

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)