### PR TITLE
refactor: extract car hero buttons and detail cards into shared partials (#924, #925)

### DIFF
--- a/app/cars/details.php
+++ b/app/cars/details.php
@@ -115,7 +115,7 @@ if (!empty($_GET)) {
                                                 <i class="fas fa-hashtag me-3 fa-lg"></i>
                                                 <div>
                                                     <div class="text-white-75 fw-medium mb-1">Registry ID</div>
-                                                    <div class="fw-bold fs-5"><?= $carData->id ?></div>
+                                                    <div class="fw-bold fs-5"><?= (int)$carData->id ?></div>
                                                 </div>
                                             </div>
                                         </div>
@@ -149,60 +149,18 @@ if (!empty($_GET)) {
                                     </div>
                                 </div>
                                 <div class="col-md-4 text-md-end">
-                                    <?php
-                                    if (isset($user) && $user->isLoggedIn()) {
-                                        $isOwner = ($user->data()->id === $car->data()->user_id);
-                                        $isAdmin = isRegistryAdmin($user->data()->id); // Administrator (2) or Editor (3)
-
-                                        if ($isOwner) { ?>
-                                            <form method="POST" action="<?= $us_url_root ?>app/cars/form.php" class="d-inline">
-                                                <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
-                                                <input type="hidden" name="action" value="updateCar" />
-                                                <input type="hidden" name="car_id" id="car_id" value="<?= $carData->id ?>" />
-                                                <button class="btn btn-light btn-lg" type="submit">
-                                                    <i class="fas fa-edit"></i> Update Car
-                                                </button>
-                                            </form>
-                                        <?php } elseif ($isAdmin) { ?>
-                                            <div class="alert alert-warning mb-2">
-                                                <i class="fas fa-shield-alt"></i> <strong>Administrative Override:</strong>
-                                                You are editing a car that you do not own using Administrator/Editor privileges.
-                                            </div>
-                                            <form method="POST" action="<?= $us_url_root ?>app/cars/form.php" class="d-inline me-2">
-                                                <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
-                                                <input type="hidden" name="action" value="updateCar" />
-                                                <input type="hidden" name="car_id" id="car_id" value="<?= $carData->id ?>" />
-                                                <input type="hidden" name="admin_override" value="1" />
-                                                <button class="btn btn-warning btn-lg" type="submit">
-                                                    <i class="fas fa-edit"></i> Admin Edit Car
-                                                </button>
-                                            </form>
-                                            <form method="POST" action="<?= $us_url_root ?>app/contact/owner.php" class="d-inline">
-                                                <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
-                                                <input type="hidden" name="action" value="contact_owner" />
-                                                <input type="hidden" name="car_id" id="car_id" value="<?= $carData->id ?>" />
-                                                <button class="btn btn-light btn-lg" type="submit">
-                                                    <i class="fas fa-envelope"></i> Contact Owner
-                                                </button>
-                                            </form>
                                         <?php
-                                        } else {
-                                        ?>
-                                            <form method="POST" action="<?= $us_url_root ?>app/contact/owner.php" class="d-inline">
-                                                <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
-                                                <input type="hidden" name="action" value="contact_owner" />
-                                                <input type="hidden" name="car_id" id="car_id" value="<?= $carData->id ?>" />
-                                                <button class="btn btn-light btn-lg" type="submit">
-                                                    <i class="fas fa-envelope"></i> Contact Owner
-                                                </button>
-                                            </form>
-                                    <?php
-                                        }
-                                    } else { ?>
-                                        <a href="<?= htmlspecialchars($us_url_root . 'users/login.php', ENT_QUOTES, 'UTF-8') ?>" class="btn btn-outline-light btn-sm">
-                                            <i class="fas fa-sign-in-alt me-1"></i> Log in to contact owner
-                                        </a>
-                                    <?php }
+                                    if (!$user->isLoggedIn()) {
+                                        $context = 'guest_detail';
+                                    } elseif ($user->data()->id === $carData->user_id) {
+                                        $context = 'owner_detail';
+                                    } elseif (isRegistryAdmin($user->data()->id)) {
+                                        $context = 'admin_detail';
+                                    } else {
+                                        $context = 'visitor_detail';
+                                    }
+                                    $heroCarId = (int)$carData->id;
+                                    include $abs_us_root . $us_url_root . 'usersc/includes/partials/car_hero_actions.php';
                                     ?>
                                 </div>
                             </div>
@@ -213,134 +171,10 @@ if (!empty($_GET)) {
 
             <div class="row">
                 <div class="col-lg-6 mb-4 order-last order-lg-first">
-                    <!-- Vehicle Information Card -->
-                    <div class="card registry-card mb-4">
-                        <div class="card-header">
-                            <h3 class="mb-0"><i class="fas fa-car text-primary"></i> Vehicle Information</h3>
-                        </div>
-                        <div class="card-body">
-                            <!-- Basic Vehicle Details -->
-                            <dl class="row mb-4">
-                                <dt class="col-sm-4 text-muted">
-                                    <i class="fas fa-calendar text-primary"></i> Model Year
-                                </dt>
-                                <dd class="col-sm-8">
-                                    <?= htmlspecialchars((string)($carData->year ?? ''), ENT_QUOTES, 'UTF-8') ?>
-                                </dd>
-                                
-                                <dt class="col-sm-4 text-muted">
-                                    <i class="fas fa-tag text-primary"></i> Series
-                                </dt>
-                                <dd class="col-sm-8">
-                                    <?= htmlspecialchars($carData->series ?? '', ENT_QUOTES, 'UTF-8') ?>
-                                    <?= !empty($carData->variant) ? ' - ' . htmlspecialchars($carData->variant, ENT_QUOTES, 'UTF-8') : '' ?>
-                                </dd>
-                                
-                                <dt class="col-sm-4 text-muted">
-                                    <i class="fas fa-car text-primary"></i> Type
-                                </dt>
-                                <dd class="col-sm-8">
-                                    <?= $carData->type ? htmlspecialchars($carData->type, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
-                                </dd>
-                                
-                                <dt class="col-sm-4 text-muted">
-                                    <i class="fas fa-barcode text-primary"></i> Chassis
-                                </dt>
-                                <dd class="col-sm-8">
-                                    <strong><?= $carData->chassis ? htmlspecialchars($carData->chassis, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></strong>
-                                    <?php if (!empty($carData->chassis_override)): ?>
-                                        <span class="badge bg-warning text-dark ms-1">
-                                            <i class="fas fa-exclamation-triangle"></i> Validation Override
-                                        </span>
-                                    <?php endif; ?>
-                                </dd>
-                            </dl>
-
-                            <hr>
-
-                            <!-- Appearance & Technical -->
-                            <h6 class="text-muted mb-3">
-                                <i class="fas fa-palette text-secondary"></i> Appearance & Technical
-                            </h6>
-                            <dl class="row mb-4">
-                                <dt class="col-sm-4 text-muted">Color</dt>
-                                <dd class="col-sm-8">
-                                    <?= $carData->color ? htmlspecialchars($carData->color, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
-                                </dd>
-                                
-                                <dt class="col-sm-4 text-muted">Engine</dt>
-                                <dd class="col-sm-8">
-                                    <?= $carData->engine ? htmlspecialchars($carData->engine, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
-                                </dd>
-                            </dl>
-
-                            <hr>
-
-                            <!-- Ownership & History -->
-                            <h6 class="text-muted mb-3">
-                                <i class="fas fa-history text-secondary"></i> Ownership & History
-                            </h6>
-                            <dl class="row mb-4">
-                                <?php if ($purchaseDate) { ?>
-                                <dt class="col-sm-4 text-muted">Purchase Date</dt>
-                                <dd class="col-sm-8">
-                                    <?= $purchaseDate->format('F j, Y') ?>
-                                </dd>
-                                <?php } ?>
-                                
-                                <?php if ($soldDate) { ?>
-                                <dt class="col-sm-4 text-muted">Sold Date</dt>
-                                <dd class="col-sm-8">
-                                    <?= $soldDate->format('F j, Y') ?>
-                                </dd>
-                                <?php } ?>
-                                
-                                <?php if (!empty($carData->website) && in_array(strtolower((string)parse_url($carData->website, PHP_URL_SCHEME)), ['http', 'https'], true)) { ?>
-                                <dt class="col-sm-4 text-muted">Website</dt>
-                                <dd class="col-sm-8">
-                                    <a href="<?= htmlspecialchars($carData->website, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">
-                                        <i class="fas fa-external-link-alt"></i> Visit Website
-                                    </a>
-                                </dd>
-                                <?php } ?>
-                            </dl>
-
-                            <?php if (!empty($carData->comments)) { ?>
-                            <hr>
-                            <h6 class="text-muted mb-3">
-                                <i class="fas fa-comment text-secondary"></i> Owner Comments
-                            </h6>
-                            <div class="bg-light p-3 rounded">
-                                <?= nl2br(htmlspecialchars($carData->comments, ENT_QUOTES, 'UTF-8')) ?>
-                            </div>
-                            <?php } ?>
-
-                            <!-- Registry Information -->
-                            <hr>
-                            <div class="row text-center">
-                                <div class="col-6">
-                                    <i class="fas fa-plus-circle text-success d-block mb-1"></i>
-                                    <small class="text-muted d-block">Added to Registry</small>
-                                    <strong>
-                                        <?php
-                                        $createdDate = new DateTime($car->data()->ctime);
-                                        echo $createdDate->format('M j, Y');
-                                        ?>
-                                    </strong>
-                                </div>
-                                <div class="col-6">
-                                    <i class="fas fa-edit text-info d-block mb-1"></i>
-                                    <small class="text-muted d-block">Last Updated</small>
-                                    <strong>
-                                        <?php
-                                        $modifiedDate = new DateTime($car->data()->mtime);
-                                        echo $modifiedDate->format('M j, Y');
-                                        ?>
-                                    </strong>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <?php
+                    $headingTag = 'h3';
+                    include $abs_us_root . $us_url_root . 'usersc/includes/partials/_vehicle_info_card.php';
+                    ?>
 
                     <!-- Owner Information Card -->
                     <div class="card registry-card">
@@ -374,7 +208,7 @@ if (!empty($_GET)) {
                             
                             <div class="text-center">
                                 <small class="text-muted">
-                                    <i class="fas fa-id-card"></i> Registry Owner ID: <?= $car->data()->user_id ?>
+                                    <i class="fas fa-id-card"></i> Registry Owner ID: <?= (int)$car->data()->user_id ?>
                                 </small>
                             </div>
                         </div>
@@ -424,70 +258,10 @@ if (!empty($_GET)) {
                     ?>
 
                     <!-- Factory Data Card -->
-                    <?php if (!is_null($factoryData)) { ?>
-                    <div class="card registry-card">
-                        <div class="card-header">
-                            <h3 class="mb-0">
-                                <i class="fas fa-industry text-primary"></i> Factory Data
-                                <span class="badge bg-warning ms-2">Unverified</span>
-                            </h3>
-                        </div>
-                        <div class="card-body">
-                            <div class="alert alert-primary mb-3">
-                                <i class="fas fa-exclamation-triangle"></i>
-                                <strong>Note:</strong> This information has not been verified against the official Lotus archives.
-                            </div>
-                            
-                            <dl class="row">
-                                <dt class="col-sm-5 text-muted">Production Year</dt>
-                                <dd class="col-sm-7"><?= $factoryData->year ? htmlspecialchars((string)$factoryData->year, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
-                                
-                                <dt class="col-sm-5 text-muted">Production Month</dt>
-                                <dd class="col-sm-7"><?= $factoryData->month ? htmlspecialchars((string)$factoryData->month, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
-                                
-                                <dt class="col-sm-5 text-muted">Production Batch</dt>
-                                <dd class="col-sm-7"><?= $factoryData->batch ? htmlspecialchars((string)$factoryData->batch, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
-                                
-                                <dt class="col-sm-5 text-muted">Factory Type</dt>
-                                <dd class="col-sm-7"><?= $factoryData->type ? htmlspecialchars((string)$factoryData->type, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
-                                
-                                <dt class="col-sm-5 text-muted">Factory Chassis</dt>
-                                <dd class="col-sm-7">
-                                    <strong><?= $factoryData->serial ? htmlspecialchars((string)$factoryData->serial, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></strong>
-                                </dd>
-                                
-                                <dt class="col-sm-5 text-muted">Chassis Suffix</dt>
-                                <dd class="col-sm-7"><?= $factoryData->suffix ? htmlspecialchars((string)$factoryData->suffix, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
-                                
-                                <dt class="col-sm-5 text-muted">Factory Engine</dt>
-                                <dd class="col-sm-7">
-                                    <?= htmlspecialchars((string)($factoryData->engineletter ?? ''), ENT_QUOTES, 'UTF-8') ?><?= htmlspecialchars((string)($factoryData->enginenumber ?? ''), ENT_QUOTES, 'UTF-8') ?>
-                                </dd>
-                                
-                                <dt class="col-sm-5 text-muted">Gearbox</dt>
-                                <dd class="col-sm-7"><?= $factoryData->gearbox ? htmlspecialchars((string)$factoryData->gearbox, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
-                                
-                                <dt class="col-sm-5 text-muted">Factory Color</dt>
-                                <dd class="col-sm-7"><?= $factoryData->color ? htmlspecialchars((string)$factoryData->color, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
-                                
-                                <?php if ($buildDate) { ?>
-                                <dt class="col-sm-5 text-muted">Build Date</dt>
-                                <dd class="col-sm-7">
-                                    <?= $buildDate->format('F j, Y') ?>
-                                </dd>
-                                <?php } ?>
-                            </dl>
-                            
-                            <?php if (!empty($factoryData->note)) { ?>
-                            <hr>
-                            <h6 class="text-muted mb-2">Factory Notes</h6>
-                            <div class="bg-light p-3 rounded">
-                                <small><?= htmlspecialchars($factoryData->note, ENT_QUOTES, 'UTF-8') ?></small>
-                            </div>
-                            <?php } ?>
-                        </div>
-                    </div>
-                    <?php } ?>
+                    <?php if (!is_null($factoryData)) {
+                        $headingTag = 'h3';
+                        include $abs_us_root . $us_url_root . 'usersc/includes/partials/_factory_data_card.php';
+                    } ?>
                 </div>
             </div>
 
@@ -577,10 +351,6 @@ if (!empty($_GET)) {
                                     <table><tr><td>Cell Colour Coding Information:</td><td class="table-success">Newly Inserted value</td><td class="table-danger">Deleted Value</td><td class="table-info">Changed value</td></tr></table>
                                 </div>
                             </div>
-                            
-                            <?php
-                            // $carHistory and $historyCount are loaded above
-                            ?>
                             
                             <!-- Summary Stats when collapsed -->
                             <div class="show" id="historySummary">
@@ -699,7 +469,7 @@ window.ELAN_CONFIG = {
 <script src='<?= $us_url_root ?>app/assets/js/imagedisplay.min.js'></script>
 <script src='<?= $us_url_root ?>app/assets/js/highlightDifferences.min.js'></script>
 <script>
-const img_root = '<?= $us_url_root . $settings->elan_image_dir ?>';
+const img_root = <?= json_encode($us_url_root . ($settings->elan_image_dir ?? '')) ?>;
 window.carDetailsConfig = {
     carId: <?= (int)$carData->id ?>,
     csrf: '<?= Token::generate() ?>'

--- a/docs/releases/RELEASE_NOTES_v2.25.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.1.md
@@ -22,6 +22,7 @@ None
 ## Technical Changes
 
 - **Owner display consolidation** ([#531](https://github.com/unibrain1/elanregistry/issues/531)): New `ElanRegistry\OwnerView` static utility class centralises all owner name, quality badge, location, contact info, and missing-fields rendering. Eliminates ~200+ lines of duplicated inline HTML across 8 template files. Consistent quality score thresholds (≥80 success, ≥60 warning, <60 danger) and XSS escaping applied uniformly at the view layer.
+- **Car detail partials** ([#924](https://github.com/unibrain1/elanregistry/issues/924), [#925](https://github.com/unibrain1/elanregistry/issues/925)): Hero action buttons and both car detail cards (Vehicle Information, Factory Data) extracted into shared PHP partials under `usersc/includes/partials/`. Eliminates ~240 lines of duplicated HTML from `details.php`; the new `usersc/account.php` (#923) adopts these partials directly. Accessibility fix: all decorative Font Awesome icons now carry `aria-hidden="true"`; guest contact button corrected from `btn-sm` to `btn`.
 
 ## Admin-Facing Changes
 

--- a/usersc/includes/partials/_factory_data_card.php
+++ b/usersc/includes/partials/_factory_data_card.php
@@ -1,0 +1,67 @@
+<?php
+if (count(get_included_files()) == 1) { die(); }
+
+$headingTag       = in_array($headingTag, ['h1','h2','h3','h4','h5','h6'], true) ? $headingTag : 'h3';
+$_cardHeaderClass = $headingTag === 'h4' ? ' card-header-er-l2' : '';
+$_headingClass    = $headingTag === 'h4' ? 'mb-0 card-header-er-l2-text' : 'mb-0';
+?>
+<div class="card registry-card">
+    <div class="card-header<?= $_cardHeaderClass ?>">
+        <<?= $headingTag ?> class="<?= $_headingClass ?>">
+            <i class="fas fa-industry text-primary" aria-hidden="true"></i> Factory Data
+            <span class="badge bg-warning ms-2">Unverified</span>
+        </<?= $headingTag ?>>
+    </div>
+    <div class="card-body">
+        <div class="alert alert-primary mb-3">
+            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+            <strong>Note:</strong> This information has not been verified against the official Lotus archives.
+        </div>
+
+        <dl class="row">
+            <dt class="col-sm-5 text-muted">Production Year</dt>
+            <dd class="col-sm-7"><?= $factoryData->year ? htmlspecialchars((string)$factoryData->year, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
+
+            <dt class="col-sm-5 text-muted">Production Month</dt>
+            <dd class="col-sm-7"><?= $factoryData->month ? htmlspecialchars((string)$factoryData->month, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
+
+            <dt class="col-sm-5 text-muted">Production Batch</dt>
+            <dd class="col-sm-7"><?= $factoryData->batch ? htmlspecialchars((string)$factoryData->batch, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
+
+            <dt class="col-sm-5 text-muted">Factory Type</dt>
+            <dd class="col-sm-7"><?= $factoryData->type ? htmlspecialchars((string)$factoryData->type, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
+
+            <dt class="col-sm-5 text-muted">Factory Chassis</dt>
+            <dd class="col-sm-7">
+                <strong><?= $factoryData->serial ? htmlspecialchars((string)$factoryData->serial, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></strong>
+            </dd>
+
+            <dt class="col-sm-5 text-muted">Chassis Suffix</dt>
+            <dd class="col-sm-7"><?= $factoryData->suffix ? htmlspecialchars((string)$factoryData->suffix, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
+
+            <dt class="col-sm-5 text-muted">Factory Engine</dt>
+            <dd class="col-sm-7">
+                <?= htmlspecialchars((string)($factoryData->engineletter ?? ''), ENT_QUOTES, 'UTF-8') ?><?= htmlspecialchars((string)($factoryData->enginenumber ?? ''), ENT_QUOTES, 'UTF-8') ?>
+            </dd>
+
+            <dt class="col-sm-5 text-muted">Gearbox</dt>
+            <dd class="col-sm-7"><?= $factoryData->gearbox ? htmlspecialchars((string)$factoryData->gearbox, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
+
+            <dt class="col-sm-5 text-muted">Factory Color</dt>
+            <dd class="col-sm-7"><?= $factoryData->color ? htmlspecialchars((string)$factoryData->color, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Unknown</em>' ?></dd>
+
+            <?php if ($buildDate) { ?>
+            <dt class="col-sm-5 text-muted">Build Date</dt>
+            <dd class="col-sm-7"><?= $buildDate->format('F j, Y') ?></dd>
+            <?php } ?>
+        </dl>
+
+        <?php if (!empty($factoryData->note)) { ?>
+        <hr>
+        <h6 class="text-muted mb-2">Factory Notes</h6>
+        <div class="bg-light p-3 rounded">
+            <small><?= htmlspecialchars($factoryData->note, ENT_QUOTES, 'UTF-8') ?></small>
+        </div>
+        <?php } ?>
+    </div>
+</div>

--- a/usersc/includes/partials/_vehicle_info_card.php
+++ b/usersc/includes/partials/_vehicle_info_card.php
@@ -1,0 +1,127 @@
+<?php
+if (count(get_included_files()) == 1) { die(); }
+
+$headingTag       = in_array($headingTag, ['h1','h2','h3','h4','h5','h6'], true) ? $headingTag : 'h3';
+$_cardHeaderClass = $headingTag === 'h4' ? ' card-header-er-l2' : '';
+$_headingClass    = $headingTag === 'h4' ? 'mb-0 card-header-er-l2-text' : 'mb-0';
+$_subHeadingClass = $headingTag === 'h4' ? 'card-header-er-l4-text mb-2' : 'text-muted mb-3';
+?>
+<div class="card registry-card mb-4">
+    <div class="card-header<?= $_cardHeaderClass ?>">
+        <<?= $headingTag ?> class="<?= $_headingClass ?>">
+            <i class="fas fa-car text-primary" aria-hidden="true"></i> Vehicle Information
+        </<?= $headingTag ?>>
+    </div>
+    <div class="card-body">
+        <!-- Basic Vehicle Details -->
+        <dl class="row mb-4">
+            <dt class="col-sm-4 text-muted">
+                <i class="fas fa-calendar text-primary" aria-hidden="true"></i> Model Year
+            </dt>
+            <dd class="col-sm-8">
+                <?= htmlspecialchars((string)($carData->year ?? ''), ENT_QUOTES, 'UTF-8') ?>
+            </dd>
+
+            <dt class="col-sm-4 text-muted">
+                <i class="fas fa-tag text-primary" aria-hidden="true"></i> Series
+            </dt>
+            <dd class="col-sm-8">
+                <?= htmlspecialchars($carData->series ?? '', ENT_QUOTES, 'UTF-8') ?>
+                <?= !empty($carData->variant) ? ' - ' . htmlspecialchars($carData->variant, ENT_QUOTES, 'UTF-8') : '' ?>
+            </dd>
+
+            <dt class="col-sm-4 text-muted">
+                <i class="fas fa-car text-primary" aria-hidden="true"></i> Type
+            </dt>
+            <dd class="col-sm-8">
+                <?= $carData->type ? htmlspecialchars($carData->type, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
+            </dd>
+
+            <dt class="col-sm-4 text-muted">
+                <i class="fas fa-barcode text-primary" aria-hidden="true"></i> Chassis
+            </dt>
+            <dd class="col-sm-8">
+                <strong><?= $carData->chassis ? htmlspecialchars($carData->chassis, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?></strong>
+                <?php if (!empty($carData->chassis_override)): ?>
+                    <span class="badge bg-warning text-dark ms-1">
+                        <i class="fas fa-exclamation-triangle" aria-hidden="true"></i> Validation Override
+                    </span>
+                <?php endif; ?>
+            </dd>
+        </dl>
+
+        <hr>
+
+        <!-- Appearance & Technical -->
+        <h6 class="<?= $_subHeadingClass ?>">
+            <i class="fas fa-palette text-secondary" aria-hidden="true"></i> Appearance & Technical
+        </h6>
+        <dl class="row mb-4">
+            <dt class="col-sm-4 text-muted">Color</dt>
+            <dd class="col-sm-8">
+                <?= $carData->color ? htmlspecialchars($carData->color, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
+            </dd>
+
+            <dt class="col-sm-4 text-muted">Engine</dt>
+            <dd class="col-sm-8">
+                <?= $carData->engine ? htmlspecialchars($carData->engine, ENT_QUOTES, 'UTF-8') : '<em class="text-muted">Not specified</em>' ?>
+            </dd>
+        </dl>
+
+        <hr>
+
+        <!-- Ownership & History -->
+        <h6 class="<?= $_subHeadingClass ?>">
+            <i class="fas fa-history text-secondary" aria-hidden="true"></i> Ownership & History
+        </h6>
+        <dl class="row mb-4">
+            <?php if ($purchaseDate) { ?>
+            <dt class="col-sm-4 text-muted">Purchase Date</dt>
+            <dd class="col-sm-8"><?= $purchaseDate->format('F j, Y') ?></dd>
+            <?php } ?>
+
+            <?php if ($soldDate) { ?>
+            <dt class="col-sm-4 text-muted">Sold Date</dt>
+            <dd class="col-sm-8"><?= $soldDate->format('F j, Y') ?></dd>
+            <?php } ?>
+
+            <?php if (!empty($carData->website) && in_array(strtolower((string)parse_url($carData->website, PHP_URL_SCHEME)), ['http', 'https'], true)) { ?>
+            <dt class="col-sm-4 text-muted">Website</dt>
+            <dd class="col-sm-8">
+                <a href="<?= htmlspecialchars($carData->website, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">
+                    <i class="fas fa-external-link-alt" aria-hidden="true"></i> Visit Website
+                </a>
+            </dd>
+            <?php } ?>
+        </dl>
+
+        <?php if (!empty($carData->comments)) { ?>
+        <hr>
+        <h6 class="<?= $_subHeadingClass ?>">
+            <i class="fas fa-comment text-secondary" aria-hidden="true"></i> Owner Comments
+        </h6>
+        <div class="bg-light p-3 rounded">
+            <?= nl2br(htmlspecialchars($carData->comments, ENT_QUOTES, 'UTF-8')) ?>
+        </div>
+        <?php } ?>
+
+        <!-- Registry Information -->
+        <hr>
+        <div class="row text-center">
+            <div class="col-6">
+                <i class="fas fa-plus-circle text-success d-block mb-1" aria-hidden="true"></i>
+                <small class="text-muted d-block">Added to Registry</small>
+                <strong>
+                    <?= (new DateTime($carData->ctime))->format('M j, Y') ?>
+                </strong>
+            </div>
+            <div class="col-6">
+                <i class="fas fa-edit text-info d-block mb-1" aria-hidden="true"></i>
+                <small class="text-muted d-block">Last Updated</small>
+                <strong>
+                    <?= (new DateTime($carData->mtime))->format('M j, Y') ?>
+                </strong>
+            </div>
+        </div>
+    </div>
+</div>

--- a/usersc/includes/partials/car_hero_actions.php
+++ b/usersc/includes/partials/car_hero_actions.php
@@ -1,0 +1,72 @@
+<?php
+if (count(get_included_files()) == 1) { die(); }
+
+$_baseUrl = htmlspecialchars($us_url_root, ENT_QUOTES, 'UTF-8');
+
+switch ($context) {
+    case 'owner_detail': ?>
+        <form method="POST" action="<?= $_baseUrl ?>app/cars/form.php" class="d-inline">
+            <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
+            <input type="hidden" name="action" value="updateCar" />
+            <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
+            <button class="btn btn-light btn-lg" type="submit">
+                <i class="fas fa-edit" aria-hidden="true"></i> Update Car
+            </button>
+        </form>
+        <?php break;
+
+    case 'admin_detail': ?>
+        <div class="alert alert-warning mb-2">
+            <i class="fas fa-shield-alt" aria-hidden="true"></i> <strong>Administrative Override:</strong>
+            You are editing a car that you do not own using Administrator/Editor privileges.
+        </div>
+        <form method="POST" action="<?= $_baseUrl ?>app/cars/form.php" class="d-inline me-2">
+            <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
+            <input type="hidden" name="action" value="updateCar" />
+            <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
+            <input type="hidden" name="admin_override" value="1" />
+            <button class="btn btn-warning btn-lg" type="submit">
+                <i class="fas fa-edit" aria-hidden="true"></i> Admin Edit Car
+            </button>
+        </form>
+        <form method="POST" action="<?= $_baseUrl ?>app/contact/owner.php" class="d-inline">
+            <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
+            <input type="hidden" name="action" value="contact_owner" />
+            <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
+            <button class="btn btn-light btn-lg" type="submit">
+                <i class="fas fa-envelope" aria-hidden="true"></i> Contact Owner
+            </button>
+        </form>
+        <?php break;
+
+    case 'visitor_detail': ?>
+        <form method="POST" action="<?= $_baseUrl ?>app/contact/owner.php" class="d-inline">
+            <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
+            <input type="hidden" name="action" value="contact_owner" />
+            <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
+            <button class="btn btn-light btn-lg" type="submit">
+                <i class="fas fa-envelope" aria-hidden="true"></i> Contact Owner
+            </button>
+        </form>
+        <?php break;
+
+    case 'guest_detail': ?>
+        <a href="<?= $_baseUrl ?>users/login.php" class="btn btn-outline-light btn">
+            <i class="fas fa-sign-in-alt me-1" aria-hidden="true"></i> Log in to contact owner
+        </a>
+        <?php break;
+
+    case 'owner_account': ?>
+        <form method="POST" action="<?= $_baseUrl ?>app/cars/form.php" class="d-inline me-2">
+            <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
+            <input type="hidden" name="action" value="updateCar" />
+            <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
+            <button class="btn btn-light btn-lg" type="submit">
+                <i class="fas fa-edit" aria-hidden="true"></i> Update Car
+            </button>
+        </form>
+        <a class="btn btn-outline-light btn-lg" role="button" href="<?= $_baseUrl ?>app/cars/details.php?car_id=<?= $heroCarId ?>">
+            <i class="fas fa-eye" aria-hidden="true"></i> View Details
+        </a>
+        <?php break;
+}

--- a/z_us_root.php
+++ b/z_us_root.php
@@ -6,7 +6,7 @@
  * Determines the root URL for Userspice and redirects to it.
  * Used for path resolution and navigation consistency.
  */
-$path = ['', 'users/', 'usersc/', 'app/', 'app/admin/scripts/fix/', 'app/admin/scripts/maintenance/', 'app/admin/verify/', 'app/cars/', 'app/contact/', 'app/reports/', 'app/reports/api/', 'app/cars/actions/', 'app/admin/', 'app/admin/includes/', 'app/admin/includes/system/', 'error/', 'docs/', 'docs/admin/', 'docs/guides/', 'docs/reference/', 'docs/stories/', 'docs/stories/brian_walton/', 'docs/stories/SGO_2F/'];
+$path = ['', 'users/', 'usersc/', 'app/', 'app/admin/scripts/fix/', 'app/admin/scripts/maintenance/', 'app/admin/verify/', 'app/cars/', 'app/contact/', 'app/reports/', 'app/reports/api/', 'app/cars/actions/', 'app/admin/', 'app/admin/includes/', 'app/admin/includes/system/', 'error/', 'docs/', 'docs/admin/', 'docs/guides/', 'docs/reference/', 'docs/stories/', 'docs/stories/brian_walton/', 'docs/stories/SGO_2F/', 'usersc/includes/partials/'];
 // Only add or remove values in the $path variable separated by commas above
 
 $abs_us_root = Server::get('DOCUMENT_ROOT');


### PR DESCRIPTION
## Summary

- Creates three PHP partials under `usersc/includes/partials/`: `car_hero_actions.php`, `_vehicle_info_card.php`, and `_factory_data_card.php`
- Replaces ~240 lines of inline HTML in `app/cars/details.php` with three `include` calls
- The new `usersc/account.php` (#923) can adopt these partials directly with `$headingTag = 'h4'`

## Security fixes included

- `$headingTag` whitelist guard (`in_array(['h1'…'h6'])`) in both card partials
- `$us_url_root` pre-escaped as `$_baseUrl` in the hero actions partial
- `json_encode()` for the JS `img_root` assignment (was bare string concatenation into a JS literal)
- `(int)` cast for all `$carData->id` and `user_id` output points

## Accessibility fixes (#924)

- `aria-hidden="true"` added to all decorative Font Awesome `<i>` icons in the hero buttons
- Guest "Log in to contact owner" button corrected from `btn-sm` to `btn`

## Test plan

- [ ] 962/962 unit tests pass (verified in pre-commit hook)
- [ ] PHPStan passes (verified in pre-commit hook)
- [ ] Manual: hero buttons show correct set for owner / admin / visitor / guest roles
- [ ] Manual: Vehicle Info card renders with series+variant, chassis override badge, registry dates
- [ ] Manual: Factory Data card shown when data exists, absent when null; build date row omitted when null
- [ ] Manual: website link appears for http/https only; Owner Comments section absent when empty
- [ ] Manual: no visual regression vs pre-change on `details.php`

Closes #924, Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kLk37X98cmJDVKDeGQNup