### PR TITLE
security: validate to_user_id matches car owner in send-owner-email.php (#1014)

### DIFF
--- a/app/contact/send-owner-email.php
+++ b/app/contact/send-owner-email.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 use ElanRegistry\Input;
 
 /**
- * contact_owner_email.php
+ * send-owner-email.php
  * Processes contact owner requests and sends emails between users.
  *
  * Handles the backend processing for the contact owner functionality, including
@@ -26,8 +26,9 @@ $subject = '[ELANREGISTRY] Owner to Owner Message';
 $errors = [];
 $email_sent = false;
 $post_attempted = Input::exists('post');
+$carId = 0;
 
-if (Input::exists('post')) {
+if ($post_attempted) {
     $token = Input::get('csrf');
     if (!Token::check($token)) {
         include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
@@ -44,9 +45,43 @@ if (Input::exists('post')) {
 
             $fromUserId = (int) $user->data()->id;
             $toUserId   = (int) Input::get('to_user_id');
-            
+            $carId      = (int) Input::get('car_id');
+
+            if ($toUserId <= 0 || $carId <= 0) {
+                logger(
+                    $user->data()->id,
+                    LogCategories::LOG_CATEGORY_ACCESS_DENIED,
+                    'send-owner-email.php: invalid to_user_id=' . $toUserId . ' or car_id=' . $carId
+                );
+                include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
+                exit();
+            }
+
             // Validate user IDs and get user data from database
             $db = DB::getInstance();
+
+            // Verify the recipient owns the car — prevents sending to arbitrary users (IDOR)
+            $carOwnerResult = $db->query('SELECT user_id FROM cars WHERE id = ?', [$carId]);
+            if ($carOwnerResult->error()) {
+                logger(
+                    $user->data()->id,
+                    LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                    'send-owner-email.php: DB error fetching owner for car_id=' . $carId
+                );
+                include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
+                exit();
+            }
+            $carOwner = $carOwnerResult->first();
+            if (!$carOwner || (int)$carOwner->user_id !== $toUserId) {
+                logger(
+                    $user->data()->id,
+                    LogCategories::LOG_CATEGORY_ACCESS_DENIED,
+                    'send-owner-email.php: to_user_id ' . $toUserId . ' does not match owner of car_id=' . $carId
+                );
+                include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
+                exit();
+            }
+
             $fromUser = $db->query('SELECT id, email, fname, lname FROM users WHERE id = ?', [$fromUserId])->first();
             $toUser = $db->query('SELECT id, email, fname, lname FROM users WHERE id = ?', [$toUserId])->first();
             
@@ -103,8 +138,8 @@ if (Input::exists('post')) {
                 'send-owner-email.php: missing parameters — action=' . $safeAction
             );
         }
-    } // End Post with data
-    
+    } // End CSRF check
+
     // Convert error/success arrays to UserSpice session messages (Issue #237)
     if (!empty($errors)) {
         foreach ($errors as $error) {
@@ -130,7 +165,6 @@ if (Input::exists('post')) {
                     <script>
                         setTimeout(function() {
                             <?php
-                            $carId = Input::get('car_id');
                             if ($carId) {
                                 echo "window.location.href = '" . $us_url_root . "app/cars/details.php?car_id=" . (int)$carId . "';";
                             } else {

--- a/docs/releases/RELEASE_NOTES_v2.25.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.0.md
@@ -41,6 +41,7 @@
 ### Bug Fixes
 
 - **Owner Validation Error Messages** ([#927](https://github.com/unibrain1/elanregistry/issues/927)): Admin owner edit now shows the specific validation error (e.g. "Website URL must use http:// or https://") instead of a generic fallback when input is invalid.
+- **Contact Recipient Ownership Check** ([#1014](https://github.com/unibrain1/elanregistry/issues/1014)): `send-owner-email.php` now verifies that `to_user_id` matches `cars.user_id` for the supplied `car_id` before sending. Previously, any authenticated user could POST an arbitrary `to_user_id` to send an unsolicited email to any registered user (IDOR). Mismatched recipients are rejected with an error and logged to `LOG_CATEGORY_ACCESS_DENIED`.
 - **Timestamp Hour Padding** ([#947](https://github.com/unibrain1/elanregistry/issues/947)): Fixed `AppConstants::DATETIME_FORMAT` using `G` (no leading zero) instead of `H` (zero-padded) for the hour. Morning timestamps `0–9` now correctly produce `09:xx:xx` instead of `9:xx:xx`, ensuring consistent lexicographic sort order.
 - **CSRF Audit Logging Gap** ([#958](https://github.com/unibrain1/elanregistry/issues/958)): Four AJAX endpoints were returning HTTP 403 on CSRF failure with no security log entry. All four now log via `LOG_CATEGORY_SECURITY`, consistent with the rest of the codebase.
 - **Car Update Ownership Check** ([#970](https://github.com/unibrain1/elanregistry/issues/970)): Any authenticated user could update another owner's car record by POSTing a `car_id` they don't own to the `updateCar` endpoint. Added ownership guard matching the existing `fetchImages`/`removeImages` pattern — non-owners receive HTTP 403; admins (group 2/3) are unaffected.
@@ -77,3 +78,4 @@
 - [#958](https://github.com/unibrain1/elanregistry/issues/958) — security: add CSRF failure audit logging to 4 AJAX endpoints
 - [#970](https://github.com/unibrain1/elanregistry/issues/970) — security: add car ownership check to updateCar action in edit.php
 - [#971](https://github.com/unibrain1/elanregistry/issues/971) — security: fix sender impersonation in owner-to-owner contact email
+- [#1014](https://github.com/unibrain1/elanregistry/issues/1014) — security: validate to_user_id matches car owner in send-owner-email.php

--- a/tests/regression/Issue1014RegressionTest.php
+++ b/tests/regression/Issue1014RegressionTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for Issue #1014: validate to_user_id matches car owner in send-owner-email.php
+ *
+ * Ensures that the IDOR guard cannot be accidentally removed or restructured in future
+ * refactors. Without the ownership check, any authenticated user could send an unsolicited
+ * contact email to any registered user by crafting a POST with an arbitrary to_user_id.
+ *
+ * @issue 1014
+ * @link https://github.com/unibrain1/elanregistry/issues/1014
+ * @category regression
+ *
+ * Root cause: send-owner-email.php accepted to_user_id from POST without verifying that
+ * the supplied user owns the car referenced by car_id. The car_id hidden field was only
+ * consumed for the post-send redirect, never for authorization.
+ *
+ * Fix: after reading to_user_id and car_id, query cars.user_id for the supplied car_id
+ * and reject (with LOG_CATEGORY_ACCESS_DENIED logging) if it does not match to_user_id.
+ * Added a prior positive-integer guard that logs and rejects zero or negative IDs.
+ * Added a DB-error guard that logs LOG_CATEGORY_DATABASE_ERROR before the ownership
+ * comparison to prevent DB failures from being misclassified as IDOR attempts.
+ */
+final class Issue1014RegressionTest extends TestCase
+{
+    /** @var string Absolute path to the project root */
+    private string $projectRoot;
+
+    /** @var string Absolute path to the target file */
+    private string $targetFile;
+
+    protected function setUp(): void
+    {
+        // tests/regression/ is two levels below the project root
+        $this->projectRoot = dirname(__DIR__, 2);
+        $this->targetFile  = $this->projectRoot . '/app/contact/send-owner-email.php';
+    }
+
+    /**
+     * The ownership query must exist in send-owner-email.php.
+     *
+     * If removed, the IDOR vulnerability (#1014) is reintroduced: any authenticated
+     * user can send email to an arbitrary registered user.
+     */
+    public function testOwnershipQueryExists(): void
+    {
+        $this->assertFileExists($this->targetFile);
+        $content = file_get_contents($this->targetFile);
+
+        $this->assertStringContainsString(
+            'SELECT user_id FROM cars WHERE id = ?',
+            $content,
+            'send-owner-email.php must query cars.user_id to verify the recipient owns the car (#1014)'
+        );
+    }
+
+    /**
+     * The ownership query must execute before the user data lookup.
+     *
+     * Guards against a structural regression where the ownership check is moved after
+     * the user lookup — an attacker with a valid to_user_id that does not own the car
+     * would still receive the email if the check runs too late.
+     */
+    public function testOwnershipCheckPrecedesUserLookup(): void
+    {
+        $this->assertFileExists($this->targetFile);
+        $content = file_get_contents($this->targetFile);
+
+        $ownershipPos  = strpos($content, 'SELECT user_id FROM cars WHERE id = ?');
+        $userLookupPos = strpos($content, 'SELECT id, email, fname, lname FROM users WHERE id = ?');
+
+        $this->assertNotFalse($ownershipPos,  'Ownership query string not found in send-owner-email.php');
+        $this->assertNotFalse($userLookupPos, 'User lookup query string not found in send-owner-email.php');
+        $this->assertLessThan(
+            $userLookupPos,
+            $ownershipPos,
+            'Ownership check must execute before user data lookup (#1014)'
+        );
+    }
+
+    /**
+     * LOG_CATEGORY_ACCESS_DENIED must be referenced for the ownership mismatch path.
+     *
+     * Guards the audit trail: removing the constant reference silently removes the
+     * access-denied log entry that records IDOR attempts.
+     */
+    public function testAccessDeniedIsLoggedOnOwnerMismatch(): void
+    {
+        $this->assertFileExists($this->targetFile);
+        $content = file_get_contents($this->targetFile);
+
+        $this->assertStringContainsString(
+            'LOG_CATEGORY_ACCESS_DENIED',
+            $content,
+            'send-owner-email.php must log LOG_CATEGORY_ACCESS_DENIED when to_user_id does not match car owner (#1014)'
+        );
+    }
+
+    /**
+     * A positive-integer guard must reject zero or negative IDs before the DB query.
+     *
+     * Guards the defense-in-depth boundary check: a missing or zero car_id must be
+     * rejected before the ownership query runs, preventing reliance on the schema
+     * accident of no car with id=0.
+     */
+    public function testZeroOrNegativeIdGuardExists(): void
+    {
+        $this->assertFileExists($this->targetFile);
+        $content = file_get_contents($this->targetFile);
+
+        $this->assertMatchesRegularExpression(
+            '/\$toUserId\s*<=\s*0\s*\|\|\s*\$carId\s*<=\s*0/',
+            $content,
+            'send-owner-email.php must reject zero/negative IDs before the ownership query (#1014)'
+        );
+    }
+
+    /**
+     * A DB error check must precede the ownership comparison.
+     *
+     * Guards against DB failures being silently misclassified as IDOR access violations:
+     * if the query errors, the file must log LOG_CATEGORY_DATABASE_ERROR (not ACCESS_DENIED)
+     * and exit before reaching the ownership comparison.
+     */
+    public function testDbErrorCheckPrecedesOwnershipComparison(): void
+    {
+        $this->assertFileExists($this->targetFile);
+        $content = file_get_contents($this->targetFile);
+
+        $this->assertStringContainsString(
+            'LOG_CATEGORY_DATABASE_ERROR',
+            $content,
+            'send-owner-email.php must check for DB errors before the ownership comparison (#1014)'
+        );
+
+        $dbErrorPos    = strpos($content, 'LOG_CATEGORY_DATABASE_ERROR');
+        $accessDeniedPos = strrpos($content, 'LOG_CATEGORY_ACCESS_DENIED');
+
+        $this->assertNotFalse($dbErrorPos,     'LOG_CATEGORY_DATABASE_ERROR not found');
+        $this->assertNotFalse($accessDeniedPos, 'LOG_CATEGORY_ACCESS_DENIED not found');
+        $this->assertLessThan(
+            $accessDeniedPos,
+            $dbErrorPos,
+            'DB error log must appear before the ownership-mismatch ACCESS_DENIED log (#1014)'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes IDOR vulnerability in `send-owner-email.php` where any authenticated user could send an unsolicited contact email to any registered user by POSTing an arbitrary `to_user_id` not validated against the car's actual owner
- Adds three-layer rejection: invalid IDs (logged `ACCESS_DENIED`) → DB error (logged `DATABASE_ERROR`) → owner mismatch (logged `ACCESS_DENIED`)
- Adds `Issue1014RegressionTest.php` with 5 structural regression tests guarding the ownership check, its execution order, the boundary guard, and the DB error path

## Bug Escape Analysis

- **Root cause**: `car_id` was passed as a hidden field but only consumed for the post-send redirect, never for authorization. The recipient was fully trust-by-POST.
- **Testing gap**: `SerializedDataRemovalTest.php` validates which POST fields are accepted but never validates authorization logic (that recipients must own the referenced car).
- **Preventive**: `Issue1014RegressionTest.php` guards all rejection layers and the ordering invariant via source-inspection tests.

## Test plan

- [x] `composer test:quick` — 912 unit tests pass
- [x] `vendor/bin/phpunit tests/regression/Issue1014RegressionTest.php` — 5/5 regression tests pass
- [x] Pre-commit hooks: PHPStan clean, phpcs clean, unit tests pass
- [ ] Manual: normal `owner.php → send-owner-email.php` flow sends email successfully
- [ ] Manual: crafted POST with mismatched `to_user_id` → token error page, `AccessDenied` logged

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)