### PR TITLE
fix: remove preg_replace pre-sanitization from website URL validation

### DIFF
--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -625,21 +625,21 @@ class ElanRegistryOwner
 
                 case 'website':
                     if (!empty($value)) {
-                        $sanitized = preg_replace('/[^a-zA-Z0-9\-._~:\/?#\[\]@!$&\'()*+,;=%]/', '', trim($value));
-                        if (!filter_var($sanitized, FILTER_VALIDATE_URL)) {
+                        $trimmed = trim($value);
+                        if (!filter_var($trimmed, FILTER_VALIDATE_URL)) {
                             throw OwnerValidationException::withUserMessage(
                                 'Website URL must start with http:// or https:// (e.g. https://example.com)',
                                 'Website URL must start with http:// or https:// (e.g. https://example.com)'
                             );
                         }
-                        $scheme = strtolower((string) parse_url($sanitized, PHP_URL_SCHEME));
+                        $scheme = strtolower((string) parse_url($trimmed, PHP_URL_SCHEME));
                         if (!in_array($scheme, ['http', 'https'], true)) {
                             throw OwnerValidationException::withUserMessage(
                                 'Website URL must use http:// or https:// — other protocols are not allowed',
                                 'Website URL must use http:// or https:// — other protocols are not allowed'
                             );
                         }
-                        $validatedFields[$key] = $sanitized;
+                        $validatedFields[$key] = $trimmed;
                     }
                     break;
 


### PR DESCRIPTION
## Summary

- Removed the `preg_replace('/[^a-zA-Z0-9\-._~:\/.../', '', trim($value))` pre-sanitization from the `website` case in `ElanRegistryOwner::validateAndSanitizeFields()`
- Now validates `trim($value)` directly with `FILTER_VALIDATE_URL`, rejecting invalid URLs rather than silently stripping characters and storing a mutated string
- Consistent with `CarValidator::validateAndSanitizeFields()` which has always used direct validation
- Scheme check (`http`/`https` only) and empty-value passthrough are unchanged

**Before:** `"http://example.com spaces here"` → stripped to `"http://example.comspaceshere"` → passes FILTER_VALIDATE_URL → stored (wrong)  
**After:** `"http://example.com spaces here"` → fails FILTER_VALIDATE_URL → throws `OwnerValidationException`

## Test plan

- [x] 912 unit tests pass
- [x] phpcs: 0 errors
- [x] PHPStan: no errors
- [ ] Manual: submit owner profile with a URL containing embedded spaces — verify validation error, not silent mutation
- [ ] Manual: submit valid `https://example.com` — verify stored unchanged
- [ ] Manual: submit `ftp://example.com` — verify scheme rejection

Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy