### PR TITLE
test: fix integration test car cleanup to prevent orphaned test records

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -47,6 +47,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 
 - **`Car::delete()` CSRF now mandatory** ([#930](https://github.com/unibrain1/elanregistry/issues/930)): Changed `Car::delete()` from an optional nullable token to a required `string $token`, consistent with `create()` and `update()`. Removes the opt-in bypass that could be silently exploited by future callers.
 - **Admin delete path routed through `Car::delete()`** ([#956](https://github.com/unibrain1/elanregistry/issues/956)): The admin car deletion handler in `manage-consolidated.php` previously issued raw SQL, bypassing the class-level CSRF guard added in #930. Refactored to call `Car::delete()`, which enforces CSRF validation, authentication, transaction wrapping, and audit logging. Defense-in-depth: page-level guards remain in place.
+- **Integration test car cleanup**: Added `IntegrationTestCase::trackCarId()` so tests that create cars via `Car::create()` directly (rather than through `createTestCar()`) can register the IDs for tearDown deletion. Fixed two methods in `CarDatabaseOperationsTest` (`testCarCreationPersistsToDatabases`, `testMarkSoldUpdatesDatabase`) that were leaving orphaned test cars assigned to the admin account after each test run.
 
 ## Issues Resolved
 

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -263,6 +263,19 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Register a car ID for cleanup in tearDown
+     *
+     * Call this when a test creates a car via Car::create() directly instead of
+     * through createTestCar(), so the car is cleaned up after the test.
+     *
+     * @param int $carId The car ID to track
+     */
+    protected function trackCarId(int $carId): void
+    {
+        $this->createdCarIds[] = $carId;
+    }
+
+    /**
      * Check if database is currently connected
      *
      * @return bool True if database connection is active

--- a/tests/integration/database/CarDatabaseOperationsTest.php
+++ b/tests/integration/database/CarDatabaseOperationsTest.php
@@ -87,6 +87,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
 
         $this->assertTrue($result);
         $createdId = $car->data()->id;
+        $this->trackCarId((int) $createdId);
 
         // Verify data was persisted
         $query = $this->db->query('SELECT * FROM cars WHERE id = ?', [$createdId]);
@@ -342,6 +343,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
         $car = new Car();
         $car->create($carData);
         $carId = $car->data()->id;
+        $this->trackCarId((int) $carId);
 
         // Mark as sold
         $soldDate = '2023-06-15';


### PR DESCRIPTION
## Summary

- Added `IntegrationTestCase::trackCarId()` so tests that create cars via `Car::create()` directly can register the resulting ID for `tearDown()` deletion
- Fixed `testCarCreationPersistsToDatabases()` and `testMarkSoldUpdatesDatabase()` in `CarDatabaseOperationsTest`, which were bypassing `createTestCar()` and leaving orphaned test cars assigned to the admin account after each run
- Updated v2.25.0 release notes with the change

## Test plan

- [ ] `composer test:medium` passes (20/20 integration tests, 906/906 unit tests)
- [ ] Confirm no new test cars appear on the admin account after running `composer test:medium`

🤖 Generated with [Claude Code](https://claude.com/claude-code)