### PR TITLE
security: remove GET action fallback and harden CSRF guard in schema-operations.php

### DIFF
--- a/app/admin/includes/system/schema-operations.php
+++ b/app/admin/includes/system/schema-operations.php
@@ -18,7 +18,9 @@ if (!securePage($php_self)) {
 }
 
 if ($method !== 'POST') {
-    ApiResponse::error('POST method required')->send();
+    ApiResponse::error('POST method required')
+        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'schema-operations: rejected non-POST request (method: ' . $method . ')')
+        ->send();
 }
 
 if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
@@ -129,7 +131,7 @@ try {
                     ->withDataArray([
                         'operations' => $result['operations'],
                         'backup_created' => $result['backup_created'],
-                        'backup_path' => isset($result['backup_path']) ? basename($result['backup_path']) : null,
+                        'backup_path' => (isset($result['backup_path']) && $result['backup_path'] !== '') ? basename($result['backup_path']) : null,
                         'validation_issues' => $result['validation_issues'] ?? []
                     ])
                     ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_DATABASE_MAINTENANCE, $message)
@@ -139,7 +141,7 @@ try {
                     ->withDataArray([
                         'operations' => $result['operations'],
                         'backup_created' => $result['backup_created'],
-                        'backup_path' => isset($result['backup_path']) ? basename($result['backup_path']) : null,
+                        'backup_path' => (isset($result['backup_path']) && $result['backup_path'] !== '') ? basename($result['backup_path']) : null,
                         'validation_issues' => $result['validation_issues'] ?? []
                     ])
                     ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_DATABASE_MAINTENANCE, $message)
@@ -153,7 +155,7 @@ try {
 
 } catch (Exception $e) {
     // Log full error details server-side; generic message returned to client
-    $errorDetails = "Schema operation '" . ($action ?? 'unknown') . "' failed for user " . ($user->data()->username ?? 'unknown') . "\n";
+    $errorDetails = "Schema operation '" . ($action ?? 'unknown') . "' failed [" . get_class($e) . "] for user " . ($user->data()->username ?? 'unknown') . "\n";
     $errorDetails .= "Error: " . $e->getMessage() . "\n";
     $errorDetails .= "File: " . $e->getFile() . " (Line " . $e->getLine() . ")\n";
     $errorDetails .= "Stack trace:\n" . $e->getTraceAsString();

--- a/app/admin/includes/system/schema-operations.php
+++ b/app/admin/includes/system/schema-operations.php
@@ -17,19 +17,18 @@ if (!securePage($php_self)) {
         ->send();
 }
 
-// CSRF protection for all POST operations
-if ($method === 'POST' && (!isset($_POST['csrf']) || !Token::check($_POST['csrf']))) {
+if ($method !== 'POST') {
+    ApiResponse::badRequest('POST method required')->send();
+}
+
+if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
     ApiResponse::forbidden('Invalid CSRF token')
         ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in schema operations')
         ->send();
 }
 
-// Set content type for JSON responses
-header('Content-Type: application/json');
-
 try {
-    $action = preg_replace('/[^\w\-]/', '', $_POST['action'] ?? $_GET['action'] ?? '') ?? '';
-    $action = $action ?: null;
+    $action = preg_replace('/[^\w\-]/', '', $_POST['action'] ?? '') ?: null;
 
     if (!$action) {
         throw new SchemaException('No action specified');
@@ -120,11 +119,6 @@ try {
             break;
 
         case 'perform_maintenance':
-            // CSRF token check for destructive operations
-            if (!Token::check($_POST['csrf'] ?? '')) {
-                throw new SchemaException('Invalid CSRF token');
-            }
-
             $result = $schemaManager->performMaintenance();
             $message = $result['success']
                 ? 'Schema maintenance completed successfully'
@@ -135,7 +129,7 @@ try {
                     ->withDataArray([
                         'operations' => $result['operations'],
                         'backup_created' => $result['backup_created'],
-                        'backup_path' => $result['backup_path'] ?? null,
+                        'backup_path' => isset($result['backup_path']) ? basename($result['backup_path']) : null,
                         'validation_issues' => $result['validation_issues'] ?? []
                     ])
                     ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_DATABASE_MAINTENANCE, $message)
@@ -145,7 +139,7 @@ try {
                     ->withDataArray([
                         'operations' => $result['operations'],
                         'backup_created' => $result['backup_created'],
-                        'backup_path' => $result['backup_path'] ?? null,
+                        'backup_path' => isset($result['backup_path']) ? basename($result['backup_path']) : null,
                         'validation_issues' => $result['validation_issues'] ?? []
                     ])
                     ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_DATABASE_MAINTENANCE, $message)

--- a/app/admin/includes/system/schema-operations.php
+++ b/app/admin/includes/system/schema-operations.php
@@ -18,7 +18,7 @@ if (!securePage($php_self)) {
 }
 
 if ($method !== 'POST') {
-    ApiResponse::badRequest('POST method required')->send();
+    ApiResponse::error('POST method required')->send();
 }
 
 if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {

--- a/docs/releases/RELEASE_NOTES_v2.25.2.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.2.md
@@ -1,0 +1,31 @@
+# Elan Registry v2.25.2 Release Notes
+
+**Release Date:** [DATE]
+**Type:** Patch Release - Security & Critical Bugs
+
+## Required Actions After Deployment
+
+None.
+
+## User-Facing Changes
+
+### Improvements
+
+- **Transfer request rate limiting** ([#973](https://github.com/unibrain1/elanregistry/issues/973)): Transfer request and owner contact email endpoints now enforce rate limits to prevent inbox flooding.
+
+## Admin-Facing Changes
+
+### Improvements
+
+- **Quality score consistency** ([#961](https://github.com/unibrain1/elanregistry/issues/961)): Quality score in the owner management tab now matches the score shown on the owner profile page.
+- **Correct error status codes** ([#981](https://github.com/unibrain1/elanregistry/issues/981)): Admin owner-info and owner-profile includes now return HTTP 400/404 on validation errors instead of 200.
+
+## Issues Resolved
+
+- [#942](https://github.com/unibrain1/elanregistry/issues/942) — Fix inconsistent DB update signature in ElanRegistryOwner::updateLocation()
+- [#943](https://github.com/unibrain1/elanregistry/issues/943) — ElanRegistryOwner website validation silently mutates input instead of rejecting it
+- [#961](https://github.com/unibrain1/elanregistry/issues/961) — fix: quality score calculation diverges between tab-owner_mgmt.php and ElanRegistryOwner class
+- [#972](https://github.com/unibrain1/elanregistry/issues/972) — security: add explicit isLoggedIn() guard to edit.php AJAX endpoint
+- [#973](https://github.com/unibrain1/elanregistry/issues/973) — security: add rate limiting to owner contact email, feedback, and transfer request endpoints
+- [#974](https://github.com/unibrain1/elanregistry/issues/974) — security: remove GET action fallback from schema-operations.php
+- [#981](https://github.com/unibrain1/elanregistry/issues/981) — fix: return correct HTTP status codes from load-owner-info and load-owner-profile on validation errors


### PR DESCRIPTION
## Summary

- Rejects non-POST requests with HTTP 400 before any action processing
- Applies CSRF check unconditionally (was POST-only, allowing GET-based CSRF bypass)
- Removes `$_GET['action']` fallback so `action` is accepted from POST only
- Removes redundant per-action CSRF check inside `perform_maintenance`
- Strips server filesystem path from `backup_path` in JSON response (security finding: path disclosure)
- Removes dead `header('Content-Type: application/json')` superseded by `ApiResponse`

Closes #974

## Security findings addressed

| Severity | Finding | Fix |
|----------|---------|-----|
| CRITICAL | GET requests bypass CSRF guard entirely | Method check + unconditional CSRF guard |
| MEDIUM | `backup_path` exposes absolute server path in JSON | `basename()` strips directory prefix |
| LOW | Dead `header()` call after `ApiResponse` took over | Removed |

## Test plan

- [x] Unit tests pass (1068 tests, 4456 assertions)
- [x] PHPStan: no errors
- [x] phpcs: no blocking issues
- [x] Security review: no remaining findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy