### PR TITLE
feat: chassis override indicator and filter in Invalid Chassis Numbers table

### DIFF
--- a/app/admin/includes/tab-manage_cars.php
+++ b/app/admin/includes/tab-manage_cars.php
@@ -153,7 +153,7 @@ function getDataQualityReports(object $db): array {
     // Report 2: Invalid Chassis Numbers (using centralized validator)
     $invalidChassisData = [];
     $chassisCheckQ = $db->query("
-        SELECT c.id, c.model, c.series, c.year, c.chassis, c.mtime,
+        SELECT c.id, c.model, c.series, c.year, c.chassis, c.chassis_override, c.mtime,
                u.id as user_id, u.fname, u.lname, u.email
         FROM cars c
         LEFT JOIN car_user cu ON c.id = cu.car_id
@@ -399,6 +399,10 @@ $qualityScore = $totalCars > 0 ? max(0, 100 - (($carIssues / $totalCars) * 100))
                                         <li>Historical documentation supports the unusual chassis format</li>
                                     </ul>
                                 </div>
+                                <div class="form-check mb-2">
+                                    <input class="form-check-input" type="checkbox" id="hide_overridden_chassis">
+                                    <label class="form-check-label" for="hide_overridden_chassis">Hide cars with override set</label>
+                                </div>
                                 <div class="table-responsive">
                                     <table class="table table-hover">
                                         <thead class="thead-light">
@@ -407,14 +411,17 @@ $qualityScore = $totalCars > 0 ? max(0, 100 - (($carIssues / $totalCars) * 100))
                                                 <th>Model</th>
                                                 <th>Year</th>
                                                 <th>Chassis</th>
+                                                <th>Override</th>
                                                 <th>Validation Error</th>
                                                 <th>Owner</th>
                                                 <th>Actions</th>
                                             </tr>
                                         </thead>
-                                        <tbody>
-                                            <?php foreach ($report['data'] as $car) { ?>
-                                            <tr>
+                                        <tbody id="invalid-chassis-tbody">
+                                            <?php foreach ($report['data'] as $car) {
+                                                $chassisOverride = (int)($car->chassis_override ?? 0);
+                                            ?>
+                                            <tr data-override="<?= $chassisOverride ?>">
                                                 <td>
                                                     <button class="btn btn-sm btn-outline-primary" onclick="openCarDetails(<?= $car->id ?>)">
                                                         <i class="fas fa-eye"></i> <?= $car->id ?>
@@ -423,6 +430,11 @@ $qualityScore = $totalCars > 0 ? max(0, 100 - (($carIssues / $totalCars) * 100))
                                                 <td><?= htmlspecialchars($car->model) ?></td>
                                                 <td><?= $car->year ?></td>
                                                 <td><code class="text-danger"><?= htmlspecialchars($car->chassis) ?></code></td>
+                                                <td class="text-center">
+                                                    <?php if ($chassisOverride === 1) { ?>
+                                                        <i class="fas fa-check-circle text-success" title="Validation override set" aria-label="Validation override set"></i>
+                                                    <?php } ?>
+                                                </td>
                                                 <td>
                                                     <small class="text-danger">
                                                         <i class="fas fa-exclamation-triangle"></i>
@@ -454,9 +466,30 @@ $qualityScore = $totalCars > 0 ? max(0, 100 - (($carIssues / $totalCars) * 100))
                                                 </td>
                                             </tr>
                                             <?php } ?>
+                                            <tr id="invalid-chassis-no-results" class="d-none">
+                                                <td colspan="8" class="text-center text-muted py-3">No cars match the current filter.</td>
+                                            </tr>
                                         </tbody>
                                     </table>
                                 </div>
+                                <script>
+                                (function() {
+                                    const cb    = document.getElementById('hide_overridden_chassis');
+                                    const tbody = document.getElementById('invalid-chassis-tbody');
+                                    const empty = document.getElementById('invalid-chassis-no-results');
+                                    if (!cb || !tbody || !empty) return;
+                                    cb.addEventListener('change', function() {
+                                        const hide = cb.checked;
+                                        let visible = 0;
+                                        tbody.querySelectorAll('tr[data-override]').forEach(function(tr) {
+                                            const shouldHide = hide && tr.getAttribute('data-override') === '1';
+                                            tr.classList.toggle('d-none', shouldHide);
+                                            if (!shouldHide) visible++;
+                                        });
+                                        empty.classList.toggle('d-none', visible > 0);
+                                    });
+                                })();
+                                </script>
                             <?php } else { ?>
                                 <!-- Data table for other reports -->
                                 <div class="table-responsive">

--- a/docs/releases/RELEASE_NOTES_v2.25.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.1.md
@@ -30,6 +30,10 @@
 
 - **Misleading rollback log on successful owner updates** ([#928](https://github.com/unibrain1/elanregistry/issues/928)): `ElanRegistryOwner::update()` and `create()` no longer log "Owner update failed" / "Owner creation failed" when a post-commit reload throws. The post-commit `find()` and success-logger calls now run outside the transaction's try/catch block, so the data-was-saved state is correctly reflected even when the reload fails. Also fixes a no-op `ROLLBACK` issued after a successful `COMMIT` in the same case.
 
+### New Features
+
+- **Chassis override indicator and filter** ([#1020](https://github.com/unibrain1/elanregistry/issues/1020)): Invalid Chassis Numbers table now shows a check icon for cars with the chassis override flag set, and includes a "Hide cars with override set" checkbox to filter them out — making triage faster by distinguishing cars already handled from those still needing attention.
+
 ### Improvements
 
 - **Local Playwright test suite fully restored** ([#881](https://github.com/unibrain1/elanregistry/issues/881)): Fixed broken local MAMP config (`elan_registry` typo, leading-slash `goto` calls), updated all test files to work against the local dev environment, converted TypeScript security specs to JavaScript to eliminate Node.js DEP0205 deprecation warnings, upgraded `@playwright/test` from 1.56 to 1.61.1 (also resolves residual DEP0205 from Playwright's own TypeScript loader on Node 26) and downgraded `dotenv` from 17 to 16 (also triggered DEP0205). 118 tests pass; 35 skip gracefully (E2E tests that target production environments, and authenticated tests that skip when `.env.local` credentials are absent).
@@ -45,3 +49,4 @@
 - [#925](https://github.com/unibrain1/elanregistry/issues/925) — refactor: extract shared car display card partials (vehicle info, factory data)
 - [#928](https://github.com/unibrain1/elanregistry/issues/928) — bug: ElanRegistryOwner::update() broad catch wraps post-commit find() causing misleading rollback log
 - [#1019](https://github.com/unibrain1/elanregistry/issues/1019) — ux: standardize validation error display across all three error mechanisms
+- [#1020](https://github.com/unibrain1/elanregistry/issues/1020) — admin: show chassis override indicator and add filter to Invalid Chassis Numbers table


### PR DESCRIPTION
## Summary

- Adds `chassis_override` column to the Invalid Chassis Numbers SQL query (was missing from the SELECT)
- Inserts an **Override** column between Chassis and Validation Error; rows with `chassis_override = 1` render a `fas fa-check-circle text-success` icon
- Adds a `data-override` attribute on each `<tr>` for client-side filtering
- Adds a **"Hide cars with override set"** checkbox above the table; checking it hides overridden rows instantly via a vanilla-JS IIFE and shows a "No results" empty state when all rows are hidden

## Test plan

- [ ] Load `manage-consolidated.php?tab=manage-cars` — Invalid Chassis Numbers section renders with new Override column
- [ ] Rows with `chassis_override = 1` show check icon; rows without it show empty cell
- [ ] Check "Hide cars with override set" — overridden rows disappear, non-overridden rows remain; if all rows are overridden, "No cars match the current filter" message appears
- [ ] Uncheck — all rows restore without page reload
- [ ] "Edit" button on a visible row opens the car details modal correctly (regression guard)
- [ ] 962 unit tests pass (confirmed locally)

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kLk37X98cmJDVKDeGQNup