### PR TITLE
fix: change DATETIME_FORMAT from G to H for zero-padded hour (#947)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -39,6 +39,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 ### Bug Fixes
 
 - **Owner Validation Error Messages** ([#927](https://github.com/unibrain1/elanregistry/issues/927)): Admin owner edit now shows the specific validation error (e.g. "Website URL must use http:// or https://") instead of a generic fallback when input is invalid.
+- **Timestamp Hour Padding** ([#947](https://github.com/unibrain1/elanregistry/issues/947)): Fixed `AppConstants::DATETIME_FORMAT` using `G` (no leading zero) instead of `H` (zero-padded) for the hour. Morning timestamps `0–9` now correctly produce `09:xx:xx` instead of `9:xx:xx`, ensuring consistent lexicographic sort order.
 
 ## Issues Resolved
 
@@ -59,3 +60,4 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - [#927](https://github.com/unibrain1/elanregistry/issues/927) — bug: OwnerValidationException getUserMessage() returns generic default instead of specific validation text
 - [#931](https://github.com/unibrain1/elanregistry/issues/931) — test: add integration test for manage-consolidated.php car deletion audit trail
 - [#935](https://github.com/unibrain1/elanregistry/issues/935) — bug: CarVerificationManager::markSold() accepts overflow dates that PHP rolls forward silently
+- [#947](https://github.com/unibrain1/elanregistry/issues/947) — bug: AppConstants::DATETIME_FORMAT uses 'G' (no leading zero) instead of 'H'

--- a/tests/unit/system/AppConstantsTest.php
+++ b/tests/unit/system/AppConstantsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AppConstantsTest
+ *
+ * Regression coverage for GitHub issue #947: DATETIME_FORMAT used 'G' (no leading zero)
+ * instead of 'H' (zero-padded 24-hour), causing inconsistent hour strings for hours 0–9.
+ *
+ * @issue 947
+ * @link https://github.com/unibrain1/elanregistry/issues/947
+ */
+class AppConstantsTest extends TestCase
+{
+    /**
+     * Regression for #947: morning hours must be zero-padded.
+     *
+     * Before the fix, hour 9 produced "9:30:00"; after, it produces "09:30:00".
+     */
+    public function testDatetimeFormatProducesZeroPaddedHour(): void
+    {
+        $timestamp = mktime(9, 30, 0, 1, 1, 2025);
+        $formatted = date(AppConstants::DATETIME_FORMAT, $timestamp);
+
+        $this->assertEquals('2025-01-01 09:30:00', $formatted, 'Hour 9 must be zero-padded to 09');
+    }
+
+    public function testDatetimeFormatProducesTwoDigitHourForDoubleDigits(): void
+    {
+        $timestamp = mktime(14, 5, 3, 6, 15, 2024);
+        $formatted = date(AppConstants::DATETIME_FORMAT, $timestamp);
+
+        $this->assertEquals('2024-06-15 14:05:03', $formatted);
+    }
+
+    public function testDatetimeFormatMidnightIsZeroPadded(): void
+    {
+        $timestamp = mktime(0, 0, 0, 3, 7, 2025);
+        $formatted = date(AppConstants::DATETIME_FORMAT, $timestamp);
+
+        $this->assertEquals('2025-03-07 00:00:00', $formatted, 'Midnight (hour 0) must be 00');
+    }
+
+    public function testDatetimeFormatMatchesMysqlDatetimePattern(): void
+    {
+        $formatted = date(AppConstants::DATETIME_FORMAT);
+
+        // MySQL DATETIME: YYYY-MM-DD HH:MM:SS with exactly 2-digit hour
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+            $formatted,
+            'Format must produce exactly YYYY-MM-DD HH:MM:SS (2-digit hour required)'
+        );
+    }
+}

--- a/usersc/classes/AppConstants.php
+++ b/usersc/classes/AppConstants.php
@@ -20,5 +20,5 @@ class AppConstants
      * Used consistently across Car, ElanRegistryOwner, and admin pages
      * for ctime/mtime fields and other datetime columns.
      */
-    public const DATETIME_FORMAT = 'Y-m-d G:i:s';
+    public const DATETIME_FORMAT = 'Y-m-d H:i:s';
 }


### PR DESCRIPTION
## Summary

- Fixed `AppConstants::DATETIME_FORMAT` typo: `'Y-m-d G:i:s'` → `'Y-m-d H:i:s'`
- Morning timestamps (hours 0–9) were stored as single-digit hour strings (`9:30:00`); now correctly zero-padded (`09:30:00`)
- Added `AppConstantsTest` with 4 regression tests to prevent recurrence

## Bug Escape Analysis

**Root cause:** `G` used instead of `H` when the constant was introduced in v2.14.0 — both are valid PHP format codes and the typo isn't obvious at a glance.

**Testing gap:** `AppConstants` had zero unit test coverage. No caller asserted on the string format of the result, so the single-digit hour was never observed in tests.

**Preventive:** `AppConstantsTest::testDatetimeFormatProducesZeroPaddedHour()` pins that hour 9 produces `09:30:00`, not `9:30:00`. The regex test (`testDatetimeFormatMatchesMysqlDatetimePattern`) locks the exact `YYYY-MM-DD HH:MM:SS` shape for all future runs.

## Affected callers (no code changes needed — all use the constant)

`Car.php`, `ElanRegistryOwner.php`, `CarAdministrationService.php`, `CarVerificationManager.php`, `app/admin/manage-consolidated.php`, `usersc/user_settings.php` — 14 call sites total.

## Test plan

- [x] `composer test:quick` — 899/899 passing (pre-commit hook verified)
- [x] PHPStan — no errors
- [x] Coding standards — clean

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)