### PR TITLE
fix: prevent misleading rollback log when post-commit reload fails (#928)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.25.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.1.md
@@ -21,6 +21,10 @@ None
 
 ## Admin-Facing Changes
 
+### Bug Fixes
+
+- **Misleading rollback log on successful owner updates** ([#928](https://github.com/unibrain1/elanregistry/issues/928)): `ElanRegistryOwner::update()` and `create()` no longer log "Owner update failed" / "Owner creation failed" when a post-commit reload throws. The post-commit `find()` and success-logger calls now run outside the transaction's try/catch block, so the data-was-saved state is correctly reflected even when the reload fails. Also fixes a no-op `ROLLBACK` issued after a successful `COMMIT` in the same case.
+
 ### Improvements
 
 - **Local Playwright test suite fully restored** ([#881](https://github.com/unibrain1/elanregistry/issues/881)): Fixed broken local MAMP config (`elan_registry` typo, leading-slash `goto` calls), updated all test files to work against the local dev environment, converted TypeScript security specs to JavaScript to eliminate Node.js DEP0205 deprecation warnings, upgraded `@playwright/test` from 1.56 to 1.61.1 (also resolves residual DEP0205 from Playwright's own TypeScript loader on Node 26) and downgraded `dotenv` from 17 to 16 (also triggered DEP0205). 118 tests pass; 35 skip gracefully (E2E tests that target production environments, and authenticated tests that skip when `.env.local` credentials are absent).

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -150,20 +150,18 @@ class ElanRegistryOwner
             }
 
             $this->_db->query("COMMIT");
-
-            // Load the created owner data
-            $this->find($userId);
-
-            // Log successful creation
-            logger($userId, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "Owner created: {$userFields['fname']} {$userFields['lname']} ({$userFields['email']})");
-
-            return true;
-
         } catch (Exception $e) {
             $this->_db->query("ROLLBACK");
-            logger(0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Owner creation failed: ' . $e->getMessage());
+            logger(0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Owner creation transaction failed: ' . $e->getMessage());
             throw $e;
         }
+
+        // Post-commit: reload and log outside the transaction so that a failure
+        // here does not trigger ROLLBACK or log a false "transaction failed" message.
+        $this->find($userId);
+        logger($userId, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "Owner created: {$userFields['fname']} {$userFields['lname']} ({$userFields['email']})");
+
+        return true;
     }
 
     /**
@@ -252,21 +250,19 @@ class ElanRegistryOwner
             }
 
             $this->_db->query("COMMIT");
-
-            // Reload owner data
-            $this->find($userId);
-
-            // Log successful update
-            $fieldsUpdated = array_merge(array_keys($userFields), array_keys($profileFields));
-            logger($userId, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "Owner updated - fields: " . implode(', ', $fieldsUpdated));
-
-            return true;
-
         } catch (Exception $e) {
             $this->_db->query("ROLLBACK");
-            logger($userId, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Owner update failed: ' . $e->getMessage());
+            logger($userId, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Owner update transaction failed: ' . $e->getMessage());
             throw $e;
         }
+
+        // Post-commit: reload and log outside the transaction so that a failure
+        // here does not trigger ROLLBACK or log a false "transaction failed" message.
+        $this->find($userId);
+        $fieldsUpdated = array_merge(array_keys($userFields), array_keys($profileFields));
+        logger($userId, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "Owner updated - fields: " . implode(', ', $fieldsUpdated));
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Moves post-commit `find()` and success-logger calls **outside** the transaction's `try/catch` block in both `ElanRegistryOwner::update()` and `create()`
- A failure in the post-commit reload path no longer issues a no-op `ROLLBACK` (after `COMMIT` already succeeded) or logs a false "Owner update/creation failed" message
- The `create()` bug was discovered during code inspection for this issue — same root cause, folded in as a two-line fix

## Bug Escape Analysis

**Root cause:** The post-commit `find()` reload and success logger were inside the `try` block that protects the transaction. If `find()` threw (e.g., a DB reconnection failure between `COMMIT` and the subsequent `SELECT`), the `catch` handler issued a no-op `ROLLBACK` and logged "Owner update failed" — even though the data was already committed.

**Testing gap:** No test for the COMMIT-succeeded-but-reload-failed path. Adding one cleanly requires injectable DB infrastructure the class doesn't have today. The fix itself is structural (code placement), not behavioural, so the existing integration test suite (11 tests) continues to serve as the regression guard for the happy path.

**Preventive measure:** Inline comment in each method documents *why* post-commit operations must stay outside the `try` block, so future refactors don't silently reintroduce the issue.

## Test plan

- [x] 912 unit tests pass
- [x] 11 `ElanRegistryOwnerIntegrationTest` integration tests pass
- [x] PHPStan: no errors
- [x] phpcs: no blocking issues (1 advisory warning, pre-existing)
- [x] `php -l` clean

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kLk37X98cmJDVKDeGQNup