### PR TITLE
security: add CSRF failure audit logging to 4 AJAX endpoints

### DIFF
--- a/app/action/location-reverse.php
+++ b/app/action/location-reverse.php
@@ -29,7 +29,9 @@ $userId = $user->isLoggedIn() ? (int)$user->data()->id : 0;
 
 // Verify CSRF token (required for all requests)
 if (!Token::check(Input::get('csrf'))) {
-    ApiResponse::forbidden('Invalid CSRF token')->send();
+    ApiResponse::forbidden('Invalid CSRF token')
+        ->withLogging($userId, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in location reverse')
+        ->send();
 }
 
 try {

--- a/app/action/location-search.php
+++ b/app/action/location-search.php
@@ -27,7 +27,9 @@ $userId = $user->isLoggedIn() ? (int)$user->data()->id : 0;
 
 // Verify CSRF token (required for all requests)
 if (!Token::check(Input::get('csrf'))) {
-    ApiResponse::forbidden('Invalid CSRF token')->send();
+    ApiResponse::forbidden('Invalid CSRF token')
+        ->withLogging($userId, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in location search')
+        ->send();
 }
 
 try {

--- a/app/cars/actions/get-models.php
+++ b/app/cars/actions/get-models.php
@@ -33,7 +33,9 @@ if (!Input::exists('post')) {
 // Validate CSRF token (required for all POST endpoints)
 $token = Input::get('csrf');
 if (!Token::check($token)) {
-    ApiResponse::forbidden('Invalid CSRF token')->send();
+    ApiResponse::forbidden('Invalid CSRF token')
+        ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in get-models')
+        ->send();
 }
 
 $action = Input::get('action');

--- a/app/cars/actions/validateChassis.php
+++ b/app/cars/actions/validateChassis.php
@@ -36,7 +36,9 @@ if (strtolower(Server::get('HTTP_X_REQUESTED_WITH', '')) !== 'xmlhttprequest') {
 
 // Check CSRF token for security
 if (!Token::check(Input::get('csrf'))) {
-    ApiResponse::forbidden('CSRF token validation failed')->send();
+    ApiResponse::forbidden('Invalid CSRF token')
+        ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in chassis validation')
+        ->send();
 }
 
 // Get validation parameters

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -42,6 +42,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 
 - **Owner Validation Error Messages** ([#927](https://github.com/unibrain1/elanregistry/issues/927)): Admin owner edit now shows the specific validation error (e.g. "Website URL must use http:// or https://") instead of a generic fallback when input is invalid.
 - **Timestamp Hour Padding** ([#947](https://github.com/unibrain1/elanregistry/issues/947)): Fixed `AppConstants::DATETIME_FORMAT` using `G` (no leading zero) instead of `H` (zero-padded) for the hour. Morning timestamps `0–9` now correctly produce `09:xx:xx` instead of `9:xx:xx`, ensuring consistent lexicographic sort order.
+- **CSRF Audit Logging Gap** ([#958](https://github.com/unibrain1/elanregistry/issues/958)): Four AJAX endpoints were returning HTTP 403 on CSRF failure with no security log entry. All four now log via `LOG_CATEGORY_SECURITY`, consistent with the rest of the codebase.
 
 ## Technical Changes
 
@@ -71,3 +72,4 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - [#956](https://github.com/unibrain1/elanregistry/issues/956) — refactor: migrate manage-consolidated.php delete path to Car::delete()
 - [#935](https://github.com/unibrain1/elanregistry/issues/935) — bug: CarVerificationManager::markSold() accepts overflow dates that PHP rolls forward silently
 - [#947](https://github.com/unibrain1/elanregistry/issues/947) — bug: AppConstants::DATETIME_FORMAT uses 'G' (no leading zero) instead of 'H'
+- [#958](https://github.com/unibrain1/elanregistry/issues/958) — security: add CSRF failure audit logging to 4 AJAX endpoints


### PR DESCRIPTION
## Summary

- Four AJAX endpoints were returning HTTP 403 on CSRF failure with no security log entry, creating a blind spot in the audit trail
- Added `->withLogging(LOG_CATEGORY_SECURITY, ...)` to all four, matching the pattern already used by every other AJAX endpoint (`getDataTables.php` and 8 admin endpoints)
- Also normalizes the user-facing 403 message in `validateChassis.php` from `'CSRF token validation failed'` to `'Invalid CSRF token'` to match the rest of the codebase

**Affected files:**
- `app/action/location-search.php`
- `app/action/location-reverse.php`
- `app/cars/actions/validateChassis.php`
- `app/cars/actions/get-models.php`

## Test plan

- [ ] Pre-commit hooks passed: phpcs (0 errors), PHPStan (0 errors), 906 unit tests green
- [ ] Multi-agent `/review-pr` passed: code-reviewer (clean), silent-failure-hunter (clean — `$user->data()->id ?? 0` safety on unauthenticated requests verified), code-simplifier (messages aligned to project-wide short pattern)
- [ ] No logic changes — response format, HTTP status, and behavior are unchanged

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)