### PR TITLE
security: add rate limiting to owner-contact, feedback, and transfer endpoints

### DIFF
--- a/app/cars/actions/request-transfer.php
+++ b/app/cars/actions/request-transfer.php
@@ -27,6 +27,11 @@ try {
         throw new CarTransferException('You must be logged in to request transfers');
     }
 
+    if (!checkRateLimit('transfer_request', $user->data()->id)) {
+        logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'request-transfer.php: rate limit exceeded from ' . $remote_addr);
+        throw new CarTransferException('Too many transfer requests. Please wait before trying again.');
+    }
+
     // Get and validate input
     $chassis = trim(Input::get('chassis'));
     $year = trim(Input::get('year'));

--- a/app/cars/actions/request-transfer.php
+++ b/app/cars/actions/request-transfer.php
@@ -29,8 +29,10 @@ try {
 
     if (!checkRateLimit('transfer_request', $user->data()->id)) {
         logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'request-transfer.php: rate limit exceeded from ' . $remote_addr);
+        recordRateLimit('transfer_request', false, (int)$user->data()->id);
         throw new CarTransferException('Too many transfer requests. Please wait before trying again.');
     }
+    recordRateLimit('transfer_request', true, (int)$user->data()->id);
 
     // Get and validate input
     $chassis = trim(Input::get('chassis'));

--- a/app/contact/send-feedback.php
+++ b/app/contact/send-feedback.php
@@ -60,7 +60,10 @@ if ($post_attempted) {
 
     if (!checkRateLimit('feedback_submission', $logUserId ?: null)) {
         logger($logUserId, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'send-feedback.php: rate limit exceeded from ' . $remote_addr);
+        recordRateLimit('feedback_submission', false, $logUserId ?: null);
         $errors[] = 'Too many submissions. Please wait before trying again.';
+    } else {
+        recordRateLimit('feedback_submission', true, $logUserId ?: null);
     }
 
     $email_to = getFeedbackEmail();

--- a/app/contact/send-feedback.php
+++ b/app/contact/send-feedback.php
@@ -57,6 +57,12 @@ if ($post_attempted) {
     }
 
     $logUserId = ($user->isLoggedIn() && $user->data()) ? (int)$user->data()->id : 0;
+
+    if (!checkRateLimit('feedback_submission', $logUserId ?: null)) {
+        logger($logUserId, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'send-feedback.php: rate limit exceeded from ' . $remote_addr);
+        $errors[] = 'Too many submissions. Please wait before trying again.';
+    }
+
     $email_to = getFeedbackEmail();
     $email_subject = "[ELANREGISTRY] Feedback";
 

--- a/app/contact/send-owner-email.php
+++ b/app/contact/send-owner-email.php
@@ -34,6 +34,12 @@ if ($post_attempted) {
         include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');
         exit;
     } else {
+        $senderId = ($user->isLoggedIn() && $user->data()) ? (int)$user->data()->id : null;
+        if (!checkRateLimit('owner_contact_email', $senderId)) {
+            logger($senderId ?? 0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'send-owner-email.php: rate limit exceeded from ' . $remote_addr);
+            $errors[] = 'Too many messages sent. Please wait before sending another.';
+        }
+
         $action = Input::get('action');
         $message = Input::raw('message'); // raw — _email_contact_owner.php escapes via EmailTemplate
         if ($action === 'send_message' && Input::get('to_user_id') && $message !== null && $message !== '') {

--- a/app/contact/send-owner-email.php
+++ b/app/contact/send-owner-email.php
@@ -37,7 +37,10 @@ if ($post_attempted) {
         $senderId = ($user->isLoggedIn() && $user->data()) ? (int)$user->data()->id : null;
         if (!checkRateLimit('owner_contact_email', $senderId)) {
             logger($senderId ?? 0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'send-owner-email.php: rate limit exceeded from ' . $remote_addr);
+            recordRateLimit('owner_contact_email', false, $senderId);
             $errors[] = 'Too many messages sent. Please wait before sending another.';
+        } else {
+            recordRateLimit('owner_contact_email', true, $senderId);
         }
 
         $action = Input::get('action');

--- a/docs/releases/RELEASE_NOTES_v2.25.2.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.2.md
@@ -1,0 +1,34 @@
+# Elan Registry v2.25.2 Release Notes
+
+**Release Date:** TBD
+**Type:** Patch Release - Security Hardening & Code Quality
+
+## Required Actions After Deployment
+
+None.
+
+## User-Facing Changes
+
+None in this release.
+
+## Admin-Facing Changes
+
+### Improvements
+
+- **Rate limiting for contact and transfer endpoints** ([#973](https://github.com/unibrain1/elanregistry/issues/973)): Owner-contact email, feedback form, and car transfer requests are now rate-limited to prevent abuse.
+- **Schema operations endpoint hardened** ([#974](https://github.com/unibrain1/elanregistry/issues/974)): Removed unsafe GET action fallback; CSRF check now unconditional; server paths no longer exposed in backup responses.
+- **Car edit endpoint authentication fix** ([#972](https://github.com/unibrain1/elanregistry/issues/972)): Added explicit login guard before CSRF check and replaced legacy token error include with structured API response.
+- **DB update call signature fix** ([#942](https://github.com/unibrain1/elanregistry/issues/942)): Fixed inconsistent argument order in `ElanRegistryOwner::updateLocation()` to match UserSpice DB API.
+- **Website URL validation cleanup** ([#943](https://github.com/unibrain1/elanregistry/issues/943)): Removed redundant pre-sanitization regex from URL validation, preventing false rejection of valid URLs.
+- **Unified quality score calculation** ([#961](https://github.com/unibrain1/elanregistry/issues/961)): Centralized duplicate quality score logic from 5 admin files into `ElanRegistryOwner` class methods.
+- **HTTP status codes for owner info endpoints** ([#981](https://github.com/unibrain1/elanregistry/issues/981)): `load-owner-info.php` and `load-owner-profile.php` now return proper 400/404 status codes on error.
+
+## Issues Resolved
+
+- [#942](https://github.com/unibrain1/elanregistry/issues/942) — Fix inconsistent DB update signature in ElanRegistryOwner::updateLocation()
+- [#943](https://github.com/unibrain1/elanregistry/issues/943) — Remove preg_replace pre-sanitization from website URL validation
+- [#961](https://github.com/unibrain1/elanregistry/issues/961) — Unify quality score calculation across admin files
+- [#972](https://github.com/unibrain1/elanregistry/issues/972) — Fix CSRF/auth ordering and structured error response in car edit endpoint
+- [#973](https://github.com/unibrain1/elanregistry/issues/973) — Add rate limiting to owner-contact email, feedback form, and transfer request
+- [#974](https://github.com/unibrain1/elanregistry/issues/974) — Remove GET action fallback and harden CSRF guard in schema-operations endpoint
+- [#981](https://github.com/unibrain1/elanregistry/issues/981) — Return proper HTTP status codes from owner info AJAX endpoints

--- a/usersc/includes/rate_limits.php
+++ b/usersc/includes/rate_limits.php
@@ -120,6 +120,32 @@ $rateLimits = [
         'total_window' => 3600
     ],
 
+    // Contact and communication
+    'owner_contact_email' => [
+        'user_max' => 5,
+        'user_window' => 3600,
+        'ip_max' => 10,
+        'ip_window' => 3600,
+        'total_max' => 20,
+        'total_window' => 3600,
+    ],
+
+    'feedback_submission' => [
+        'ip_max' => 10,
+        'ip_window' => 3600,
+        'total_max' => 50,
+        'total_window' => 3600,
+    ],
+
+    'transfer_request' => [
+        'user_max' => 3,
+        'user_window' => 3600,
+        'ip_max' => 5,
+        'ip_window' => 3600,
+        'total_max' => 20,
+        'total_window' => 3600,
+    ],
+
     // Development/testing - very lenient
     'diagnostics' => [
         'ip_max' => 100,


### PR DESCRIPTION
## Summary

- Adds `owner_contact_email`, `feedback_submission`, and `transfer_request` rate limit definitions to `usersc/includes/rate_limits.php`
- Guards `send-owner-email.php` with a null-safe user ID check and rate limit after CSRF passes
- Guards `send-feedback.php` with IP-only rate limiting for anonymous users, user+IP for authenticated
- Guards `request-transfer.php` with user+IP rate limiting after the auth check, using exception-based error handling consistent with the existing pattern
- All three failures log to `LOG_CATEGORY_ACCESS_DENIED` with the remote IP for audit trail

## Security Review

Security reviewed — all findings addressed:
- **HIGH**: Null-safe `$user->data()` pattern in `send-owner-email.php` (defense-in-depth against edge-case session state)
- **LOW**: Added `logger()` calls on all three rate limit failure paths

## Test plan

- [x] 912 unit tests pass
- [x] phpcs: 0 errors on changed files
- [x] PHPStan: no errors on changed files
- [x] Pre-commit hooks pass clean
- [ ] Manual: submit feedback form rapidly and verify rate limit kicks in
- [ ] Manual: send owner-contact email rapidly and verify rate limit kicks in
- [ ] Manual: submit transfer request rapidly and verify rate limit kicks in

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy