### PR TITLE
feat: add car_user_hist triggers, indexes, fix script, and tests (#592)

### DIFF
--- a/app/admin/scripts/fix/06-Add-Car-User-Hist-Triggers.php
+++ b/app/admin/scripts/fix/06-Add-Car-User-Hist-Triggers.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * 06-Add-Car-User-Hist-Triggers.php
+ * Add database triggers and performance indexes for the car_user_hist table.
+ * Issue #592: Add database triggers and indexes for car_user_hist table
+ *
+ * The car_user_hist audit table has existed since ADR-003 but was never
+ * populated. This script installs AFTER INSERT/UPDATE/DELETE triggers on
+ * car_user and adds indexes on car_id and userid. Idempotent: triggers are
+ * dropped before recreation and indexes are skipped if already present.
+ *
+ * DEPLOYMENT INSTRUCTIONS:
+ * 1. Copy this file to app/admin/scripts/fix/ with proper naming: ##-Descriptive-Name.php
+ * 2. Scripts are accessed via manage-maintenance.php (Maintenance tab) or direct URL
+ * 3. Use sequential numbering (01, 02, 03...) for proper execution order
+ * 4. All scripts auto-log completion to fix_script_runs table
+ * 5. See app/admin/scripts/fix/README.md for detailed instructions and best practices
+ */
+
+// UI Constants for progress output
+define('SECTION_SEPARATOR', '═══════════════════════════════════════════════════════');
+
+require_once '../../../../users/init.php';
+require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
+
+if (!securePage($php_self)) {
+    die();
+}
+
+// Set up custom error handler to log through UserSpice logger
+set_error_handler(function($errno, $errstr, $errfile, $errline) {
+    if ($errno !== E_DEPRECATED) {
+        logger(isset($user) ? $user->data()->id : 0, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "Error [$errno]: $errstr in $errfile:$errline");
+    }
+    return true;
+});
+
+$db = DB::getInstance();
+
+?>
+
+<div id="page-wrapper">
+    <div class="container-fluid">
+        <div class="well">
+
+            <?php if (!isset($_GET['start'])): ?>
+            <!-- Initial Description -->
+            <div class="row">
+                <div class="col-lg-12 mb-4">
+                    <div class="card registry-card">
+                        <div class="card-header">
+                            <h2 class="mb-0">
+                                <i class="fa fa-history"></i> Add car_user_hist Triggers and Indexes
+                            </h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="mb-3">Installs audit triggers and performance indexes for the <code>car_user_hist</code> table so that changes to car-user relationships are recorded at the database level.</p>
+
+                            <div class="alert alert-info">
+                                <h5><i class="fa fa-info-circle"></i> What this script does:</h5>
+                                <ul class="mb-0">
+                                    <li>Creates the <code>car_user_insert</code>, <code>car_user_update</code>, and <code>car_user_delete</code> triggers on <code>car_user</code></li>
+                                    <li>Each trigger writes an audit row to <code>car_user_hist</code> (operation, car_id, userid)</li>
+                                    <li>Adds index <code>idx_car_user_hist_car_id</code> on <code>car_id</code></li>
+                                    <li>Adds index <code>idx_car_user_hist_userid</code> on <code>userid</code></li>
+                                    <li>Is idempotent: existing triggers are recreated and existing indexes are skipped</li>
+                                </ul>
+                            </div>
+
+                            <div class="alert alert-warning">
+                                <h5><i class="fa fa-exclamation-triangle"></i> Important Notes:</h5>
+                                <ul class="mb-0">
+                                    <li>This changes schema objects on live data — run on dev first</li>
+                                    <li>Safe to re-run; it will not create duplicate triggers or indexes</li>
+                                    <li>Back up the database before running on production</li>
+                                </ul>
+                            </div>
+
+                            <div class="text-center">
+                                <a href="?start=1" class="btn btn-success btn-lg">
+                                    <i class="fa fa-play"></i> Continue - Install Triggers and Indexes
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <?php else:
+                // Processing mode - simple text output
+                ob_end_clean(); // Clear template buffering
+                header('Content-Type: text/html; charset=utf-8');
+                echo str_repeat(' ', 1024); // Pad to force initial flush
+                flush();
+            ?>
+
+            <div class="card registry-card">
+                <div class="card-header">
+                    <h2 class="mb-0">
+                        <i class="fa fa-cogs"></i> Installing car_user_hist Triggers and Indexes
+                    </h2>
+                    <small class="text-muted">
+                        <i class="fa fa-clock-o"></i> Started: <?php echo date('Y-m-d H:i:s'); ?>
+                    </small>
+                </div>
+                <div class="card-body">
+                    <pre style="background: #f5f5f5; padding: 15px; border-radius: 4px; max-height: 600px; overflow-y: auto; font-family: 'Courier New', monospace; font-size: 13px;"><?php
+
+                    /**
+                     * Helper function for progress output
+                     *
+                     * @param string $message Message to display
+                     * @param string $type Type of message: 'info', 'success', 'error', 'warning', 'step'
+                     */
+                    function logProgress(string $message, string $type = 'info'): void {
+                        $icons = [
+                            'info' => 'ℹ️',
+                            'success' => '✅',
+                            'error' => '❌',
+                            'warning' => '⚠️',
+                            'step' => '▶️'
+                        ];
+                        $icon = $icons[$type] ?? '•';
+                        echo date('[H:i:s] ') . $icon . ' ' . $message . "\n";
+                        flush();
+                    }
+
+                    // Initialize results tracking
+                    $results = [
+                        'processed' => 0,
+                        'errors' => 0,
+                        'warnings' => 0
+                    ];
+
+                    /**
+                     * Drop and recreate a trigger. Both SQL arguments ($dropSql, $createSql)
+                     * are complete literal strings at every call site — no user input is ever
+                     * interpolated into either query. $name is used only for log messages.
+                     *
+                     * @param string $name      Trigger name (log messages only)
+                     * @param string $dropSql   Complete DROP TRIGGER IF EXISTS statement
+                     * @param string $createSql Complete CREATE TRIGGER statement
+                     */
+                    $createTrigger = function(string $name, string $dropSql, string $createSql) use ($db, $user, &$results): void {
+                        $db->query($dropSql);
+                        if ($db->error()) {
+                            $dbError = $db->errorString();
+                            logProgress("Trigger {$name}: DB error on DROP — {$dbError}", 'error');
+                            logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "06-Add-Car-User-Hist-Triggers: DB error dropping trigger {$name}: {$dbError}");
+                            $results['errors']++;
+                            return;
+                        }
+
+                        $db->query($createSql);
+                        if ($db->error()) {
+                            $dbError = $db->errorString();
+                            logProgress("Trigger {$name}: DB error on CREATE — {$dbError}", 'error');
+                            logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "06-Add-Car-User-Hist-Triggers: DB error creating trigger {$name}: {$dbError}");
+                            $results['errors']++;
+                        } else {
+                            logProgress("Trigger {$name}: created", 'success');
+                            logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "06-Add-Car-User-Hist-Triggers: trigger {$name} created");
+                            $results['processed']++;
+                        }
+                    };
+
+                    /**
+                     * Add an index on car_user_hist if it does not already exist.
+                     * $indexName is passed as a bound parameter to the SHOW INDEX query and
+                     * used in log messages — never interpolated into SQL. $addKeySql is a
+                     * complete literal string at every call site.
+                     *
+                     * @param string $indexName  Index name (bound parameter in SHOW INDEX query)
+                     * @param string $addKeySql  Complete ALTER TABLE … ADD KEY statement
+                     */
+                    $addIndex = function(string $indexName, string $addKeySql) use ($db, $user, &$results): void {
+                        $existing = $db->query("SHOW INDEX FROM car_user_hist WHERE Key_name = ?", [$indexName]);
+                        if ($db->error()) {
+                            $dbError = $db->errorString();
+                            logProgress("Index {$indexName}: DB error on existence check — {$dbError}", 'error');
+                            logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "06-Add-Car-User-Hist-Triggers: DB error checking index {$indexName}: {$dbError}");
+                            $results['errors']++;
+                            return;
+                        }
+
+                        if ($existing->count() > 0) {
+                            logProgress("Index {$indexName}: already exists, skipping", 'warning');
+                            $results['warnings']++;
+                            return;
+                        }
+
+                        $db->query($addKeySql);
+                        if ($db->error()) {
+                            $dbError = $db->errorString();
+                            logProgress("Index {$indexName}: DB error on ADD — {$dbError}", 'error');
+                            logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "06-Add-Car-User-Hist-Triggers: DB error adding index {$indexName}: {$dbError}");
+                            $results['errors']++;
+                        } else {
+                            logProgress("Index {$indexName}: created", 'success');
+                            logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "06-Add-Car-User-Hist-Triggers: index {$indexName} created");
+                            $results['processed']++;
+                        }
+                    };
+
+                    try {
+                        // STEP 1: CREATE TRIGGERS
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 1: CREATE TRIGGERS', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $createTrigger(
+                            'car_user_delete',
+                            "DROP TRIGGER IF EXISTS `car_user_delete`",
+                            "CREATE TRIGGER `car_user_delete` AFTER DELETE ON `car_user` FOR EACH ROW BEGIN
+    INSERT INTO car_user_hist (operation, car_id, userid)
+    VALUES ('DELETE', OLD.car_id, OLD.userid);
+END"
+                        );
+
+                        $createTrigger(
+                            'car_user_insert',
+                            "DROP TRIGGER IF EXISTS `car_user_insert`",
+                            "CREATE TRIGGER `car_user_insert` AFTER INSERT ON `car_user` FOR EACH ROW BEGIN
+    INSERT INTO car_user_hist (operation, car_id, userid)
+    VALUES ('INSERT', NEW.car_id, NEW.userid);
+END"
+                        );
+
+                        $createTrigger(
+                            'car_user_update',
+                            "DROP TRIGGER IF EXISTS `car_user_update`",
+                            "CREATE TRIGGER `car_user_update` AFTER UPDATE ON `car_user` FOR EACH ROW BEGIN
+    IF @disable_triggers IS NULL THEN
+        INSERT INTO car_user_hist (operation, car_id, userid)
+        VALUES ('UPDATE', OLD.car_id, OLD.userid);
+    END IF;
+END"
+                        );
+
+                        // STEP 2: ADD INDEXES
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 2: ADD INDEXES', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $addIndex(
+                            'idx_car_user_hist_car_id',
+                            "ALTER TABLE car_user_hist ADD KEY idx_car_user_hist_car_id (car_id)"
+                        );
+
+                        $addIndex(
+                            'idx_car_user_hist_userid',
+                            "ALTER TABLE car_user_hist ADD KEY idx_car_user_hist_userid (userid)"
+                        );
+
+                        // STEP 3: VERIFY AND COMPLETE
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 3: VERIFY TRIGGER STATE', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $found = $db->query("SHOW TRIGGERS WHERE `Table` = 'car_user'")->results();
+                        $presentNames = array_column((array) $found, 'Trigger');
+                        foreach (['car_user_delete', 'car_user_insert', 'car_user_update'] as $expected) {
+                            if (in_array($expected, $presentNames, true)) {
+                                logProgress("  {$expected}: present", 'success');
+                            } else {
+                                logProgress("  {$expected}: MISSING", 'error');
+                                $results['errors']++;
+                            }
+                        }
+
+                        // Display summary
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        if ($results['errors'] > 0) {
+                            logProgress('COMPLETED WITH ERRORS — some operations failed, review above.', 'error');
+                        } else {
+                            logProgress('car_user_hist triggers and indexes installation complete.', 'step');
+                        }
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        if ($results['errors'] > 0) {
+                            logProgress("Errors: {$results['errors']}", 'error');
+                        }
+                        if ($results['warnings'] > 0) {
+                            logProgress("Warnings: {$results['warnings']}", 'warning');
+                        }
+                        logProgress("Items Processed: {$results['processed']}", 'success');
+
+                        // Only record completion when all schema operations succeeded
+                        if ($results['errors'] === 0) {
+                            $inserted = $db->insert('fix_script_runs', [
+                                'script_name' => '06-Add-Car-User-Hist-Triggers.php',
+                                'completed_at' => date('Y-m-d H:i:s')
+                            ]);
+                            if (!$inserted) {
+                                logProgress('Warning: could not record completion in fix_script_runs — ' . $db->errorString(), 'warning');
+                            }
+                            logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT,
+                                "Script completed successfully — Processed: {$results['processed']}, Warnings: {$results['warnings']}");
+                        } else {
+                            logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT,
+                                "Script completed WITH ERRORS — Processed: {$results['processed']}, Errors: {$results['errors']}, Warnings: {$results['warnings']}");
+                        }
+
+                    } catch (\Throwable $e) {
+                        $detail = get_class($e) . ': ' . $e->getMessage()
+                            . ' in ' . $e->getFile() . ':' . $e->getLine();
+                        logProgress('FATAL ERROR: ' . $detail, 'error');
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT_ERROR,
+                            '06-Add-Car-User-Hist-Triggers fatal error: ' . $detail);
+                    }
+
+                    ?></pre>
+
+                    <div class="text-center mt-3">
+                        <a href="../../manage-maintenance.php?tab=maintenance" class="btn btn-primary btn-lg">
+                            <i class="fa fa-arrow-left"></i> Return to Maintenance
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <?php endif; ?>
+
+        </div>
+    </div>
+</div>
+
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/database/1-schema.sql
+++ b/database/1-schema.sql
@@ -300,6 +300,12 @@ ALTER TABLE `car_user`
 ALTER TABLE `car_user_hist`
   ADD UNIQUE KEY `id` (`id`) USING BTREE;
 
+ALTER TABLE `car_user_hist`
+  ADD KEY `idx_car_user_hist_car_id` (`car_id`);
+
+ALTER TABLE `car_user_hist`
+  ADD KEY `idx_car_user_hist_userid` (`userid`);
+
 -- car_transfer_requests table
 ALTER TABLE `car_transfer_requests`
   ADD PRIMARY KEY (`id`),
@@ -410,6 +416,38 @@ CREATE TRIGGER `cars_update` AFTER UPDATE ON `cars` FOR EACH ROW BEGIN
             OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
             OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
         );
+    END IF;
+END$$
+DELIMITER ;
+
+-- -----------------------------------------------------------------------------
+-- Trigger: car_user_delete (Audit trail for car-user relationship removals)
+-- -----------------------------------------------------------------------------
+DELIMITER $$
+CREATE TRIGGER `car_user_delete` AFTER DELETE ON `car_user` FOR EACH ROW BEGIN
+    INSERT INTO car_user_hist (operation, car_id, userid)
+    VALUES ('DELETE', OLD.car_id, OLD.userid);
+END$$
+DELIMITER ;
+
+-- -----------------------------------------------------------------------------
+-- Trigger: car_user_insert (Audit trail for car-user relationship additions)
+-- -----------------------------------------------------------------------------
+DELIMITER $$
+CREATE TRIGGER `car_user_insert` AFTER INSERT ON `car_user` FOR EACH ROW BEGIN
+    INSERT INTO car_user_hist (operation, car_id, userid)
+    VALUES ('INSERT', NEW.car_id, NEW.userid);
+END$$
+DELIMITER ;
+
+-- -----------------------------------------------------------------------------
+-- Trigger: car_user_update (Audit trail for car-user relationship updates)
+-- -----------------------------------------------------------------------------
+DELIMITER $$
+CREATE TRIGGER `car_user_update` AFTER UPDATE ON `car_user` FOR EACH ROW BEGIN
+    IF @disable_triggers IS NULL THEN
+        INSERT INTO car_user_hist (operation, car_id, userid)
+        VALUES ('UPDATE', OLD.car_id, OLD.userid);
     END IF;
 END$$
 DELIMITER ;

--- a/docs/development/DATABASE.md
+++ b/docs/development/DATABASE.md
@@ -117,6 +117,8 @@ to own multiple cars.
 | `userid` | `int` | User ID |
 | `timestamp` | `timestamp` | Change timestamp |
 
+**Note**: This table is populated by database triggers on `car_user` (added in [#592](https://github.com/unibrain1/elanregistry/issues/592)). Indexes on `car_id` and `userid` were added for query performance.
+
 #### `car_transfer_requests` - Ownership transfer workflow
 
 | Column | Type | Description |
@@ -262,9 +264,12 @@ id=5, years=1971-1974, series="S4", variant="FHC", type_code="36", model_value="
 - Triggers updated 2025-09-12 to use current schema (no deprecated columns)
 - Each trigger records operation type (INSERT/UPDATE/DELETE) and timestamp
 
-**Note**: Currently only `cars` table has triggers. The `car_user` relationship
-changes are logged through application-level logging to `car_user_hist` table,
-not database triggers.
+**Car-User Relationship Triggers** (implemented in #592):
+
+- `car_user_insert`: Logs new car-user relationships to `car_user_hist`
+- `car_user_update`: Logs car-user relationship modifications to `car_user_hist` with bypass via
+  `@disable_triggers` variable
+- `car_user_delete`: Logs car-user relationship removals to `car_user_hist`
 
 ### Special System Accounts
 

--- a/docs/development/adr/ADR-003-database-audit-trails-triggers-history-tables.md
+++ b/docs/development/adr/ADR-003-database-audit-trails-triggers-history-tables.md
@@ -111,9 +111,9 @@ relationship table:
 | `userid` | int |
 | `timestamp` | timestamp DEFAULT CURRENT_TIMESTAMP |
 
-**Current status:** This table is designed but unimplemented. No database
-triggers populate it, and no application code writes to it. Car sharing
-relationship changes are currently unaudited at the database level.
+**Status:** Implemented in #592. AFTER INSERT, AFTER UPDATE, and AFTER DELETE
+triggers on `car_user` now populate this table. Indexes added on `car_id` and
+`userid` for query performance.
 
 ### Application-Level History Writes
 
@@ -218,9 +218,9 @@ column lists in triggers make this error-prone if not carefully automated.
   database-level constraints preventing history row modification remains an
   architectural gap regardless.
 
-- **car_user_hist is unimplemented.** The table exists in the schema but has no
-  triggers and no application code writing to it. Ownership relationship changes
-  (car sharing, transfer) are currently unaudited at the database level.
+- **car_user_hist gap resolved (#592).** AFTER INSERT, AFTER UPDATE, and AFTER DELETE
+  triggers on `car_user` now populate this table. Indexes on `car_id` and `userid`
+  were added for query performance. See the `car_user_hist` section above.
 
 - **GDPR complexity.** Owner PII (name, email, location) is embedded in
   `cars_hist` rows as a direct consequence of the denormalized snapshot design
@@ -237,9 +237,9 @@ column lists in triggers make this error-prone if not carefully automated.
   "legitimate interest" basis covers retention of historical registry data or
   whether PII scrubbing is required on deletion.
 
-- **No indexes on car_user_hist.** The table has only a unique key on `id`, with
-  no indexes on `car_id` or `userid`. If the table were populated, queries to
-  find all changes to a car or by a user would perform full table scans.
+- **Indexes on car_user_hist.** In addition to the unique key on `id`, the table
+  now has indexes on `car_id` and `userid` (added in #592), so queries to find
+  all changes to a car or by a user avoid full table scans.
 
 - **Storage growth.** Every car modification creates a full row copy in
   `cars_hist`, including large text columns (`comments` mediumtext, `image`
@@ -256,7 +256,7 @@ column lists in triggers make this error-prone if not carefully automated.
 | @disable_triggers bleeding across pooled connections | Low | Low | PHP connection lifecycle resets session state; variable defaults to NULL |
 | GDPR deletion requiring history scrubbing | Low-Medium | High | noowner covers prospective writes; historical PII requires targeted UPDATE |
 | Double-writes creating duplicate history rows | Resolved | — | Removed app pre-delete write in v2.25.0 (#593) |
-| car_user_hist audit gaps during implementation | Medium | High | Acknowledged; implementation should include trigger setup and test coverage |
+| car_user_hist audit gaps during implementation | Medium | High | Resolved in #592; triggers and tests added |
 
 ## Alternatives Considered
 
@@ -274,7 +274,8 @@ or service classes) instead of database triggers.
 
 - The `car_user_hist` table provides concrete evidence of this failure mode: the
   table was designed for application-level logging but no code was ever written
-  to populate it, leaving car sharing relationship changes completely unaudited.
+  to populate it, leaving car sharing relationship changes completely unaudited
+  until #592 added triggers to fill the gap.
 
 - Bulk operations and administrative scripts frequently bypass the normal
   application layer. A solution that depends on application-level cooperation

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -7,7 +7,9 @@
 
 - **Run fix script `05-Fix-Website-Scheme.php`** ([#851](https://github.com/unibrain1/elanregistry/issues/851)): Migrates existing `cars` rows with scheme-less website URLs (e.g. `example.com`) to `https://example.com`; nulls out invalid values (`javascript:`, relative paths, etc.). Run via the Maintenance tab in the admin panel.
 
-_Additional deployment actions expected: SQL migrations for new `chassis_override` column on `cars`, `cars_hist` trigger updates, and `car_user_hist` triggers/indexes (#915, #592)._
+- **Run fix script `06-Add-Car-User-Hist-Triggers.php`** ([#592](https://github.com/unibrain1/elanregistry/issues/592)): Installs AFTER INSERT/UPDATE/DELETE triggers on `car_user` and adds indexes on `car_user_hist(car_id)` and `car_user_hist(userid)`. Run via the Maintenance tab in the admin panel.
+
+_Additional deployment actions expected: SQL migrations for new `chassis_override` column on `cars` and `cars_hist` trigger updates (#915)._
 
 ## User-Facing Changes
 

--- a/tests/integration/CarUserHistTriggerTest.php
+++ b/tests/integration/CarUserHistTriggerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration tests for the car_user_hist triggers and indexes introduced in #592.
+ *
+ * Verifies that the three AFTER triggers on `car_user` (INSERT, UPDATE, DELETE)
+ * correctly write audit rows to `car_user_hist`, that the UPDATE trigger respects
+ * the `@disable_triggers` session variable bypass, and that the two covering
+ * indexes are present in the database.
+ *
+ * Only the UPDATE trigger implements the `@disable_triggers` guard — INSERT and
+ * DELETE triggers always fire unconditionally, matching the existing cars_insert
+ * and cars_delete pattern.
+ *
+ * Requires the fix script 06-Add-Car-User-Hist-Triggers.php to have been run
+ * against the target database. Tests are skipped if the triggers are absent.
+ */
+#[Group('integration')]
+final class CarUserHistTriggerTest extends IntegrationTestCase
+{
+    private int $testUserId;
+    private int $testCarId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireDatabase();
+
+        $triggerCheck = $this->db->query("SHOW TRIGGERS WHERE `Trigger` = 'car_user_insert'");
+        if ($triggerCheck->count() === 0) {
+            $this->markTestSkipped(
+                'car_user triggers not yet installed — run fix script 06-Add-Car-User-Hist-Triggers.php first'
+            );
+        }
+
+        $this->testUserId = 1;
+
+        try {
+            $this->testCarId = $this->createTestCar($this->testUserId, [
+                'chassis' => 'CUH' . uniqid(),
+            ]);
+        } catch (RuntimeException $e) {
+            $this->markTestSkipped('Could not create test car: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Verifies the AFTER INSERT trigger fires and writes one INSERT row to
+     * car_user_hist when a car_user record is created.
+     */
+    #[Group('fast')]
+    public function testInsertTriggerFiresOnCarUserInsert(): void
+    {
+        $histRows = $this->db->query(
+            "SELECT * FROM car_user_hist WHERE car_id = ? AND operation = 'INSERT'",
+            [$this->testCarId]
+        );
+
+        $this->assertSame(
+            1,
+            $histRows->count(),
+            'Expected exactly one INSERT row in car_user_hist after car_user insert'
+        );
+    }
+
+    /**
+     * Verifies the AFTER UPDATE trigger fires and writes one UPDATE row to
+     * car_user_hist when a car_user record is updated.
+     */
+    #[Group('fast')]
+    public function testUpdateTriggerFiresOnCarUserUpdate(): void
+    {
+        $this->db->query(
+            "UPDATE car_user SET mtime = NOW() WHERE car_id = ?",
+            [$this->testCarId]
+        );
+
+        $histRows = $this->db->query(
+            "SELECT * FROM car_user_hist WHERE car_id = ? AND operation = 'UPDATE'",
+            [$this->testCarId]
+        );
+
+        $this->assertSame(
+            1,
+            $histRows->count(),
+            'Expected exactly one UPDATE row in car_user_hist after car_user update'
+        );
+    }
+
+    /**
+     * Verifies the AFTER UPDATE trigger is bypassed when the session variable
+     * @disable_triggers is set, producing zero UPDATE rows in car_user_hist.
+     */
+    #[Group('fast')]
+    public function testUpdateTriggerBypassedWhenDisableTriggersSet(): void
+    {
+        $this->db->query("SET @disable_triggers = 1");
+        try {
+            $this->db->query(
+                "UPDATE car_user SET mtime = NOW() WHERE car_id = ?",
+                [$this->testCarId]
+            );
+        } finally {
+            $this->db->query("SET @disable_triggers = NULL");
+        }
+
+        $histRows = $this->db->query(
+            "SELECT * FROM car_user_hist WHERE car_id = ? AND operation = 'UPDATE'",
+            [$this->testCarId]
+        );
+
+        $this->assertSame(
+            0,
+            $histRows->count(),
+            'Expected zero UPDATE rows in car_user_hist when @disable_triggers is set'
+        );
+    }
+
+    /**
+     * Verifies the AFTER DELETE trigger fires and writes one DELETE row to
+     * car_user_hist when a car_user record is deleted.
+     */
+    #[Group('fast')]
+    public function testDeleteTriggerFiresOnCarUserDelete(): void
+    {
+        $this->db->query(
+            "DELETE FROM car_user WHERE car_id = ?",
+            [$this->testCarId]
+        );
+
+        $histRows = $this->db->query(
+            "SELECT * FROM car_user_hist WHERE car_id = ? AND operation = 'DELETE'",
+            [$this->testCarId]
+        );
+
+        $this->assertSame(
+            1,
+            $histRows->count(),
+            'Expected exactly one DELETE row in car_user_hist after car_user delete'
+        );
+    }
+
+    /**
+     * Verifies the INSERT trigger captures the correct car_id and userid.
+     * Each test gets its own car via uniqid() in setUp, so this hist row is
+     * unique to this test invocation regardless of execution order.
+     */
+    #[Group('fast')]
+    public function testCarUserHistColumnsMatchCarUser(): void
+    {
+        $histRow = $this->db->query(
+            "SELECT car_id, userid FROM car_user_hist WHERE car_id = ? AND operation = 'INSERT'",
+            [$this->testCarId]
+        )->first();
+
+        $this->assertNotEmpty($histRow, 'INSERT hist row must exist in car_user_hist');
+        $this->assertSame($this->testCarId, (int) $histRow->car_id, 'car_id in hist must match the test car');
+        $this->assertSame($this->testUserId, (int) $histRow->userid, 'userid in hist must match the test user');
+    }
+
+    /**
+     * Verifies that both covering indexes exist on car_user_hist, guarding
+     * against the fix script being skipped in a deployment environment.
+     */
+    #[Group('fast')]
+    public function testIndexesExistOnCarUserHist(): void
+    {
+        $carIdIndex = $this->db->query(
+            "SHOW INDEX FROM car_user_hist WHERE Key_name = 'idx_car_user_hist_car_id'"
+        );
+        $this->assertSame(
+            1,
+            $carIdIndex->count(),
+            'Index idx_car_user_hist_car_id must exist on car_user_hist'
+        );
+
+        $useridIndex = $this->db->query(
+            "SHOW INDEX FROM car_user_hist WHERE Key_name = 'idx_car_user_hist_userid'"
+        );
+        $this->assertSame(
+            1,
+            $useridIndex->count(),
+            'Index idx_car_user_hist_userid must exist on car_user_hist'
+        );
+    }
+}

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -79,6 +79,7 @@ abstract class IntegrationTestCase extends TestCase
                 try {
                     $this->db->query("DELETE FROM car_user WHERE car_id = ?", [$carId]);
                     $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
+                    $this->db->query("DELETE FROM car_user_hist WHERE car_id = ?", [$carId]);
                     $this->db->delete('cars', ['id', '=', $carId]);
                 } catch (RuntimeException $e) {
                     // Ignore cleanup errors


### PR DESCRIPTION
## Summary

- Adds AFTER INSERT, AFTER UPDATE, and AFTER DELETE triggers on `car_user` that write audit rows to `car_user_hist`, closing the database-level audit gap identified in ADR-003
- Adds covering indexes on `car_user_hist(car_id)` and `car_user_hist(userid)` for query performance
- Adds idempotent fix script `06-Add-Car-User-Hist-Triggers.php` for live deployment (DROP TRIGGER IF EXISTS + CREATE; SHOW INDEX existence check before ADD KEY)
- Adds 6 integration tests verifying all three trigger behaviors, the `@disable_triggers` bypass, column capture correctness, and index presence
- Updates ADR-003, DATABASE.md, and v2.25.0 release notes to reflect the resolved gap

## Trigger Design

INSERT and DELETE triggers are unconditional (matching existing `cars_insert`/`cars_delete` pattern). Only the UPDATE trigger implements the `@disable_triggers IS NULL` bypass for bulk administrative operations.

The UPDATE trigger captures `OLD.car_id` and `OLD.userid` (pre-change state), consistent with `cars_update` semantics.

## Required Actions After Deployment

Run fix script `06-Add-Car-User-Hist-Triggers.php` via the Maintenance tab in the admin panel.

## Test Plan

- [x] `CarUserHistTriggerTest` — 6 integration tests, all pass (requires triggers installed in target DB)
- [x] Tests skip gracefully when triggers are not yet installed (skip guard in `setUp`)
- [x] `composer check:php` — clean (PHPStan + phpcs)
- [x] 906 unit tests pass
- [x] `car_user_hist` trigger behavior verified against live DB (fix script run; DELETE audit rows confirmed for user 1)

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)