### PR TITLE
refactor: migrate manage-consolidated.php delete path to Car::delete() (#956)

### DIFF
--- a/app/admin/includes/tab-car_mgmt.php
+++ b/app/admin/includes/tab-car_mgmt.php
@@ -345,6 +345,12 @@ try {
                                                placeholder="Type DELETE" required>
                                         <div class="invalid-feedback">You must type DELETE to confirm deletion.</div>
                                     </div>
+                                    <div class="mb-3">
+                                        <label for="delete_reason" class="form-label">Reason for deletion (optional)</label>
+                                        <input type="text" class="form-control" id="delete_reason" name="reason"
+                                               maxlength="500"
+                                               placeholder="e.g. Spam record, test data, duplicate">
+                                    </div>
                                     <button type="submit" class="btn btn-danger btn-sm w-100" id="deleteBtn" disabled>
                                         <i class="fas fa-trash-alt"></i> Permanent Delete
                                     </button>

--- a/app/admin/manage-consolidated.php
+++ b/app/admin/manage-consolidated.php
@@ -1,6 +1,11 @@
 <?php
 declare(strict_types=1);
 
+use ElanRegistry\Exceptions\CarDatabaseException;
+use ElanRegistry\Exceptions\CarDeletionException;
+use ElanRegistry\Exceptions\CarNotFoundException;
+use ElanRegistry\Input as ElanInput;
+
 /**
  * manage-consolidated.php
  * Consolidated Management Interface
@@ -288,6 +293,7 @@ if (Input::exists('post')) {
                 case "delete":
                     $car_id = (int) Input::get('car_id');
                     $confirmation = Input::get('confirmation');
+                    $reason = mb_substr(ElanInput::raw('reason') ?: 'Administrative deletion', 0, 500);
 
                     if (!$car_id) {
                         $errors[] = 'Please provide a valid car ID';
@@ -299,27 +305,27 @@ if (Input::exists('post')) {
                         break;
                     }
 
-                    // Get car details before deletion for logging
-                    $carQ = $db->query("SELECT * FROM cars WHERE id = ?", [$car_id]);
-                    if ($carQ->count() === 0) {
+                    try {
+                        $car = new Car($car_id);
+                        if (!$car->exists()) {
+                            $errors[] = "Car ID $car_id not found";
+                            break;
+                        }
+                        $chassis = $car->data()->chassis;
+                        $car->delete($reason, $token);
+                        $successes[] = "Car ID $car_id ($chassis) has been permanently deleted";
+                    } catch (CarNotFoundException $e) {
+                        // Race: car deleted between the exists() check and delete().
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_DELETION,
+                            "Car ID $car_id not found during deletion attempt");
                         $errors[] = "Car ID $car_id not found";
-                        break;
-                    }
-
-                    $carData = $carQ->first();
-
-                    // Remove from car_user relationship table
-                    $db->query("DELETE FROM car_user WHERE car_id = ?", [$car_id]);
-
-                    // Remove the car record
-                    $result = $db->query("DELETE FROM cars WHERE id = ?", [$car_id]);
-
-                    if ($db->error()) {
-                        $errors[] = "Failed to delete car: " . $db->errorString();
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_DELETION, "FAILED: Delete car ID $car_id - " . $db->errorString());
-                    } else {
-                        $successes[] = "Car ID $car_id ({$carData->chassis}) has been permanently deleted";
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_DELETION, "SUCCESS: Deleted car ID $car_id ({$carData->chassis})");
+                    } catch (CarDeletionException | CarDatabaseException $e) {
+                        // CarAdministrationService::delete() logs technical detail before throwing.
+                        $errors[] = "Failed to delete car. Check the system log for details.";
+                    } catch (\Exception $e) {
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_DELETION,
+                            "Unexpected error deleting car ID $car_id: " . get_class($e) . ': ' . $e->getMessage());
+                        $errors[] = "An unexpected error occurred. Check the system log for details.";
                     }
                     break;
             }

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -44,6 +44,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 ## Technical Changes
 
 - **`Car::delete()` CSRF now mandatory** ([#930](https://github.com/unibrain1/elanregistry/issues/930)): Changed `Car::delete()` from an optional nullable token to a required `string $token`, consistent with `create()` and `update()`. Removes the opt-in bypass that could be silently exploited by future callers.
+- **Admin delete path routed through `Car::delete()`** ([#956](https://github.com/unibrain1/elanregistry/issues/956)): The admin car deletion handler in `manage-consolidated.php` previously issued raw SQL, bypassing the class-level CSRF guard added in #930. Refactored to call `Car::delete()`, which enforces CSRF validation, authentication, transaction wrapping, and audit logging. Defense-in-depth: page-level guards remain in place.
 
 ## Issues Resolved
 
@@ -64,5 +65,6 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - [#927](https://github.com/unibrain1/elanregistry/issues/927) — bug: OwnerValidationException getUserMessage() returns generic default instead of specific validation text
 - [#931](https://github.com/unibrain1/elanregistry/issues/931) — test: add integration test for manage-consolidated.php car deletion audit trail
 - [#930](https://github.com/unibrain1/elanregistry/issues/930) — refactor: Car::delete() CSRF token is nullable — bypassable by omitting token
+- [#956](https://github.com/unibrain1/elanregistry/issues/956) — refactor: migrate manage-consolidated.php delete path to Car::delete()
 - [#935](https://github.com/unibrain1/elanregistry/issues/935) — bug: CarVerificationManager::markSold() accepts overflow dates that PHP rolls forward silently
 - [#947](https://github.com/unibrain1/elanregistry/issues/947) — bug: AppConstants::DATETIME_FORMAT uses 'G' (no leading zero) instead of 'H'

--- a/tests/integration/ManageConsolidatedDeletionTest.php
+++ b/tests/integration/ManageConsolidatedDeletionTest.php
@@ -7,28 +7,46 @@ require_once __DIR__ . '/IntegrationTestCase.php';
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Regression guard for the legacy car deletion path in
- * app/admin/manage-consolidated.php.
+ * Regression guard for the car deletion path in
+ * app/admin/manage-consolidated.php after migration to Car::delete().
  *
- * That page issues raw DELETE statements against car_user and cars and
- * relies on the cars_delete DB trigger to write the cars_hist audit row.
- * Issue #593 removed a duplicate application-layer INSERT INTO cars_hist
- * from this path; if a similar manual insert is ever re-introduced above
- * the DELETE FROM cars statement, the cars_hist DELETE row count will
- * climb to 2 and this test will fail. Companion to
- * CarDeletionTest::testDeleteCarCreatesAuditTrail(), which guards the
- * Car::delete() / CarAdministrationService path. See #593, #931.
+ * Prior to #956 that page issued raw DELETE statements directly against
+ * car_user and cars. Issue #956 routes deletion through Car::delete() /
+ * CarAdministrationService::delete(), which handles the transaction,
+ * car_user removal, and audit trail. This test guards against regressions
+ * to that path — specifically verifying that exactly one DELETE row appears
+ * in cars_hist (written by the DB trigger). A second row would indicate an
+ * accidental application-layer re-introduction of a pre-delete INSERT.
+ *
+ * Companion to CarDeletionTest::testDeleteCarCreatesAuditTrail(), which
+ * guards the Car::delete() / CarAdministrationService path directly.
+ *
+ * @see CarDeletionTest
+ * @see #593, #930, #931, #956
  */
 #[Group('integration')]
 final class ManageConsolidatedDeletionTest extends IntegrationTestCase
 {
-    private int $testUserId = 1;
+    private int $testUserId;
     private int $testCarId;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->requireDatabase();
+
+        // Set up authenticated user context required by Car::delete()
+        global $user;
+        $user = new User();
+        $user->find(1);
+
+        $reflection = new ReflectionClass($user);
+        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
+        $isLoggedInProperty->setAccessible(true);
+        $isLoggedInProperty->setValue($user, true);
+
+        $GLOBALS['user'] = $user;
+        $this->testUserId = 1;
 
         try {
             $this->testCarId = $this->createTestCar($this->testUserId, [
@@ -42,10 +60,8 @@ final class ManageConsolidatedDeletionTest extends IntegrationTestCase
     #[Group('fast')]
     public function testManageConsolidatedDeleteCreatesExactlyOneAuditRow(): void
     {
-        // Replicate the raw DB ops performed by
-        // app/admin/manage-consolidated.php (action=delete).
-        $this->db->query("DELETE FROM car_user WHERE car_id = ?", [$this->testCarId]);
-        $this->db->query("DELETE FROM cars WHERE id = ?", [$this->testCarId]);
+        $car = new Car($this->testCarId);
+        $car->delete('Integration test deletion', Token::generate());
 
         $historyQuery = $this->db->query(
             "SELECT * FROM cars_hist WHERE car_id = ? AND operation = 'DELETE'",
@@ -55,8 +71,8 @@ final class ManageConsolidatedDeletionTest extends IntegrationTestCase
         $this->assertSame(
             1,
             $historyQuery->count(),
-            'Expected exactly one DELETE row in cars_hist for the legacy '
-                . 'manage-consolidated.php delete path'
+            'Expected exactly one DELETE row in cars_hist for the '
+                . 'manage-consolidated.php Car::delete() path'
         );
     }
 }


### PR DESCRIPTION
## Summary

- Routes admin car deletion through `Car::delete()` instead of raw `DELETE FROM cars`/`DELETE FROM car_user` SQL, closing the defense-in-depth gap left after #930 made CSRF mandatory on the class-level guard
- Adds optional "Reason for deletion" field to the admin delete form (maxlength=500, server-side capped with `mb_substr`) for richer audit-trail context
- Updates `ManageConsolidatedDeletionTest` from raw-SQL replication to `Car::delete()` path with authenticated user context

## Changes

**`app/admin/manage-consolidated.php`**
- Added `use` statements for `CarNotFoundException`, `CarDeletionException`, `CarDatabaseException`, and `ElanInput` alias
- Replaced `case "delete":` raw SQL block with `Car::delete($reason, $token)` call
- Guards existence before reading chassis (`$car->exists()`) to prevent null-dereference fatal
- Exception hierarchy: `CarNotFoundException` (with logger), `CarDeletionException|CarDatabaseException`, and catch-all `\Exception`

**`app/admin/includes/tab-car_mgmt.php`**
- Optional "Reason for deletion" input field added between confirmation and submit button

**`tests/integration/ManageConsolidatedDeletionTest.php`**
- Rewired from raw-SQL replication to `Car::delete()` path
- Added authenticated user setup (reflection pattern, matching `CarDeletionTest`)
- Removes redundant `protected $db` re-declaration (inherits from `IntegrationTestCase`)

## Test plan

- [x] `composer test:medium` — 906 unit + 20 integration tests pass
- [x] `composer check:php` — no blocking issues on changed files
- [x] Pre-commit hooks: phpcs, PHPStan, unit tests — all pass
- [x] Multi-agent PR review (code, tests, error-handling) — all findings addressed

## Security

- Page-level `securePage()` and `Token::check()` guards unchanged (defense-in-depth)
- `ElanInput::raw('reason')` used for DB-destined text field (encode-at-output policy)
- `$e->getMessage()` never exposed to user — only to `logger()`
- `Token::check()` confirmed non-consuming (verified against `Token.php`); double-check is safe

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)