### PR TITLE
fix: persist chassis_override to DB column, fix JS unchecking bug, add UI badge (#915)

### DIFF
--- a/app/admin/scripts/fix/07-Chassis-Override-Schema-Backfill.php
+++ b/app/admin/scripts/fix/07-Chassis-Override-Schema-Backfill.php
@@ -1,0 +1,385 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * 07-Chassis-Override-Schema-Backfill.php
+ * Add the chassis_override column to cars and cars_hist, refresh the cars
+ * insert/update triggers to carry it, and backfill the flag on existing cars.
+ * Issue #915: Chassis override flag persistence
+ *
+ * The chassis_override flag was previously never persisted. This script adds
+ * the column to both cars and cars_hist, recreates all three cars_* triggers
+ * (insert, update, delete) so audit rows include the column, and backfills
+ * chassis_override = 1 on cars whose comments contain the legacy audit phrase
+ * "CHASSIS VALIDATION OVERRIDDEN", or whose chassis is currently invalid AND
+ * were modified on or after the override feature ship date (2025-08-31).
+ *
+ * Safe to re-run: column additions are skipped if columns already exist,
+ * triggers are unconditionally recreated (non-destructive), and the backfill
+ * skips cars already marked chassis_override = 1.
+ *
+ * DEPLOYMENT:
+ * 1. Run on dev/staging before production.
+ * 2. Back up the database before running on production.
+ * 3. Run via the Maintenance tab in the admin panel.
+ * 4. Completion is auto-logged to fix_script_runs.
+ */
+
+// UI Constants for progress output
+define('SECTION_SEPARATOR', '═══════════════════════════════════════════════════════');
+
+require_once '../../../../users/init.php';
+require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
+
+if (!securePage($php_self)) {
+    die();
+}
+
+// Set up custom error handler to log through UserSpice logger
+set_error_handler(function($errno, $errstr, $errfile, $errline) {
+    if ($errno !== E_DEPRECATED) {
+        logger(isset($user) ? $user->data()->id : 0, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "Error [$errno]: $errstr in $errfile:$errline");
+    }
+    return true;
+});
+
+$db = DB::getInstance();
+
+?>
+
+<div id="page-wrapper">
+    <div class="container-fluid">
+        <div class="well">
+
+            <?php if (!isset($_GET['start'])): ?>
+            <!-- Initial Description -->
+            <div class="row">
+                <div class="col-lg-12 mb-4">
+                    <div class="card registry-card">
+                        <div class="card-header">
+                            <h2 class="mb-0">
+                                <i class="fa fa-wrench"></i> Chassis Override Schema and Backfill
+                            </h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="mb-3">Adds the <code>chassis_override</code> column to the car tables, refreshes the audit triggers to carry it, and backfills the flag on qualifying existing cars (Issue #915).</p>
+
+                            <div class="alert alert-info">
+                                <h5><i class="fa fa-info-circle"></i> What this script does:</h5>
+                                <ul class="mb-0">
+                                    <li>Adds <code>chassis_override TINYINT(1) NOT NULL DEFAULT 0</code> to <code>cars_hist</code> (if not exists)</li>
+                                    <li>Adds <code>chassis_override TINYINT(1) NOT NULL DEFAULT 0</code> to <code>cars</code> (if not exists)</li>
+                                    <li>Drops and recreates the <code>cars_insert</code> and <code>cars_update</code> triggers with the new column</li>
+                                    <li>Backfills <code>chassis_override = 1</code> on qualifying existing cars: those whose comments contain "CHASSIS VALIDATION OVERRIDDEN", or whose chassis is currently invalid AND were modified on/after 2025-08-31</li>
+                                </ul>
+                            </div>
+
+                            <div class="alert alert-warning">
+                                <h5><i class="fa fa-exclamation-triangle"></i> Important Notes:</h5>
+                                <ul class="mb-0">
+                                    <li>This changes schema objects on live data — run on dev first</li>
+                                    <li>Safe to re-run — column additions skipped if already present, triggers unconditionally recreated (non-destructive), backfill skips already-set rows</li>
+                                    <li>Back up the database before running on production</li>
+                                </ul>
+                            </div>
+
+                            <div class="text-center">
+                                <a href="?start=1" class="btn btn-success btn-lg">
+                                    <i class="fa fa-play"></i> Continue - Start Schema and Backfill
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <?php else:
+                // Processing mode - simple text output
+                ob_end_clean(); // Clear template buffering
+                header('Content-Type: text/html; charset=utf-8');
+                echo str_repeat(' ', 1024); // Pad to force initial flush
+                flush();
+            ?>
+
+            <div class="card registry-card">
+                <div class="card-header">
+                    <h2 class="mb-0">
+                        <i class="fa fa-cogs"></i> Applying Chassis Override Schema and Backfill
+                    </h2>
+                    <small class="text-muted">
+                        <i class="fa fa-clock-o"></i> Started: <?php echo date('Y-m-d H:i:s'); ?>
+                    </small>
+                </div>
+                <div class="card-body">
+                    <pre style="background: #f5f5f5; padding: 15px; border-radius: 4px; max-height: 600px; overflow-y: auto; font-family: 'Courier New', monospace; font-size: 13px;"><?php
+
+                    /**
+                     * Helper function for progress output
+                     *
+                     * @param string $message Message to display
+                     * @param string $type Type of message: 'info', 'success', 'error', 'warning', 'step'
+                     */
+                    function logProgress(string $message, string $type = 'info'): void {
+                        $icons = [
+                            'info' => 'ℹ️',
+                            'success' => '✅',
+                            'error' => '❌',
+                            'warning' => '⚠️',
+                            'step' => '▶️'
+                        ];
+                        $icon = $icons[$type] ?? '•';
+                        echo date('[H:i:s] ') . $icon . ' ' . $message . "\n";
+                        flush();
+                    }
+
+                    // Initialize results tracking
+                    $results = [
+                        'processed' => 0,
+                        'errors' => 0,
+                        'warnings' => 0
+                    ];
+
+                    try {
+                        // STEP 1: ADD chassis_override TO cars_hist
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 1: ADD chassis_override TO cars_hist', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $col = $db->query("SHOW COLUMNS FROM cars_hist LIKE 'chassis_override'")->first();
+                        if (!$col) {
+                            $db->query("ALTER TABLE cars_hist ADD COLUMN chassis_override TINYINT(1) NOT NULL DEFAULT 0 AFTER chassis");
+                            logProgress('Added chassis_override column to cars_hist', 'success');
+                        } else {
+                            logProgress('cars_hist.chassis_override already exists — skipped', 'warning');
+                            $results['warnings']++;
+                        }
+
+                        // STEP 2: ADD chassis_override TO cars
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 2: ADD chassis_override TO cars', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $col = $db->query("SHOW COLUMNS FROM cars LIKE 'chassis_override'")->first();
+                        if (!$col) {
+                            $db->query("ALTER TABLE cars ADD COLUMN chassis_override TINYINT(1) NOT NULL DEFAULT 0 AFTER chassis");
+                            logProgress('Added chassis_override column to cars', 'success');
+                        } else {
+                            logProgress('cars.chassis_override already exists — skipped', 'warning');
+                            $results['warnings']++;
+                        }
+
+                        // STEP 3: RECREATE cars_insert TRIGGER
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 3: RECREATE cars_insert TRIGGER', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $db->query("DROP TRIGGER IF EXISTS cars_insert");
+                        $db->query("CREATE TRIGGER cars_insert AFTER INSERT ON cars FOR EACH ROW BEGIN
+    INSERT INTO cars_hist(
+        operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+        year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+        image, user_id, email, fname, lname, join_date, city, state, country,
+        lat, lon, website
+    )
+    VALUES (
+        'INSERT', NEW.id, NEW.ctime, NEW.mtime, NEW.ModifiedBy, NEW.model,
+        NEW.series, NEW.variant, NEW.year, NEW.type, NEW.chassis, NEW.chassis_override,
+        NEW.color, NEW.engine, NEW.purchasedate, NEW.solddate, NEW.comments, NEW.image,
+        NEW.user_id, NEW.email, NEW.fname, NEW.lname, NEW.join_date, NEW.city,
+        NEW.state, NEW.country, NEW.lat, NEW.lon, NEW.website
+    );
+END");
+                        logProgress('Recreated cars_insert trigger', 'success');
+
+                        // STEP 4: RECREATE cars_update TRIGGER
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 4: RECREATE cars_update TRIGGER', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $db->query("DROP TRIGGER IF EXISTS cars_update");
+                        $db->query("CREATE TRIGGER cars_update AFTER UPDATE ON cars FOR EACH ROW BEGIN
+    IF @disable_triggers IS NULL THEN
+        INSERT INTO cars_hist(
+            operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+            year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+            image, user_id, email, fname, lname, join_date, city, state, country,
+            lat, lon, website
+        )
+        VALUES (
+            'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
+            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.chassis_override,
+            OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+            OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
+            OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
+        );
+    END IF;
+END");
+                        logProgress('Recreated cars_update trigger', 'success');
+
+                        // STEP 5: RECREATE cars_delete TRIGGER
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 5: RECREATE cars_delete TRIGGER', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $db->query("DROP TRIGGER IF EXISTS cars_delete");
+                        $db->query("CREATE TRIGGER cars_delete AFTER DELETE ON cars FOR EACH ROW BEGIN
+    INSERT INTO cars_hist(
+        operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+        year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+        image, user_id, email, fname, lname, join_date, city, state, country,
+        lat, lon, website
+    )
+    VALUES (
+        'DELETE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
+        OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.chassis_override,
+        OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+        OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
+        OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
+    );
+END");
+                        logProgress('Recreated cars_delete trigger', 'success');
+
+                        // STEP 6: BACKFILL chassis_override ON QUALIFYING CARS
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 6: BACKFILL chassis_override ON QUALIFYING CARS', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        require_once $abs_us_root . $us_url_root . 'usersc/classes/ChassisValidator.php';
+                        $chassisValidator = new ChassisValidator();
+
+                        // Suppress trigger during backfill (avoid duplicate history rows)
+                        $db->query("SET @disable_triggers = 1");
+                        $qualifying = $db->query(
+                            "SELECT id, chassis, year, series, variant, type, ctime, mtime,
+                                    GREATEST(ctime, mtime) AS last_modified,
+                                    comments
+                             FROM cars
+                             WHERE chassis_override = 0
+                               AND (GREATEST(ctime, mtime) >= '2025-08-31'
+                                    OR comments LIKE '%CHASSIS VALIDATION OVERRIDDEN%')"
+                        )->results();
+                        foreach ($qualifying as $car) {
+                            $matchesDate    = strtotime((string) $car->last_modified) >= strtotime('2025-08-31');
+                            $matchesComment = str_contains((string) $car->comments, 'CHASSIS VALIDATION OVERRIDDEN');
+
+                            $reasons = [];
+
+                            if ($matchesComment) {
+                                $reasons[] = 'COMMENT';
+                            }
+
+                            if ($matchesDate) {
+                                $model = $car->series . '|' . $car->variant . '|' . $car->type;
+                                try {
+                                    $validation = $chassisValidator->validate((string) $car->chassis, (int) $car->year, $model);
+                                } catch (\Throwable $e) {
+                                    $errMsg = 'ChassisValidator threw for car ID ' . $car->id . ' (chassis "' . $car->chassis . '"): ' . $e->getMessage();
+                                    logProgress($errMsg, 'error');
+                                    logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT_ERROR, $errMsg);
+                                    $results['errors']++;
+                                    continue;
+                                }
+                                if (!$validation['valid']) {
+                                    $reasons[] = 'After Date AND invalid chassis (' . $car->last_modified . ')';
+                                }
+                            }
+
+                            if (empty($reasons)) {
+                                continue;
+                            }
+
+                            if (!$matchesComment) {
+                                $auditPhrase = 'CHASSIS VALIDATION OVERRIDDEN: ' . date('Y-m-d H:i:s') . ' - Admin override used for chassis validation.';
+                                $updatedComments = trim((string) $car->comments . "\n" . $auditPhrase);
+                                $db->query("UPDATE cars SET chassis_override = 1, comments = ? WHERE id = ?", [$updatedComments, $car->id]);
+                            } else {
+                                $db->query("UPDATE cars SET chassis_override = 1 WHERE id = ?", [$car->id]);
+                            }
+
+                            if ($db->error()) {
+                                $errMsg = 'UPDATE failed for car ID ' . $car->id . ': ' . $db->errorString();
+                                logProgress($errMsg, 'error');
+                                logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT_ERROR, $errMsg);
+                                $results['errors']++;
+                                continue;
+                            }
+
+                            logProgress(
+                                'Set chassis_override=1 for car ID ' . $car->id
+                                    . ' (chassis: ' . htmlspecialchars((string) $car->chassis, ENT_QUOTES, 'UTF-8') . ')'
+                                    . ' — reason: ' . htmlspecialchars(implode('; ', $reasons), ENT_QUOTES, 'UTF-8'),
+                                'info'
+                            );
+                            $results['processed']++;
+                        }
+                        $db->query("SET @disable_triggers = NULL"); // Re-enable triggers before any subsequent writes
+                        if ($results['errors'] > 0) {
+                            logProgress('Backfill finished with errors: ' . $results['processed'] . ' updated, ' . $results['errors'] . ' failed — check logs', 'warning');
+                        } else {
+                            logProgress('Backfill complete: ' . $results['processed'] . ' car(s) updated', 'success');
+                        }
+
+                        // STEP 7: LOG AND COMPLETE
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 7: RECORD COMPLETION', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $inserted = $db->insert('fix_script_runs', [
+                            'script_name' => '07-Chassis-Override-Schema-Backfill.php',
+                            'completed_at' => date('Y-m-d H:i:s')
+                        ]);
+                        if (!$inserted) {
+                            logProgress('Warning: could not record completion in fix_script_runs — ' . $db->errorString(), 'warning');
+                            $results['warnings']++;
+                        }
+
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT,
+                            "07-Chassis-Override-Schema-Backfill completed — Processed: {$results['processed']}, Errors: {$results['errors']}, Warnings: {$results['warnings']}");
+
+                        // Display summary
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('Chassis override schema and backfill complete.', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress("Cars Backfilled: {$results['processed']}", 'success');
+                        if ($results['warnings'] > 0) {
+                            logProgress("Warnings: {$results['warnings']}", 'warning');
+                        }
+                        if ($results['errors'] > 0) {
+                            logProgress("Errors: {$results['errors']}", 'error');
+                        }
+
+                    } catch (\Throwable $e) {
+                        // Ensure trigger suppression is cleared if backfill aborted mid-run
+                        $db->query("SET @disable_triggers = NULL");
+                        $detail = get_class($e) . ': ' . $e->getMessage()
+                            . ' in ' . $e->getFile() . ':' . $e->getLine();
+                        logProgress('FATAL ERROR: ' . $detail, 'error');
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT_ERROR,
+                            '07-Chassis-Override-Schema-Backfill fatal error: ' . $detail);
+                    }
+
+                    ?></pre>
+
+                    <div class="text-center mt-3">
+                        <a href="../../manage-maintenance.php?tab=maintenance" class="btn btn-primary btn-lg">
+                            <i class="fa fa-arrow-left"></i> Return to Maintenance
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <?php endif; ?>
+
+        </div>
+    </div>
+</div>
+
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/app/cars/actions/edit.php
+++ b/app/cars/actions/edit.php
@@ -427,6 +427,7 @@ function updateChassis(array &$cardetails): void
             $validator = new ChassisValidator();
             $result = $validator->validate($chassis, $year, $model, $chassisOverride);
         } catch (ElanRegistryException $e) {
+            logger($user->data()->id, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'ChassisValidator ElanRegistryException for chassis "' . htmlspecialchars($chassis, ENT_QUOTES, 'UTF-8') . '": ' . $e->getMessage());
             $errors[] = 'Chassis validation error: ' . $e->getUserMessage();
             return;
         } catch (\Throwable $e) {
@@ -436,11 +437,13 @@ function updateChassis(array &$cardetails): void
         }
         
         // Handle validation result
-        if ($result['valid'] && !$result['override_used']) {
-            $successes[] = 'Chassis: ' . htmlspecialchars($cardetails['chassis'], ENT_QUOTES, 'UTF-8');
-        } elseif ($result['valid'] && $result['override_used']) {
-            $successes[] = 'Chassis: ' . htmlspecialchars($cardetails['chassis'], ENT_QUOTES, 'UTF-8') . ' (Override used)';
-            $chassis_override_used = true; // Track that override was used for comments
+        if ($result['valid']) {
+            $cardetails['chassis_override'] = $result['override_used'] ? 1 : 0;
+            $label = htmlspecialchars($cardetails['chassis'], ENT_QUOTES, 'UTF-8');
+            $successes[] = 'Chassis: ' . $label . ($result['override_used'] ? ' (Override used)' : '');
+            if ($result['override_used']) {
+                $chassis_override_used = true; // Track that override was used for comments
+            }
         } else {
             $errors[] = '<strong>ERROR:</strong> Chassis Validation Failed: ' . $result['error_reason'];
         }

--- a/app/cars/details.php
+++ b/app/cars/details.php
@@ -248,6 +248,11 @@ if (!empty($_GET)) {
                                 </dt>
                                 <dd class="col-sm-8">
                                     <strong><?= $carData->chassis ? htmlspecialchars($carData->chassis, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></strong>
+                                    <?php if (!empty($carData->chassis_override)): ?>
+                                        <span class="badge bg-warning text-dark ms-1">
+                                            <i class="fas fa-exclamation-triangle"></i> Validation Override
+                                        </span>
+                                    <?php endif; ?>
                                 </dd>
                             </dl>
 

--- a/app/cars/form.php
+++ b/app/cars/form.php
@@ -894,11 +894,12 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
 
         // Show/hide override section and validation error
         const overrideEnabled = $('#chassis_override').is(':checked');
-        $('#chassis_override_section').toggleClass('d-none', isValid);
-        if (isValid) {
+        // Only hide section when chassis is genuinely valid (without override)
+        $('#chassis_override_section').toggleClass('d-none', isValid && !overrideEnabled);
+        if (isValid && !overrideEnabled) {
             $('#chassis_override').prop('checked', false);
             $('#chassis_validation_error').addClass('hidden').hide();
-        } else if (errorReason && !overrideEnabled) {
+        } else if (!isValid && errorReason && !overrideEnabled) {
             $('#chassis_validation_error').removeClass('hidden').show();
             $('#chassis_error_reason').text(errorReason);
         } else {

--- a/app/views/_edit_car_1.php
+++ b/app/views/_edit_car_1.php
@@ -109,9 +109,11 @@
                     <span id="chassis_error_reason"></span>
                 </div>
                 
-                <div id="chassis_override_section" class="d-none">
+                <?php $chassisOverrideActive = !empty($cardetails['chassis_override']); ?>
+                <div id="chassis_override_section" class="<?= $chassisOverrideActive ? '' : 'd-none' ?>">
                     <div class="form-check mt-2">
-                        <input type="checkbox" class="form-check-input" id="chassis_override" name="chassis_override" value="1">
+                        <input type="checkbox" class="form-check-input" id="chassis_override" name="chassis_override" value="1"
+                               <?= $chassisOverrideActive ? 'checked' : '' ?>>
                         <label class="form-check-label text-warning" for="chassis_override">
                             <strong>⚠️ Override chassis validation</strong><br>
                             <small>Use only if this chassis number is correct but fails validation.</small>

--- a/database/1-schema.sql
+++ b/database/1-schema.sql
@@ -105,6 +105,7 @@ CREATE TABLE `cars` (
   `year` varchar(4) COLLATE utf8mb4_unicode_ci NOT NULL,
   `type` char(3) COLLATE utf8mb4_unicode_ci NOT NULL,
   `chassis` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `chassis_override` TINYINT(1) NOT NULL DEFAULT 0,
   `color` varchar(25) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `engine` varchar(15) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `purchasedate` date DEFAULT NULL,
@@ -140,6 +141,7 @@ CREATE TABLE `cars_hist` (
   `year` varchar(4) COLLATE utf8mb4_unicode_ci NOT NULL,
   `type` char(3) COLLATE utf8mb4_unicode_ci NOT NULL,
   `chassis` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `chassis_override` TINYINT(1) NOT NULL DEFAULT 0,
   `color` varchar(25) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `engine` varchar(15) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `purchasedate` date DEFAULT NULL,
@@ -362,14 +364,14 @@ DELIMITER $$
 CREATE TRIGGER `cars_delete` AFTER DELETE ON `cars` FOR EACH ROW BEGIN
     INSERT INTO cars_hist(
         operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
-        year, type, chassis, color, engine, purchasedate, solddate, comments,
+        year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
         image, user_id, email, fname, lname, join_date, city, state, country,
         lat, lon, website
     )
     VALUES (
         'DELETE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
-        OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.color,
-        OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+        OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.chassis_override,
+        OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
         OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
         OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
     );
@@ -383,14 +385,14 @@ DELIMITER $$
 CREATE TRIGGER `cars_insert` AFTER INSERT ON `cars` FOR EACH ROW BEGIN
     INSERT INTO cars_hist(
         operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
-        year, type, chassis, color, engine, purchasedate, solddate, comments,
+        year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
         image, user_id, email, fname, lname, join_date, city, state, country,
         lat, lon, website
     )
     VALUES (
         'INSERT', NEW.id, NEW.ctime, NEW.mtime, NEW.ModifiedBy, NEW.model,
-        NEW.series, NEW.variant, NEW.year, NEW.type, NEW.chassis, NEW.color,
-        NEW.engine, NEW.purchasedate, NEW.solddate, NEW.comments, NEW.image,
+        NEW.series, NEW.variant, NEW.year, NEW.type, NEW.chassis, NEW.chassis_override,
+        NEW.color, NEW.engine, NEW.purchasedate, NEW.solddate, NEW.comments, NEW.image,
         NEW.user_id, NEW.email, NEW.fname, NEW.lname, NEW.join_date, NEW.city,
         NEW.state, NEW.country, NEW.lat, NEW.lon, NEW.website
     );
@@ -405,14 +407,14 @@ CREATE TRIGGER `cars_update` AFTER UPDATE ON `cars` FOR EACH ROW BEGIN
     IF @disable_triggers IS NULL THEN
         INSERT INTO cars_hist(
             operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
-            year, type, chassis, color, engine, purchasedate, solddate, comments,
+            year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
             image, user_id, email, fname, lname, join_date, city, state, country,
             lat, lon, website
         )
         VALUES (
             'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
-            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.color,
-            OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.chassis_override,
+            OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
             OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
             OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
         );

--- a/docs/development/DATABASE.md
+++ b/docs/development/DATABASE.md
@@ -69,6 +69,7 @@
 | `year` | `varchar(4)` | Manufacturing year |
 | `type` | `char(3)` | Vehicle type code |
 | `chassis` | `varchar(15)` | Chassis number (INDEXED) |
+| `chassis_override` | `TINYINT(1) NOT NULL DEFAULT 0` | Flag indicating whether chassis validation was overridden by the user. Set to `1` when validation was overridden; `0` for normal/valid chassis. |
 | `color` | `varchar(25)` | Vehicle color |
 | `engine` | `varchar(15)` | Engine specification |
 | `purchasedate`, `solddate` | `date` | Purchase and sale dates |
@@ -92,7 +93,7 @@ automatically synchronized from user profiles when user data changes.
 | `operation` | `varchar(32)` | Operation type (INSERT/UPDATE/DELETE) |
 | `car_id` | `int UNSIGNED` | Original car ID |
 | `timestamp` | `timestamp` | Change timestamp |
-| *(All car columns)* | | Mirror of `cars` table structure |
+| *(All car columns)* | | Mirror of `cars` table structure including `chassis_override` |
 
 #### `car_user` - Car sharing relationships
 
@@ -260,8 +261,8 @@ id=5, years=1971-1974, series="S4", variant="FHC", type_code="36", model_value="
 
 **Trigger Details**:
 
-- All triggers capture complete car record snapshots including owner data
-- Triggers updated 2025-09-12 to use current schema (no deprecated columns)
+- All triggers capture complete car record snapshots including owner data and `chassis_override`
+- All triggers use current schema (no deprecated columns); `chassis_override` added in #915
 - Each trigger records operation type (INSERT/UPDATE/DELETE) and timestamp
 
 **Car-User Relationship Triggers** (implemented in #592):

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -9,7 +9,7 @@
 
 - **Run fix script `06-Add-Car-User-Hist-Triggers.php`** ([#592](https://github.com/unibrain1/elanregistry/issues/592)): Installs AFTER INSERT/UPDATE/DELETE triggers on `car_user` and adds indexes on `car_user_hist(car_id)` and `car_user_hist(userid)`. Run via the Maintenance tab in the admin panel.
 
-_Additional deployment actions expected: SQL migrations for new `chassis_override` column on `cars` and `cars_hist` trigger updates (#915)._
+- **Run fix script `07-Chassis-Override-Schema-Backfill.php`** ([#915](https://github.com/unibrain1/elanregistry/issues/915)): Adds `chassis_override` column to `cars` and `cars_hist`, recreates all three `cars_*` triggers to include the column, and backfills `chassis_override = 1` on cars modified on or after 2025-08-31 or whose comments contain the legacy audit phrase "CHASSIS VALIDATION OVERRIDDEN". Run via the Maintenance tab in the admin panel.
 
 ## User-Facing Changes
 
@@ -27,7 +27,7 @@ _Additional deployment actions expected: SQL migrations for new `chassis_overrid
 
 ### Improvements
 
-- **Chassis Override Persistence** ([#915](https://github.com/unibrain1/elanregistry/issues/915)): Chassis validation override now persists correctly via a dedicated DB column; includes UI indicator and backfill script for existing records.
+- **Chassis Override Persistence** ([#915](https://github.com/unibrain1/elanregistry/issues/915)): Chassis validation override now persists correctly via a dedicated `chassis_override` DB column. Fixes checkbox unchecking bug in client-side JS, adds `chassis_override` to the `Car` class allowlist and validator, adds all three database triggers (`cars_insert`, `cars_update`, `cars_delete`) to capture the column, pre-populates the checkbox on edit form reload, and displays a "Validation Override" badge on the car details page. Includes backfill script for existing records.
 - **Date Range Validation** ([#903](https://github.com/unibrain1/elanregistry/issues/903)): Server-side validation added for car purchase/sold date ranges.
 - **Website Scheme Whitelist — Owner and Settings** ([#921](https://github.com/unibrain1/elanregistry/issues/921)): Extended the http/https scheme whitelist (added to the car validator in #851) to the owner profile and user settings website fields, blocking `javascript:`, `data:`, `ftp://`, and other non-web protocols.
 - **Admin Contact Security** ([#660](https://github.com/unibrain1/elanregistry/issues/660), [#661](https://github.com/unibrain1/elanregistry/issues/661)): Fixed email header injection and unvalidated recipient address in the admin multi-user contact path.

--- a/tests/integration/database/ChassisOverridePersistenceTest.php
+++ b/tests/integration/database/ChassisOverridePersistenceTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../IntegrationTestCase.php';
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration tests for chassis_override flag persistence (issue #915)
+ *
+ * Verifies that:
+ * - New cars default chassis_override to 0
+ * - Car::update() persists chassis_override = 1
+ * - Car::update() clears chassis_override back to 0
+ * - The cars_update DB trigger captures chassis_override into cars_hist
+ *
+ * Requires the chassis_override column to be present in both the `cars` and
+ * `cars_hist` tables. Run fix script 07-Chassis-Override-Schema-Backfill.php
+ * first if the column is missing.
+ */
+#[Group('integration')]
+#[Group('chassis-override')]
+final class ChassisOverridePersistenceTest extends IntegrationTestCase
+{
+    private int $testUserId = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireDatabase();
+
+        // Verify the chassis_override column exists before running any test.
+        // If the fix script has not been run the column will be absent and all
+        // four tests should be skipped rather than failing with a DB error.
+        $columnCheck = $this->db->query(
+            "SELECT 1
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME   = 'cars'
+               AND COLUMN_NAME  = 'chassis_override'
+             LIMIT 1"
+        );
+
+        if (!$columnCheck || $columnCheck->count() === 0) {
+            $this->markTestSkipped(
+                'chassis_override column not yet available — run fix script 07-Chassis-Override-Schema-Backfill.php'
+            );
+        }
+
+        // Set up an authenticated user context (mirrors CarDatabaseOperationsTest pattern)
+        global $user;
+        $user = new User();
+        $user->find($this->testUserId);
+
+        $reflection        = new ReflectionClass($user);
+        $isLoggedInProp    = $reflection->getProperty('_isLoggedIn');
+        $isLoggedInProp->setAccessible(true);
+        $isLoggedInProp->setValue($user, true);
+
+        $GLOBALS['user'] = $user;
+    }
+
+    /**
+     * Cars created without specifying chassis_override must default to 0 in the DB.
+     */
+    #[Group('integration')]
+    #[Group('chassis-override')]
+    public function testCreateCarDefaultsChassisOverrideToZero(): void
+    {
+        $carId = $this->createTestCar($this->testUserId);
+
+        $row = $this->db->query(
+            'SELECT chassis_override FROM cars WHERE id = ?',
+            [$carId]
+        )->first();
+
+        $this->assertNotNull($row, 'Expected a cars row for the newly created test car');
+        $this->assertEqualsWithDelta(
+            0,
+            (int) $row->chassis_override,
+            0,
+            'chassis_override must default to 0 when not specified at creation time'
+        );
+    }
+
+    /**
+     * Calling Car::update() with chassis_override = 1 must persist that value.
+     */
+    #[Group('integration')]
+    #[Group('chassis-override')]
+    public function testUpdateCarPersistsChassisOverrideOne(): void
+    {
+        $carId = $this->createTestCar($this->testUserId);
+
+        $car = new Car($carId);
+        $result = $car->update([
+            'id'               => $carId,
+            'user_id'          => $this->testUserId,
+            'token'            => Token::generate(),
+            'chassis_override' => 1,
+        ]);
+
+        $this->assertTrue($result, 'Car::update() must return true on success');
+
+        $row = $this->db->query(
+            'SELECT chassis_override FROM cars WHERE id = ?',
+            [$carId]
+        )->first();
+
+        $this->assertNotNull($row, 'Expected a cars row after update');
+        $this->assertSame(
+            1,
+            (int) $row->chassis_override,
+            'chassis_override must be 1 after update with chassis_override = 1'
+        );
+    }
+
+    /**
+     * Calling Car::update() with chassis_override = 0 after it was 1 must clear the flag.
+     *
+     * Note: Car::update() strips fields with empty-string or null values via array_filter,
+     * but the integer 0 passes that filter, so chassis_override = 0 is persisted correctly.
+     */
+    #[Group('integration')]
+    #[Group('chassis-override')]
+    public function testUpdateCarClearsChassisOverride(): void
+    {
+        // Create car with chassis_override already set to 1
+        $carId = $this->createTestCar($this->testUserId, ['chassis_override' => 1]);
+
+        // Verify the starting state is actually 1
+        $before = $this->db->query(
+            'SELECT chassis_override FROM cars WHERE id = ?',
+            [$carId]
+        )->first();
+        $this->assertSame(1, (int) $before->chassis_override, 'Pre-condition: chassis_override must be 1 before clear');
+
+        // Now clear it
+        $car    = new Car($carId);
+        $result = $car->update([
+            'id'               => $carId,
+            'user_id'          => $this->testUserId,
+            'token'            => Token::generate(),
+            'chassis_override' => 0,
+        ]);
+
+        $this->assertTrue($result, 'Car::update() must return true on success');
+
+        $after = $this->db->query(
+            'SELECT chassis_override FROM cars WHERE id = ?',
+            [$carId]
+        )->first();
+
+        $this->assertNotNull($after, 'Expected a cars row after update');
+        $this->assertSame(
+            0,
+            (int) $after->chassis_override,
+            'chassis_override must be 0 after update with chassis_override = 0'
+        );
+    }
+
+    /**
+     * The cars_update trigger must capture chassis_override into cars_hist.
+     *
+     * Performs one UPDATE that sets chassis_override = 1, then reads the most
+     * recent UPDATE row from cars_hist and asserts the captured value is 1.
+     */
+    #[Group('integration')]
+    #[Group('chassis-override')]
+    public function testCarsHistTriggerCapturesChassisOverride(): void
+    {
+        // Verify the chassis_override column also exists in cars_hist
+        $histColCheck = $this->db->query(
+            "SELECT 1
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME   = 'cars_hist'
+               AND COLUMN_NAME  = 'chassis_override'
+             LIMIT 1"
+        );
+
+        if (!$histColCheck || $histColCheck->count() === 0) {
+            $this->markTestSkipped(
+                'chassis_override column not present in cars_hist — run fix script 07-Chassis-Override-Schema-Backfill.php'
+            );
+        }
+
+        $carId = $this->createTestCar($this->testUserId);
+
+        $car    = new Car($carId);
+        $result = $car->update([
+            'id'               => $carId,
+            'user_id'          => $this->testUserId,
+            'token'            => Token::generate(),
+            'chassis_override' => 1,
+        ]);
+
+        $this->assertTrue($result, 'Car::update() must return true on success');
+
+        $histRow = $this->db->query(
+            "SELECT chassis_override
+             FROM cars_hist
+             WHERE car_id   = ?
+               AND operation = 'UPDATE'
+             ORDER BY timestamp DESC
+             LIMIT 1",
+            [$carId]
+        )->first();
+
+        $this->assertNotNull(
+            $histRow,
+            'Expected an UPDATE row in cars_hist after Car::update() — check that the cars_update trigger is present'
+        );
+        $this->assertSame(
+            1,
+            (int) $histRow->chassis_override,
+            'cars_hist must capture chassis_override = 1 from the UPDATE trigger'
+        );
+    }
+}

--- a/tests/regression/Issue915RegressionTest.php
+++ b/tests/regression/Issue915RegressionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for Issue #915: chassis_override flag
+ *
+ * Ensures that the chassis_override boolean flag cannot be accidentally dropped
+ * from the allowlist or the validator switch statement in future refactors.
+ *
+ * @issue 915
+ * @link https://github.com/unibrain1/elanregistry/issues/915
+ * @category regression
+ *
+ * Root cause: chassis_override was needed to allow administrators to override
+ * chassis-number validation rules for documented edge cases. The flag must be
+ * present in Car::$validCarFields so that it passes the field-allowlist check,
+ * and it must have a dedicated case in CarValidator::validateAndSanitizeFields()
+ * so that any submitted value is coerced to a strict 0/1 integer before storage.
+ *
+ * Fix: Added 'chassis_override' to $validCarFields in Car.php and added
+ * case 'chassis_override': to the switch statement in CarValidator.php.
+ */
+final class Issue915RegressionTest extends TestCase
+{
+    /** @var string Absolute path to the project root */
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        // tests/regression/ is two levels below the project root
+        $this->projectRoot = dirname(__DIR__, 2);
+    }
+
+    /**
+     * 'chassis_override' must remain in Car::$validCarFields.
+     *
+     * If it is ever removed the field will be silently discarded on every save,
+     * causing the override to be lost without any error surfacing to the user.
+     */
+    public function testChassisOverrideIsInCarValidCarFields(): void
+    {
+        $carSource = file_get_contents($this->projectRoot . '/usersc/classes/Car.php');
+
+        $this->assertNotFalse($carSource, 'Car.php must be readable');
+        $this->assertStringContainsString(
+            "'chassis_override'",
+            $carSource,
+            "Car::\$validCarFields must contain 'chassis_override' — removing it silently discards the override flag on save"
+        );
+    }
+
+    /**
+     * case 'chassis_override': must remain in CarValidator::validateAndSanitizeFields().
+     *
+     * Without this case the value falls through to the default branch, which
+     * stores whatever string the user submitted instead of a coerced 0/1 integer.
+     */
+    public function testChassisOverrideValidatorCaseExists(): void
+    {
+        $validatorSource = file_get_contents(
+            $this->projectRoot . '/usersc/classes/Car/CarValidator.php'
+        );
+
+        $this->assertNotFalse($validatorSource, 'CarValidator.php must be readable');
+        $this->assertStringContainsString(
+            "case 'chassis_override':",
+            $validatorSource,
+            "CarValidator::validateAndSanitizeFields() must have a dedicated case for 'chassis_override' to enforce 0/1 coercion"
+        );
+    }
+
+    /**
+     * edit.php must read chassis_override from POST and write it to $cardetails.
+     *
+     * Guards the wiring between the form submission and Car::update() — if the
+     * POST key is renamed or the assignment is removed, the flag silently stops
+     * persisting even though Car.php and CarValidator.php remain correct.
+     */
+    public function testEditPhpWiresChassisOverrideThroughToCardetails(): void
+    {
+        $editSource = file_get_contents($this->projectRoot . '/app/cars/actions/edit.php');
+
+        $this->assertNotFalse($editSource, 'edit.php must be readable');
+        $this->assertStringContainsString(
+            "Input::raw('chassis_override')",
+            $editSource,
+            "edit.php must read chassis_override from POST via Input::raw()"
+        );
+        $this->assertStringContainsString(
+            "\$cardetails['chassis_override']",
+            $editSource,
+            "edit.php must assign chassis_override into \$cardetails so it reaches Car::update()"
+        );
+    }
+}

--- a/tests/unit/cars/CarCrudTest.php
+++ b/tests/unit/cars/CarCrudTest.php
@@ -469,6 +469,69 @@ final class CarCrudTest extends TestCase
     }
 
     /**
+     * Test car creation with chassis_override flag set — issue #915
+     */
+    public function testCreateCarWithChassisOverride(): void
+    {
+        $car = new Car();
+        $carData = [
+            'token'            => Token::generate(),
+            'user_id'          => $this->testUserId,
+            'year'             => '1973',
+            'model'            => 'Elan S4',
+            'series'           => 'S4',
+            'variant'          => 'SE',
+            'type'             => 'FHC',
+            'chassis'          => '1234567890125',
+            'color'            => 'White',
+            'chassis_override' => 1,
+        ];
+
+        $result = $car->create($carData);
+
+        $this->assertTrue($result);
+        $this->assertSame(1, (int) $car->data()->chassis_override);
+    }
+
+    /**
+     * Test that updating a car persists chassis_override flag — issue #915
+     */
+    public function testUpdateCarChassisOverrideFlag(): void
+    {
+        $car = new Car($this->testCarId);
+
+        $updateData = [
+            'id'               => $this->testCarId,
+            'token'            => Token::generate(),
+            'chassis_override' => 1,
+        ];
+
+        $result = $car->update($updateData);
+
+        $this->assertTrue($result);
+        $this->assertSame(1, (int) $car->data()->chassis_override);
+    }
+
+    /**
+     * Test that chassis_override = 0 survives array_filter in Car::update() — issue #915
+     */
+    public function testUpdateCarChassisOverrideClearsToZero(): void
+    {
+        $car = new Car($this->testCarId);
+
+        $updateData = [
+            'id'               => $this->testCarId,
+            'token'            => Token::generate(),
+            'chassis_override' => 0,
+        ];
+
+        $result = $car->update($updateData);
+
+        $this->assertTrue($result);
+        $this->assertSame(0, (int) $car->data()->chassis_override);
+    }
+
+    /**
      * Clean up test data after each test
      */
     private function cleanupTestData(): void

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -488,6 +488,38 @@ final class CarValidatorTest extends TestCase
     }
 
     // ============================================================
+    // chassis_override field validation — issue #915
+    // ============================================================
+
+    /**
+     * chassis_override with string '1' must be coerced to integer 1.
+     */
+    public function testChassisOverrideValidatesAsOne(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['chassis_override' => '1'], false);
+        $this->assertSame(1, $result['chassis_override']);
+    }
+
+    /**
+     * chassis_override with string '0' must be coerced to integer 0.
+     */
+    public function testChassisOverrideValidatesAsZero(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['chassis_override' => '0'], false);
+        $this->assertSame(0, $result['chassis_override']);
+    }
+
+    /**
+     * Any value other than '1' must be coerced to 0 — the field is a boolean flag,
+     * not a free integer.
+     */
+    public function testChassisOverrideCoercesNonOneToZero(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['chassis_override' => '99'], false);
+        $this->assertSame(0, $result['chassis_override']);
+    }
+
+    // ============================================================
     // normalizeString tests
     // ============================================================
 

--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -247,7 +247,7 @@ class Car
         // Filter to valid car fields
         $validCarFields = [
             'id', 'user_id', 'year', 'model', 'series', 'variant', 'type',
-            'chassis', 'color', 'engine', 'purchasedate', 'solddate',
+            'chassis', 'chassis_override', 'color', 'engine', 'purchasedate', 'solddate',
             'website', 'comments', 'image', 'mtime',
             'email', 'fname', 'lname', 'join_date', 'city', 'state', 'country', 'lat', 'lon'
         ];

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -201,6 +201,10 @@ class CarValidator
                     }
                     break;
 
+                case 'chassis_override':
+                    $validatedFields[$key] = ((int) $value === 1) ? 1 : 0;
+                    break;
+
                 default:
                     $validatedFields[$key] = $value;
                     break;


### PR DESCRIPTION
## Summary

- **JS bug fix**: `updateChassisUI()` was unconditionally unchecking the override checkbox and hiding the section whenever the chassis validated as valid — even mid-edit with the override already checked. Now gated on `!overrideEnabled` so the checkbox state is preserved.
- **Persistence gap**: `chassis_override` added to `Car::$validCarFields` allowlist and `CarValidator` switch (coerces to strict `0`/`1` int). `updateChassis()` in `edit.php` now writes `$cardetails['chassis_override']` from the validator result.
- **Schema**: `chassis_override TINYINT(1) NOT NULL DEFAULT 0` added to `cars` and `cars_hist`; all three `cars_*` triggers (insert, update, delete) updated to carry the column.
- **Edit form**: checkbox and section div pre-populated from DB on reload.
- **Details page**: "Validation Override" badge displayed when `chassis_override = 1`.
- **Fix script** `07-Chassis-Override-Schema-Backfill.php`: idempotent schema migration, trigger recreation, and `ChassisValidator`-gated backfill for existing records; appends audit phrase to comments for newly-backfilled cars.

## Bug Escape Analysis

**Root cause**: Three independent gaps — JS unchecked the checkbox before submit; `Car::update()` allowlist silently dropped the field; no DB column existed to receive it. Any one gap alone would have broken persistence.

**Testing gap**: No end-to-end test covered the checkbox-to-DB round-trip. Unit tests for `Car::update()` didn't include `chassis_override` as a test field; no integration test verified the column value after a save.

**Preventive tests added**: 3 unit tests (validator coercion), 3 unit tests (`Car::update()` round-trip including the `= 0` clear path), 4 integration tests (DB persistence + trigger capture), 3 regression guards (allowlist, validator case, `edit.php` wiring).

## Required Actions After Deployment

Run fix script **`07-Chassis-Override-Schema-Backfill.php`** via the Maintenance tab in the admin panel.

## Test plan

- [ ] 912 unit + regression tests pass (pre-commit hook verified)
- [ ] 4 integration tests skip cleanly without the column; pass after fix script runs
- [ ] Edit a car with invalid chassis → check override → submit → `chassis_override = 1` in DB
- [ ] Reload edit form → override section pre-checked and visible
- [ ] Edit → valid chassis, uncheck override → submit → `chassis_override = 0` → badge gone
- [ ] View details page → "Validation Override" badge appears when flag is set
- [ ] Run fix script on dev → qualifying cars backfilled with correct reason labels

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)