### PR TITLE
fix: improve FilePond error recovery when existing car images fail to load

### DIFF
--- a/app/cars/edit.php
+++ b/app/cars/edit.php
@@ -517,15 +517,35 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
                 if (data == null || data.success !== true) {
                     return;
                 }
-                // Chain serially so FilePond receives files in server-defined order
+                // Chain serially so FilePond receives files in server-defined order.
+                // Per-item .catch() absorbs individual load failures; imageLoadErrors is
+                // tallied and a summary banner is shown after all addFile() calls settle.
+                var imageLoadErrors = 0;
                 data.images.reduce(function(chain, img) {
                     return chain.then(function() {
                         return pond.addFile(img.path, {
                             type: 'local',
                             metadata: { serverFilename: img.basename }
+                        }).catch(function(err) {
+                            console.error('[edit.php] Photo could not be loaded:', img.basename, err);
+                            imageLoadErrors++;
                         });
                     });
-                }, Promise.resolve());
+                }, Promise.resolve()).then(function() {
+                    if (imageLoadErrors > 0) {
+                        var isSingular = imageLoadErrors === 1;
+                        var noun       = isSingular ? 'photo' : 'photos';
+                        var itemStr    = isSingular ? 'the failed item' : 'failed items';
+                        $('#message').removeClass('d-none').html(
+                            '<div class="alert alert-warning"><i class="fas fa-exclamation-circle me-1" aria-hidden="true"></i>' +
+                            imageLoadErrors + ' ' + noun + ' could not be loaded. ' +
+                            'You can remove ' + itemStr + ' and continue editing, ' +
+                            'or submit to save your other changes.</div>'
+                        );
+                    }
+                }).catch(function(summaryErr) {
+                    console.error('[edit.php] Error showing image-load summary:', summaryErr);
+                });
             }).catch(function() {
                 $('#message').removeClass('d-none').html(
                     '<div class="alert alert-warning">Existing photos could not be loaded. ' +
@@ -558,29 +578,29 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
             }
         });
 
-        // Clear file-level errors when a new file is added
-        pond.on('addfile', function() {
-            $('#message').addClass('d-none');
+        // Clear file-level errors when a new file is added successfully
+        pond.on('addfile', function(error) {
+            if (!error) {
+                $('#message').addClass('d-none');
+            }
         });
 
-        document.getElementById('submit').addEventListener('click', function(e) {
+        const submitBtn = document.getElementById('submit');
+        submitBtn.addEventListener('click', function(e) {
             e.stopPropagation();
             e.preventDefault();
 
-            const btn = document.getElementById('submit');
-
-            const pondHasErrors = pond.getFiles().some(function(item) {
-                return item.status === FilePond.FileStatus.LOAD_ERROR ||
-                       item.status === FilePond.FileStatus.PROCESSING_ERROR;
+            const pondHasProcessingErrors = pond.getFiles().some(function(item) {
+                return item.status === FilePond.FileStatus.PROCESSING_ERROR;
             });
 
-            if (pondHasErrors) {
-                $('#message').removeClass('d-none').html('<div class="alert alert-primary">Error: One or more photos have errors. Please remove them and try again.</div>');
+            if (pondHasProcessingErrors) {
+                $('#message').removeClass('d-none').html('<div class="alert alert-danger">Error: One or more photos failed to upload. Please remove them and try again.</div>');
                 return;
             }
 
-            btn.disabled = true;
-            btn.textContent = 'Saving\u2026';
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Saving\u2026';
 
             // Only process new files — LOCAL files (already on server) don't need
             // client-side transform before submit; processing them caused the slow-save regression.
@@ -589,19 +609,16 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
                 .map(function(item) { return item.id; });
 
             const handleProcessError = function(err) {
-                console.error('[form.php] Photo processing error:', err);
+                console.error('[edit.php] Photo processing error:', err);
                 $('#message').removeClass('d-none').html('<div class="alert alert-danger">An error occurred processing the photos. Please try again.</div>');
-                btn.disabled = false;
-                btn.textContent = btn.dataset.label;
+                submitBtn.disabled = false;
+                submitBtn.textContent = submitBtn.dataset.label;
             };
 
-            if (newFileIds.length > 0) {
-                pond.processFiles(newFileIds).then(function() {
-                    return submitCarForm();
-                }).catch(handleProcessError);
-            } else {
-                submitCarForm().catch(handleProcessError);
-            }
+            const submission = newFileIds.length > 0
+                ? pond.processFiles(newFileIds).then(submitCarForm)
+                : submitCarForm();
+            submission.catch(handleProcessError);
         });
 
         async function submitCarForm() {
@@ -657,15 +674,13 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
                 if (data.success === true) {
                     window.location = '<?= $us_url_root ?>app/cars/details.php?car_id=' + data.cardetails.id;
                 } else {
-                    const btn = document.getElementById('submit');
-                    btn.disabled = false;
-                    btn.textContent = btn.dataset.label;
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = submitBtn.dataset.label;
                     displayValidationErrors(data);
                 }
             } catch (err) {
-                const btn = document.getElementById('submit');
-                btn.disabled = false;
-                btn.textContent = btn.dataset.label;
+                submitBtn.disabled = false;
+                submitBtn.textContent = submitBtn.dataset.label;
                 $('#message').removeClass('d-none').html('<div class="alert alert-danger">An error occurred. Please try again.</div>');
             }
         }

--- a/tests/playwright/filepond-load-error.test.js
+++ b/tests/playwright/filepond-load-error.test.js
@@ -1,0 +1,143 @@
+// tests/playwright/filepond-load-error.test.js
+//
+// Regression tests for issue #755: FilePond image load errors during edit-mode
+// hydration caused a full-form lockout (submit disabled, no per-file feedback).
+//
+// Fix: Per-file .catch() in the hydration chain absorbs individual load errors,
+// shows a non-blocking banner, and preserves submit button state. The submit
+// handler no longer blocks on LOAD_ERROR (only PROCESSING_ERROR blocks).
+//
+// What these tests verify:
+//   - Error banner appears when an existing image fails to load (not a full lockout)
+//   - Submit button remains enabled after a photo load failure
+//   - Removing the failed photo item leaves the form in a submittable state
+//
+// Strategy: page.route() intercepts the edit.php HTML response to inject a
+// fake car_id (no real MAMP car required), mocks the fetchImages API to return
+// one fake image path, and aborts the image fetch so FilePond gets a LOAD_ERROR.
+//
+// Requires local MAMP at http://localhost:9999/elan-registry
+
+const { test, expect } = require('@playwright/test');
+const { ensureLoggedIn } = require('./auth-helper.js');
+
+const FAKE_IMAGE_FILENAME = 'fake-image-filepond-755.jpg';
+
+const FETCH_IMAGES_RESPONSE = JSON.stringify({
+    success: true,
+    images: [{
+        path: FAKE_IMAGE_FILENAME,
+        basename: FAKE_IMAGE_FILENAME,
+        size: 1234,
+        type: 'image/jpeg',
+    }]
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Navigate to the edit-car form with a fake car_id injected into the HTML
+ * and a mocked fetchImages API response that returns one image entry.
+ * The image fetch itself is NOT mocked here — each test provides its own route.
+ * Returns false if an authenticated session is not active.
+ */
+async function gotoEditFormWithFakeImages(page) {
+    // Intercept the HTML response and inject a fake car_id so the hydration
+    // block fires without needing a real car in the database.
+    // route.fetch() bypasses route handlers, so there is no re-entry loop.
+    await page.route('**/app/cars/edit.php', async (route) => {
+        const response = await route.fetch();
+        const rawBody = await response.text();
+        const modifiedBody = rawBody.replace('var car_id = null;', 'var car_id = 9999;');
+        await route.fulfill({
+            status: response.status(),
+            contentType: 'text/html; charset=utf-8',
+            headers: Object.fromEntries(
+                Object.entries(response.headers()).filter(
+                    ([k]) => k !== 'content-encoding' && k !== 'content-length'
+                )
+            ),
+            body: modifiedBody,
+        });
+    });
+
+    // Mock any fetchImages POST to return one fake image entry (the HTML
+    // interceptor ensures only car_id 9999 reaches this point in tests).
+    await page.route('**/app/cars/actions/edit.php', async (route, request) => {
+        const post = request.postData() || '';
+        if (post.includes('fetchImages')) {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: FETCH_IMAGES_RESPONSE,
+            });
+        } else {
+            await route.continue();
+        }
+    });
+
+    await page.goto('app/cars/edit.php', { waitUntil: 'domcontentloaded' });
+
+    const url = page.url();
+    const bodyText = await page.textContent('body').catch(() => '');
+    if (url.includes('login') || bodyText.includes('Please Log In')) {
+        return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('FilePond load error recovery (#755)', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await ensureLoggedIn(page);
+    });
+
+    test('error banner appears when an existing photo fails to load', async ({ page }) => {
+        await page.route('**/' + FAKE_IMAGE_FILENAME, (route) => route.abort());
+
+        const ready = await gotoEditFormWithFakeImages(page);
+        if (!ready) {
+            test.skip(true, 'Authenticated session required');
+        }
+
+        await expect(page.locator('#message .alert-warning')).toBeVisible({ timeout: 8000 });
+        await expect(page.locator('#message .alert-warning')).toContainText('could not be loaded');
+    });
+
+    test('submit button remains enabled after a photo load failure', async ({ page }) => {
+        await page.route('**/' + FAKE_IMAGE_FILENAME, (route) => route.abort());
+
+        const ready = await gotoEditFormWithFakeImages(page);
+        if (!ready) {
+            test.skip(true, 'Authenticated session required');
+        }
+
+        await expect(page.locator('#message .alert-warning')).toBeVisible({ timeout: 8000 });
+        await expect(page.locator('#message .alert-warning')).toContainText('could not be loaded');
+        await expect(page.locator('#submit')).toBeEnabled();
+    });
+
+    test('removing the failed photo item leaves the form submittable', async ({ page }) => {
+        await page.route('**/' + FAKE_IMAGE_FILENAME, (route) => route.abort());
+
+        const ready = await gotoEditFormWithFakeImages(page);
+        if (!ready) {
+            test.skip(true, 'Authenticated session required');
+        }
+
+        await expect(page.locator('#message .alert-warning')).toBeVisible({ timeout: 8000 });
+
+        const removeBtn = page.locator('.filepond--action-remove-item').first();
+        await expect(removeBtn).toBeVisible({ timeout: 5000 });
+        await removeBtn.click();
+
+        await expect(page.locator('#submit')).toBeEnabled();
+    });
+
+});


### PR DESCRIPTION
## Summary

- Per-file `.catch()` in the hydration chain absorbs individual load failures instead of aborting the entire chain; a non-blocking `alert-warning` banner shows how many photos failed to load
- Submit button no longer blocked on `LOAD_ERROR` — only `PROCESSING_ERROR` blocks submission (LOAD_ERROR LOCAL files retain their `serverFilename` metadata and are safe to submit)
- Summary `.then()` isolated with its own `.catch()` so a DOM/jQuery error inside the banner logic cannot trigger the API-failure lockout path
- Playwright regression tests added (`tests/playwright/filepond-load-error.test.js`)

## Bug Escape Analysis

**Root cause:** The hydration `reduce()` chain had no per-file error handling. One rejected `pond.addFile()` caused the entire chain to reject, which fell through to the outer `.catch()` — an error handler intended for `fetchImages` API failures — which disabled the submit button and showed a generic "refresh the page" message.

**Testing gap:** No Playwright test existed for edit-mode hydration with a failing image fetch. The condition only triggered in edit mode with an existing car that had images, and only when one of those image fetches failed at network level — not covered by any unit or integration test.

**Preventive tests added:** Three Playwright tests using `page.route()` HTML injection (no real MAMP car required): error banner appears, submit stays enabled, remove-then-submit works.

## Related

Closes #755
Tracked separately: #1031 (pre-existing `data.success !== true` silent no-op and outer catch missing error logging — surfaced during #755 review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kLk37X98cmJDVKDeGQNup