### PR TITLE
fix: reject overflow dates in CarVerificationManager::markSold() (#935)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -32,6 +32,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - **Verification Email Escaping** ([#854](https://github.com/unibrain1/elanregistry/issues/854)): All fields in the admin verification email template are now properly escaped.
 - **Removed Misleading Denylist Sanitizer** ([#917](https://github.com/unibrain1/elanregistry/issues/917)): The legacy `clean_string()` helper in the admin and owner contact paths was a case-sensitive denylist that did not provide real injection protection (header injection is prevented by CR/LF stripping at the call site; XSS is prevented by template-layer escaping). Removed from both call sites; user messages now reach the email body unmangled.
 - **Car Verification via Car Class** ([#624](https://github.com/unibrain1/elanregistry/issues/624)): `verify_car.php` now routes verification and sold-status changes through `Car::markVerified()` and `Car::markSold()` instead of direct DB writes, ensuring validation and audit trail consistency. Fixes a pre-existing gap where the "sold" action never set `cars.solddate`.
+- **Overflow Date Rejection in markSold()** ([#935](https://github.com/unibrain1/elanregistry/issues/935)): `CarVerificationManager::markSold()` now rejects calendar-invalid overflow dates (e.g. `2024-02-30`) that PHP's `DateTime::createFromFormat()` previously silently rolled forward, preventing corrupt date values from being persisted to `cars.solddate`.
 - **Audit Trail for Car Deletion** ([#593](https://github.com/unibrain1/elanregistry/issues/593)): Eliminated duplicate history row written on car deletion.
 - **car_user_hist Triggers and Indexes** ([#592](https://github.com/unibrain1/elanregistry/issues/592)): Added DB triggers and indexes to `car_user_hist` for full audit coverage.
 
@@ -57,3 +58,4 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - [#921](https://github.com/unibrain1/elanregistry/issues/921) — harden: apply http/https scheme whitelist to ElanRegistryOwner and user_settings website fields
 - [#927](https://github.com/unibrain1/elanregistry/issues/927) — bug: OwnerValidationException getUserMessage() returns generic default instead of specific validation text
 - [#931](https://github.com/unibrain1/elanregistry/issues/931) — test: add integration test for manage-consolidated.php car deletion audit trail
+- [#935](https://github.com/unibrain1/elanregistry/issues/935) — bug: CarVerificationManager::markSold() accepts overflow dates that PHP rolls forward silently

--- a/tests/unit/cars/services/CarVerificationManagerTest.php
+++ b/tests/unit/cars/services/CarVerificationManagerTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 use ElanRegistry\Car\CarVerificationManager;
 use ElanRegistry\Exceptions\CarValidationException;
-use PHPUnit\Framework\TestCase;
-
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for CarVerificationManager service class
@@ -71,11 +71,36 @@ final class CarVerificationManagerTest extends TestCase
         $this->assertEquals(date('Y-m-d'), $carData->solddate);
     }
 
-    public function testMarkSoldRejectsInvalidDate(): void
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidSoldDateProvider(): array
+    {
+        return [
+            'non-date string'        => ['not-a-date'],
+            'empty string'           => [''],
+            'slash-delimited format' => ['2024/01/15'],
+            'invalid month 13'       => ['2024-13-01'],
+            'Feb overflow day 30'    => ['2024-02-30'],
+            'Feb overflow day 31'    => ['2024-02-31'],
+            'non-leap Feb 29'        => ['2023-02-29'],
+        ];
+    }
+
+    #[DataProvider('invalidSoldDateProvider')]
+    public function testMarkSoldRejectsInvalidDate(string $date): void
     {
         $this->expectException(CarValidationException::class);
 
         $carData = (object) ['id' => 1, 'solddate' => null];
-        $this->manager->markSold($carData, 'not-a-date', $this->db);
+        $this->manager->markSold($carData, $date, $this->db);
+    }
+
+    public function testMarkSoldAcceptsLeapDay(): void
+    {
+        $carData = (object) ['id' => 1, 'solddate' => null];
+        $result = $this->manager->markSold($carData, '2024-02-29', $this->db);
+        $this->assertTrue($result);
+        $this->assertEquals('2024-02-29', $carData->solddate);
     }
 }

--- a/usersc/classes/Car/CarVerificationManager.php
+++ b/usersc/classes/Car/CarVerificationManager.php
@@ -109,7 +109,8 @@ class CarVerificationManager
             $soldDate = date('Y-m-d');
         }
 
-        if (!DateTime::createFromFormat('Y-m-d', $soldDate)) {
+        $parsedDate = DateTime::createFromFormat('Y-m-d', $soldDate);
+        if (!$parsedDate || $parsedDate->format('Y-m-d') !== $soldDate) {
             throw new CarValidationException(CarErrorMessages::getMessage('invalid_sold_date', 'user', ['date' => $soldDate]));
         }
 


### PR DESCRIPTION
## Summary

- Replaces the broken single-argument `DateTime::createFromFormat()` guard in `markSold()` with a round-trip check (parse → reformat → strict equality), matching the pattern already used in `CarValidator` (lines 133–135)
- Overflow dates like `2024-02-30` that PHP silently rolls forward are now rejected with `CarValidationException` before any DB write
- Adds a `#[DataProvider]` test covering 7 invalid inputs (overflow Feb dates, invalid month, wrong delimiter, empty string, non-leap Feb 29) and a positive leap-day case (`2024-02-29`)

## Bug Escape Analysis

**Root cause:** `DateTime::createFromFormat('Y-m-d', '2024-02-30')` returns a truthy `DateTime` object (rolled to `2024-03-01`), so the old guard `if (!DateTime::createFromFormat(...))` never triggered for calendar-invalid overflow dates — only for completely unparseable strings.

**Testing gap:** The only existing test used `'not-a-date'` — a fully malformed string that does fail `createFromFormat`. No test exercised an overflow date, so the validation gap was invisible to the test suite.

**Preventive measure:** `invalidSoldDateProvider` now enumerates all overflow categories explicitly. Any future regression to a less-strict check will be caught by the data provider immediately.

## Test plan

- [x] `composer test:quick` — 890 tests, 3955 assertions, all pass
- [x] Pre-commit hooks: phpcs + PHPStan — clean
- [x] Security review — 0 Critical/High/Medium findings
- [x] PR review (code, tests, comments) — no issues

Closes #935