### PR TITLE
fix: use array-WHERE form in ElanRegistryOwner::updateLocation()

### DIFF
--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -480,7 +480,7 @@ class ElanRegistryOwner
         try {
             $this->_db->query("BEGIN");
 
-            if (!$this->_db->update($this->profileTableName, $this->_data->id, $updateFields, 'user_id')) {
+            if (!$this->_db->update($this->profileTableName, ['user_id' => $this->_data->id], $updateFields)) {
                 $this->_db->query("ROLLBACK");
                 logger($this->_data->id, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "updateLocation() DB update failed: " . $this->_db->errorString());
                 return false;


### PR DESCRIPTION
## Summary

- `updateLocation()` was calling `$this->_db->update($this->profileTableName, $this->_data->id, $updateFields, 'user_id')` — the 4-argument positional form
- The `profiles` table uses `user_id` as its lookup key, not `id`; if profile `id` ≠ `user_id` for any row, the old form would update the wrong row or none at all
- Changed to `$this->_db->update($this->profileTableName, ['user_id' => $this->_data->id], $updateFields)` — the array-WHERE form, consistent with `update()` at line 244

## Test plan

- [x] 912 unit tests pass
- [x] phpcs: 0 errors
- [x] PHPStan: no errors
- [ ] Manual: update location fields via the owner profile form and verify correct row is updated

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy