### PR TITLE
refactor: Car::delete() CSRF token is now mandatory (#930)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -40,6 +40,10 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 
 - **Owner Validation Error Messages** ([#927](https://github.com/unibrain1/elanregistry/issues/927)): Admin owner edit now shows the specific validation error (e.g. "Website URL must use http:// or https://") instead of a generic fallback when input is invalid.
 
+## Technical Changes
+
+- **`Car::delete()` CSRF now mandatory** ([#930](https://github.com/unibrain1/elanregistry/issues/930)): Changed `Car::delete()` from an optional nullable token to a required `string $token`, consistent with `create()` and `update()`. Removes the opt-in bypass that could be silently exploited by future callers.
+
 ## Issues Resolved
 
 - [#592](https://github.com/unibrain1/elanregistry/issues/592) — Add database triggers and indexes for car_user_hist table
@@ -58,4 +62,5 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - [#921](https://github.com/unibrain1/elanregistry/issues/921) — harden: apply http/https scheme whitelist to ElanRegistryOwner and user_settings website fields
 - [#927](https://github.com/unibrain1/elanregistry/issues/927) — bug: OwnerValidationException getUserMessage() returns generic default instead of specific validation text
 - [#931](https://github.com/unibrain1/elanregistry/issues/931) — test: add integration test for manage-consolidated.php car deletion audit trail
+- [#930](https://github.com/unibrain1/elanregistry/issues/930) — refactor: Car::delete() CSRF token is nullable — bypassable by omitting token
 - [#935](https://github.com/unibrain1/elanregistry/issues/935) — bug: CarVerificationManager::markSold() accepts overflow dates that PHP rolls forward silently

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -272,8 +272,8 @@ if (!class_exists('Car')) {
         /**
          * Delete car
          */
-        public function delete(string $reason = 'Administrative deletion', ?string $token = null): bool {
-            if ($token !== null && !Token::check($token)) {
+        public function delete(string $reason, string $token): bool {
+            if (!Token::check($token)) {
                 throw new CarDeletionException('Invalid CSRF token provided');
             }
 

--- a/tests/integration/CarDeletionTest.php
+++ b/tests/integration/CarDeletionTest.php
@@ -93,6 +93,18 @@ final class CarDeletionTest extends IntegrationTestCase
     }
 
     /**
+     * Test car deletion fails with empty token
+     */
+    #[Group('fast')]
+    public function testDeleteCarFailsWithEmptyToken(): void
+    {
+        $this->expectException(CarDeletionException::class);
+
+        $car = new Car($this->testCarId);
+        $car->delete('Test deletion', '');
+    }
+
+    /**
      * Test car deletion fails when car does not exist
      */
     #[Group('fast')]
@@ -205,19 +217,4 @@ final class CarDeletionTest extends IntegrationTestCase
         }
     }
 
-    /**
-     * Test car deletion with optional token parameter
-     */
-    #[Group('fast')]
-    public function testDeleteCarWithOptionalToken(): void
-    {
-        $car = new Car($this->testCarId);
-        $this->assertTrue($car->exists());
-
-        // Delete without providing token (using default parameter)
-        $result = $car->delete('Test deletion without token');
-
-        $this->assertTrue($result);
-        $this->assertFalse($car->exists());
-    }
 }

--- a/tests/integration/database/CarDatabaseOperationsTest.php
+++ b/tests/integration/database/CarDatabaseOperationsTest.php
@@ -132,7 +132,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
     public function testCarDeletionRemovesFromDatabase(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->delete('Integration test deletion');
+        $result = $car->delete('Integration test deletion', Token::generate());
 
         $this->assertTrue($result);
 
@@ -148,7 +148,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
     public function testCarDeletionCreatesAuditTrail(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->delete('Integration test audit trail');
+        $result = $car->delete('Integration test audit trail', Token::generate());
 
         $this->assertTrue($result);
 

--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -184,18 +184,20 @@ class Car
         if (!$repo->insert($this->tableName, $fields)) {
             logger($fields['user_id'] ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Car creation failed: ' . $repo->errorString());
             throw new CarCreationException('Database error during car creation: ' . $repo->errorString());
-        } else {
-            $id = $repo->lastId();
-            $this->find($id);
-            $this->imageDir = $settings->elan_image_dir . $id . '/';
-            $ownerId = (int) $this->data()->user_id;
-            if (!$repo->insertCarUser($ownerId, $id)) {
-                logger($ownerId, LogCategories::LOG_CATEGORY_DATABASE_ERROR, "Car ID $id created but owner assignment (car_user) failed for user ID $ownerId");
-            } else {
-                logger($ownerId, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Car ID $id created and assigned to owner (user ID: $ownerId)");
-            }
-            return true;
         }
+
+        $id = $repo->lastId();
+        $this->find($id);
+        $this->imageDir = $settings->elan_image_dir . $id . '/';
+        $ownerId = (int) $this->data()->user_id;
+
+        if (!$repo->insertCarUser($ownerId, $id)) {
+            logger($ownerId, LogCategories::LOG_CATEGORY_DATABASE_ERROR, "Car ID $id created but owner assignment (car_user) failed for user ID $ownerId. DB error: " . $repo->errorString());
+            throw new CarCreationException('Car record was created but owner assignment failed. Please try again or contact the administrator.');
+        }
+
+        logger($ownerId, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Car ID $id created and assigned to owner (user ID: $ownerId)");
+        return true;
     }
 
     /**
@@ -450,16 +452,15 @@ class Car
      * Delete the car and all associated records
      *
      * @param string $reason Reason for deletion (for audit trail)
-     * @param string|null $token CSRF token (optional)
+     * @param string $token CSRF token (required)
      * @return bool True if deletion was successful
      * @throws Exception If validation fails or database operation fails
      */
-    public function delete(string $reason = 'Administrative deletion', ?string $token = null): bool
+    public function delete(string $reason, string $token): bool
     {
         global $user;
 
-        // CSRF Protection
-        if ($token !== null && !Token::check($token)) {
+        if (!Token::check($token)) {
             throw new CarDeletionException(CarErrorMessages::getMessage('csrf_token_invalid', 'admin', ['operation' => 'car deletion']));
         }
 

--- a/usersc/plugins/ai_prompts/custom_prompts/elanregistry_classes.md.php
+++ b/usersc/plugins/ai_prompts/custom_prompts/elanregistry_classes.md.php
@@ -66,8 +66,8 @@ $car->update([
     'csrf'       => Token::generate(),
 ]);
 
-// Delete (soft delete with audit trail)
-$car->delete($userId);
+// Delete (hard delete; cars_hist trigger records the audit trail)
+$car->delete('Reason for deletion', Token::generate());
 ```
 
 **Key database tables:** `cars` (primary), `cars_hist` (trigger-written audit trail),


### PR DESCRIPTION
## Summary

- Makes `Car::delete()` CSRF token a required `string $token` parameter, consistent with `create()` and `update()` — removes the nullable opt-in that allowed future callers to silently bypass CSRF validation
- Fixes a pre-existing silent failure in `Car::create()` where `insertCarUser()` failure logged a warning but returned `true`, orphaning the created car record
- Corrects a stale `Car::delete()` example in the AI prompts file that would have caused a `TypeError` with the new signature

## Changes

- `Car::delete()`: `?string $token = null` → `string $token` (required); removes default from `$reason`
- `Car::create()`: `insertCarUser()` failure now throws `CarCreationException` instead of silently succeeding
- `tests/bootstrap-unit.php`: mock updated to match new `delete()` signature
- `CarDeletionTest`: removed `testDeleteCarWithOptionalToken`; added `testDeleteCarFailsWithEmptyToken`
- `CarDatabaseOperationsTest`: two calls updated to pass `Token::generate()`
- `elanregistry_classes.md.php`: AI prompts `Car::delete()` example corrected
- Release notes updated

## Bug Escape Analysis (`Car::create()` silent failure)

- **Root cause:** `insertCarUser()` failure path logged a `DATABASE_ERROR` but fell through to `return true` inside an `else` branch — no test covered a failing `insertCarUser()` call
- **Risk:** Car created with no `car_user` row — owner can never see or manage the car; user sees a false success message
- **Fix:** Throw `CarCreationException` on failure; success logger moved to the unconditional path

## Follow-up

- #956 — migrate `manage-consolidated.php` delete path to `Car::delete()` (pre-existing gap, separate PR)

## Test plan

- [x] 902/902 unit tests pass
- [x] 22/22 `CarDeletionTest` + `CarDatabaseOperationsTest` integration tests pass (includes new `testDeleteCarFailsWithEmptyToken`)
- [x] PHPStan: no errors
- [x] Pre-commit hooks: all passed

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)