### PR TITLE
security: fix sender impersonation in owner-to-owner contact email (#971)

### DIFF
--- a/app/contact/owner.php
+++ b/app/contact/owner.php
@@ -25,10 +25,17 @@ if (!empty($_POST)) {
         $action = Input::get('action');
         if ($action === 'contact_owner') {
 
-            $carID = Input::get('car_id');
-            // Get the user data from users table  
-            $fromData = $db->findById($user->data()->id, "users")->results()[0];
-            $toData = $db->findById($carID, "cars")->results()[0];
+            $carID = (int) Input::get('car_id');
+            if ($carID <= 0) {
+                Redirect::to('/');
+            }
+            $fromResults = $db->findById($user->data()->id, "users")->results();
+            $toResults   = $db->findById($carID, "cars")->results();
+            if (empty($fromResults) || empty($toResults)) {
+                Redirect::to('/');
+            }
+            $fromData = $fromResults[0];
+            $toData   = $toResults[0];
 
             $from = array(
                 'id'    => $fromData->id,
@@ -66,7 +73,7 @@ if (!empty($_POST)) {
                         <h5 class="text-primary"><i class="fas fa-user-circle"></i> From</h5>
                         <div class="bg-light p-3 rounded">
                             <div class="mb-2">
-                                <strong><?= $from['fname'] . ' ' . $from['lname'] ?></strong>
+                                <strong><?= htmlspecialchars($from['fname'] . ' ' . $from['lname'], ENT_QUOTES, 'UTF-8') ?></strong>
                             </div>
                         </div>
                     </div>
@@ -74,7 +81,7 @@ if (!empty($_POST)) {
                         <h5 class="text-primary"><i class="fas fa-user"></i> To</h5>
                         <div class="bg-light p-3 rounded">
                             <div class="mb-2">
-                                <strong><?= $to['fname'] . ' ' . $to['lname'] ?></strong>
+                                <strong><?= htmlspecialchars($to['fname'] . ' ' . $to['lname'], ENT_QUOTES, 'UTF-8') ?></strong>
                             </div>
                         </div>
                     </div>
@@ -107,7 +114,6 @@ if (!empty($_POST)) {
                     <!-- Hidden Fields -->
                     <input type='hidden' name='csrf' value='<?= Token::generate(); ?>' />
                     <input type='hidden' name='action' value='send_message' />
-                    <input type='hidden' name='from_user_id' value='<?= htmlspecialchars($from['id'], ENT_QUOTES, 'UTF-8'); ?>' />
                     <input type='hidden' name='to_user_id' value='<?= htmlspecialchars($to['id'], ENT_QUOTES, 'UTF-8'); ?>' />
                     <input type='hidden' name='car_id' value='<?= htmlspecialchars($carID, ENT_QUOTES, 'UTF-8'); ?>' />
 

--- a/app/contact/send-owner-email.php
+++ b/app/contact/send-owner-email.php
@@ -35,17 +35,15 @@ if (Input::exists('post')) {
     } else {
         $action = Input::get('action');
         $message = Input::raw('message'); // raw — _email_contact_owner.php escapes via EmailTemplate
-        if ($action === 'send_message' && Input::get('from_user_id') && Input::get('to_user_id') && $message !== null && $message !== '') {
+        if ($action === 'send_message' && Input::get('to_user_id') && $message !== null && $message !== '') {
             if (strlen($message) > 2000) {
                 $errors[] = 'Message is too long (maximum 2000 characters)';
                 include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
                 exit();
             }
 
-
-            // Security: Get user data from database instead of trusting serialized data
-            $fromUserId = (int) Input::get('from_user_id');
-            $toUserId = (int) Input::get('to_user_id');
+            $fromUserId = (int) $user->data()->id;
+            $toUserId   = (int) Input::get('to_user_id');
             
             // Validate user IDs and get user data from database
             $db = DB::getInstance();
@@ -63,10 +61,10 @@ if (Input::exists('post')) {
             $fromEmail = $fromUser->email;
             $fromName  = $fromUser->fname . ' ' . $fromUser->lname;
 
-            $template       =  array(
-                'message'   => $message,
-                'from'      => $fromName,
-                'to'        => $toName
+            $template = array(
+                'message' => $message,
+                'from'    => $fromName,
+                'to'      => $toName,
             );
 
             $body = email_body('_email_contact_owner.php', $template);

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -44,6 +44,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - **Timestamp Hour Padding** ([#947](https://github.com/unibrain1/elanregistry/issues/947)): Fixed `AppConstants::DATETIME_FORMAT` using `G` (no leading zero) instead of `H` (zero-padded) for the hour. Morning timestamps `0–9` now correctly produce `09:xx:xx` instead of `9:xx:xx`, ensuring consistent lexicographic sort order.
 - **CSRF Audit Logging Gap** ([#958](https://github.com/unibrain1/elanregistry/issues/958)): Four AJAX endpoints were returning HTTP 403 on CSRF failure with no security log entry. All four now log via `LOG_CATEGORY_SECURITY`, consistent with the rest of the codebase.
 - **Car Update Ownership Check** ([#970](https://github.com/unibrain1/elanregistry/issues/970)): Any authenticated user could update another owner's car record by POSTing a `car_id` they don't own to the `updateCar` endpoint. Added ownership guard matching the existing `fetchImages`/`removeImages` pattern — non-owners receive HTTP 403; admins (group 2/3) are unaffected.
+- **Owner Contact Sender Impersonation** ([#971](https://github.com/unibrain1/elanregistry/issues/971)): Any authenticated user could send a contact email appearing to come from another registered owner by supplying a different `from_user_id` in the POST body. Sender identity is now always derived from the authenticated session — the `from_user_id` POST parameter is ignored and the hidden form field has been removed.
 
 ## Technical Changes
 
@@ -75,3 +76,4 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 - [#947](https://github.com/unibrain1/elanregistry/issues/947) — bug: AppConstants::DATETIME_FORMAT uses 'G' (no leading zero) instead of 'H'
 - [#958](https://github.com/unibrain1/elanregistry/issues/958) — security: add CSRF failure audit logging to 4 AJAX endpoints
 - [#970](https://github.com/unibrain1/elanregistry/issues/970) — security: add car ownership check to updateCar action in edit.php
+- [#971](https://github.com/unibrain1/elanregistry/issues/971) — security: fix sender impersonation in owner-to-owner contact email

--- a/tests/unit/security/SerializedDataRemovalTest.php
+++ b/tests/unit/security/SerializedDataRemovalTest.php
@@ -12,17 +12,17 @@ use PHPUnit\Framework\TestCase;
  */
 class SerializedDataRemovalTest extends TestCase
 {
-    private $projectRoot;
+    private string $projectRoot;
     
     protected function setUp(): void
     {
         $this->projectRoot = dirname(dirname(dirname(__DIR__)));
     }
-    
+
     /**
      * Test that no serialize() function calls exist in PHP files
      */
-    public function testNoSerializeFunctionCalls()
+    public function testNoSerializeFunctionCalls(): void
     {
         $phpFiles = $this->getPHPFiles();
         $violationFiles = [];
@@ -44,7 +44,7 @@ class SerializedDataRemovalTest extends TestCase
     /**
      * Test that no unserialize() function calls exist in PHP files
      */
-    public function testNoUnserializeFunctionCalls()
+    public function testNoUnserializeFunctionCalls(): void
     {
         $phpFiles = $this->getPHPFiles();
         $violationFiles = [];
@@ -63,19 +63,27 @@ class SerializedDataRemovalTest extends TestCase
     }
     
     /**
-     * Test that contact_owner.php uses secure individual fields instead of serialized data
+     * Test that contact_owner.php uses secure individual fields instead of serialized data.
+     * The sender (from_user_id) is now derived from the session server-side and must NOT
+     * appear as a client-controlled hidden field (#971).
      */
-    public function testContactOwnerUsesSecureFields()
+    public function testContactOwnerUsesSecureFields(): void
     {
         $contactOwnerFile = $this->projectRoot . '/app/contact/owner.php';
         $this->assertFileExists($contactOwnerFile);
-        
+
         $content = file_get_contents($contactOwnerFile);
-        
-        // Should contain the secure individual field approach
-        $this->assertStringContainsString('from_user_id', $content, 'contact_owner.php should use from_user_id field');
-        $this->assertStringContainsString('to_user_id', $content, 'contact_owner.php should use to_user_id field');
-        
+
+        // Recipient field must still be present (server cannot know the target without it)
+        $this->assertStringContainsString('to_user_id', $content, 'contact_owner.php should pass to_user_id field');
+
+        // from_user_id must NOT appear as a form field — sender is session-derived (#971)
+        $this->assertDoesNotMatchRegularExpression(
+            '/name=[\'"]from_user_id[\'"]/',
+            $content,
+            'contact_owner.php must not expose from_user_id as a tamperable form field'
+        );
+
         // Should not contain any serialize calls
         $this->assertStringNotContainsString('serialize(', $content, 'contact_owner.php should not contain serialize() calls');
     }
@@ -83,7 +91,7 @@ class SerializedDataRemovalTest extends TestCase
     /**
      * Test that send-owner-email.php uses secure database lookups
      */
-    public function testContactOwnerEmailUsesSecureLookups()
+    public function testContactOwnerEmailUsesSecureLookups(): void
     {
         $contactEmailFile = $this->projectRoot . '/app/contact/send-owner-email.php';
         $this->assertFileExists($contactEmailFile);
@@ -93,22 +101,27 @@ class SerializedDataRemovalTest extends TestCase
         // Should use secure database lookup pattern
         $this->assertStringContainsString('SELECT id, email, fname, lname FROM users WHERE id = ?', $content,
             'send-owner-email.php should use secure database lookups');
-        
+
+        // Sender must be derived from session, not from POST (#971)
+        $this->assertStringNotContainsString("Input::get('from_user_id')", $content,
+            'send-owner-email.php must not accept from_user_id from POST (#971)');
+        $this->assertStringContainsString('$user->data()->id', $content,
+            'send-owner-email.php must derive sender identity from session');
+
         // Should not contain unserialize calls
         $this->assertStringNotContainsString('unserialize(', $content, 'send-owner-email.php should not contain unserialize() calls');
     }
     
     /**
-     * Test that HTML encoding is used for user ID fields
+     * Test that HTML encoding is used for the to_user_id field.
+     * The from_user_id field was removed (#971) — sender is now session-derived, so
+     * there is no client-supplied from field to encode.
      */
-    public function testUserIdFieldsAreHTMLEncoded()
+    public function testUserIdFieldsAreHTMLEncoded(): void
     {
         $contactOwnerFile = $this->projectRoot . '/app/contact/owner.php';
         $content = file_get_contents($contactOwnerFile);
-        
-        // Should use htmlspecialchars for security
-        $this->assertStringContainsString('htmlspecialchars($from[\'id\'], ENT_QUOTES, \'UTF-8\')', $content,
-            'from_user_id field should be HTML encoded');
+
         $this->assertStringContainsString('htmlspecialchars($to[\'id\'], ENT_QUOTES, \'UTF-8\')', $content,
             'to_user_id field should be HTML encoded');
     }
@@ -116,7 +129,7 @@ class SerializedDataRemovalTest extends TestCase
     /**
      * Test that CSRF protection is maintained
      */
-    public function testCSRFProtectionMaintained()
+    public function testCSRFProtectionMaintained(): void
     {
         $contactOwnerFile = $this->projectRoot . '/app/contact/owner.php';
         $content = file_get_contents($contactOwnerFile);


### PR DESCRIPTION
## Summary

Fixes sender impersonation vulnerability in the owner-to-owner contact email endpoint.

- **Root cause:** `send-owner-email.php` accepted `from_user_id` as a POST parameter and used it directly to look up sender identity, with no check that it matched the authenticated session user. Any logged-in user could impersonate another owner by supplying a different `from_user_id` in the POST body.
- **Fix:** Derive `$fromUserId` from `$user->data()->id` (session) — the POST parameter is completely ignored. Remove the `from_user_id` hidden form field from `owner.php` so the attack surface no longer exists on the wire.

## Changes

- `app/contact/send-owner-email.php` — replace `Input::get('from_user_id')` with `$user->data()->id`; remove parameter from action-guard condition
- `app/contact/owner.php` — remove `from_user_id` hidden field; fix XSS (escape name output); add `(int)` cast and null guards for `car_id` / `findById` results (HIGH and MEDIUM findings from security review)
- `tests/unit/security/SerializedDataRemovalTest.php` — update assertions: field must NOT exist; add session-sender invariant tests; PHP 8 type hints + void returns (simplifier pass)
- `docs/releases/RELEASE_NOTES_v2.25.0.md` — add #971 entry

## Bug Escape Analysis

- **Root cause:** The endpoint was written to accept `from_user_id` from POST, treating it as a lookup key rather than a security boundary. No ownership check was ever added.
- **Testing gap:** `SerializedDataRemovalTest` verified the field *existed* (good for the deserialization fix it was written for), but never verified the endpoint *ignored* a tampered value. No integration or Playwright test covered the contact endpoint authentication path.
- **Preventive:** Added `assertStringNotContainsString("Input::get('from_user_id')")` and `assertStringContainsString('$user->data()->id')` to lock in the session-derived invariant. A cross-user Playwright test is infeasible without a real SMTP inspector (no observable `From:` header in test output).

## Pre-existing gap filed separately

[#1014](https://github.com/unibrain1/elanregistry/issues/1014) — `to_user_id` ownership verification: a crafted POST can still route a contact email to any registered user, not just car owners. Filed as a follow-on issue; out of scope for this PR.

## Test plan

- [x] `composer test:quick` — 906 tests, 4001 assertions, all pass
- [x] Pre-commit hooks: phpcs (0 errors), PHPStan (no errors), unit tests

Closes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)