### PR TITLE
security: add car ownership check to updateCar action in edit.php

### DIFF
--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -109,8 +109,20 @@ if (!empty($_POST)) {
                 break;
 
             case "updateCar":
+                $car_id = (int)Input::get('car_id');
+                if ($car_id <= 0) {
+                    ApiResponse::error('Invalid car ID', 400)
+                        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'updateCar: invalid car_id in request')
+                        ->send();
+                }
+                $carForAuth = new Car($car_id);
+                if (!$carForAuth->data() || ($user->data()->id != $carForAuth->data()->user_id && !hasPerm([2, 3]))) {
+                    ApiResponse::error('Unauthorized', 403)
+                        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'updateCar: unauthorized for car ' . $car_id)
+                        ->send();
+                }
                 try {
-                    buildCarDetails($cardetails, (int)Input::get('car_id'));
+                    buildCarDetails($cardetails, $car_id);
                     buildImageDetails($cardetails);
 
                     if (!empty($errors)) {

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -43,6 +43,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - **Owner Validation Error Messages** ([#927](https://github.com/unibrain1/elanregistry/issues/927)): Admin owner edit now shows the specific validation error (e.g. "Website URL must use http:// or https://") instead of a generic fallback when input is invalid.
 - **Timestamp Hour Padding** ([#947](https://github.com/unibrain1/elanregistry/issues/947)): Fixed `AppConstants::DATETIME_FORMAT` using `G` (no leading zero) instead of `H` (zero-padded) for the hour. Morning timestamps `0–9` now correctly produce `09:xx:xx` instead of `9:xx:xx`, ensuring consistent lexicographic sort order.
 - **CSRF Audit Logging Gap** ([#958](https://github.com/unibrain1/elanregistry/issues/958)): Four AJAX endpoints were returning HTTP 403 on CSRF failure with no security log entry. All four now log via `LOG_CATEGORY_SECURITY`, consistent with the rest of the codebase.
+- **Car Update Ownership Check** ([#970](https://github.com/unibrain1/elanregistry/issues/970)): Any authenticated user could update another owner's car record by POSTing a `car_id` they don't own to the `updateCar` endpoint. Added ownership guard matching the existing `fetchImages`/`removeImages` pattern — non-owners receive HTTP 403; admins (group 2/3) are unaffected.
 
 ## Technical Changes
 
@@ -73,3 +74,4 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - [#935](https://github.com/unibrain1/elanregistry/issues/935) — bug: CarVerificationManager::markSold() accepts overflow dates that PHP rolls forward silently
 - [#947](https://github.com/unibrain1/elanregistry/issues/947) — bug: AppConstants::DATETIME_FORMAT uses 'G' (no leading zero) instead of 'H'
 - [#958](https://github.com/unibrain1/elanregistry/issues/958) — security: add CSRF failure audit logging to 4 AJAX endpoints
+- [#970](https://github.com/unibrain1/elanregistry/issues/970) — security: add car ownership check to updateCar action in edit.php

--- a/tests/playwright/security/car-update-ownership.spec.ts
+++ b/tests/playwright/security/car-update-ownership.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ensureLoggedIn } = require('../auth-helper.js');
+
+/**
+ * Regression guard for the ownership check on the updateCar AJAX endpoint.
+ *
+ * Before #970, any authenticated user could update any car by POSTing a
+ * `car_id` they don't own to `app/cars/actions/edit.php?action=updateCar`.
+ * The guard added in #970 mirrors the existing fetchImages/removeImages pattern:
+ * a non-owner receives HTTP 403 JSON; admins (group 2/3) are unaffected.
+ *
+ * @group security
+ * @group ownership
+ */
+
+const ACTIONS_ENDPOINT = 'app/cars/actions/edit.php';
+const FORM_PAGE = 'app/cars/form.php';
+const NONEXISTENT_CAR_ID = 999999;
+
+async function getCsrfFromForm(page: import('@playwright/test').Page): Promise<string | null> {
+  await page.goto(FORM_PAGE, { waitUntil: 'domcontentloaded' });
+  try {
+    const token = await page.inputValue('#csrf', { timeout: 3000 });
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+test.describe('Car Update Endpoint — Ownership Guard', () => {
+  test.describe('authenticated user, non-existent car', () => {
+    let csrf: string;
+
+    test.beforeEach(async ({ page }) => {
+      await ensureLoggedIn(page);
+      const token = await getCsrfFromForm(page);
+      expect(token, 'CSRF token must be present on the form page after login').toBeTruthy();
+      csrf = token as string;
+    });
+
+    test('updateCar: returns 403 JSON for non-existent car_id', async ({ page }) => {
+      const response = await page.request.post(ACTIONS_ENDPOINT, {
+        form: { action: 'updateCar', car_id: String(NONEXISTENT_CAR_ID), csrf },
+      });
+      expect(response.status()).toBe(403);
+      expect(await response.json()).toMatchObject({ success: false });
+    });
+  });
+
+  // No CSRF token → token_error.php returns HTML (HTTP 200), not a success JSON envelope.
+  test('updateCar: request without CSRF is rejected', async ({ page }) => {
+    const response = await page.request.post(ACTIONS_ENDPOINT, {
+      form: { action: 'updateCar', car_id: String(NONEXISTENT_CAR_ID), csrf: '' },
+    });
+    const text = await response.text();
+    expect(text.length, 'Response body must not be empty').toBeGreaterThan(0);
+    let body: unknown = null;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      // HTML response from token_error.php — acceptable.
+    }
+    if (body && typeof body === 'object' && 'success' in body) {
+      expect((body as { success: unknown }).success).not.toBe(true);
+    } else {
+      expect(text).not.toMatch(/"success"\s*:\s*true/);
+    }
+  });
+
+  /**
+   * TODO: Cross-user ownership test — a logged-in user must not be able to
+   * update a car belonging to another (non-admin) user.
+   * Requires TEST_USERNAME_SECONDARY + TEST_OTHER_USER_CAR_ID fixtures in .env.local.
+   */
+  test.fixme("cross-user: non-owner cannot update another user's car", async () => {
+    // Pending: add fixture env vars, then assert 403 JSON for car_id owned by a different user.
+  });
+});


### PR DESCRIPTION
## Summary

- Any authenticated user could update another owner's car by POSTing a `car_id` they don't own to `app/cars/actions/edit.php?action=updateCar` — neither the endpoint nor `Car::update()` verified ownership
- Added ownership guard at the top of the `updateCar` case, mirroring the identical pattern used by `fetchImages` and `removeImages` in the same file
- Invalid/missing `car_id` → 400 (fast-fail before DB lookup, logged under `VALIDATION_ERROR`)
- Non-owner with valid `car_id` → 403 (logged under `ACCESS_DENIED`)
- Admin/editor (perm 2/3) unaffected

## Bug Escape Analysis

**Root cause:** The `fetchImages` and `removeImages` cases had an ownership guard; `updateCar` was added without one, leaving a gap in the access-control pattern.

**Testing gap:** No integration test or Playwright spec covered cross-user update attempts. The ownership guard for image actions had a `test.fixme` placeholder but no live cross-user test.

**Preventive measure:** Added `tests/playwright/security/car-update-ownership.spec.ts` with 403 regression tests for non-existent car ID and missing CSRF. Cross-user test is marked `test.fixme` pending secondary-user fixtures (same pattern as the existing image-ownership spec).

## Decision notes

Per architect and security review:
- Guard placed in the `case` block (not inside `buildCarDetails()`) — `buildCarDetails()` is shared with `addCar` where no car_id exists; keeps auth out of the data-assembly helper
- Direct `ApiResponse::error(403)` used (not `CarPermissionException`) — the existing `catch (ElanRegistryException)` block maps all exceptions to `serverError()` (HTTP 500), so throwing would produce the wrong status
- `LOG_CATEGORY_ACCESS_DENIED` used (more precise than `LOG_CATEGORY_VALIDATION_ERROR` used in the pre-existing image-action guards)

## Test plan

- [x] 906 unit tests pass
- [x] Pre-commit hooks pass (phpcs, PHPStan, unit tests)
- [x] Security review: 0 critical, 0 high findings
- [ ] Playwright security spec (`npm run playwright:security`) — requires local MAMP at localhost:9999

Closes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)