### PR TITLE
refactor: centralize quality score and badge class in ElanRegistryOwner

### DIFF
--- a/app/admin/includes/load-owner-info.php
+++ b/app/admin/includes/load-owner-info.php
@@ -73,7 +73,7 @@ try {
                     <small>Cars Owned</small>
                 </div>
                 <div class="col-4">
-                    <h4 class="text-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>">
+                    <h4 class="text-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?>">
                         <?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag.taint-unsafe-echo-tag ?>%
                     </h4>
                     <small>Profile Quality</small>
@@ -107,15 +107,15 @@ try {
     </div>
 
     <!-- Data Quality Card -->
-    <div class="card border-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?> mb-3">
-        <div class="card-header bg-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?> text-white">
+    <div class="card border-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?> mb-3">
+        <div class="card-header bg-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?> text-white">
             <h6 class="mb-0">
                 <i class="fas fa-clipboard-check"></i> Data Quality
             </h6>
         </div>
         <div class="card-body">
             <div class="progress mb-2">
-                <div class="progress-bar bg-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>"
+                <div class="progress-bar bg-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?>"
                      style="width: <?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag.taint-unsafe-echo-tag ?>%">
                     <?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag.taint-unsafe-echo-tag ?>%
                 </div>

--- a/app/admin/includes/load-owner-profile.php
+++ b/app/admin/includes/load-owner-profile.php
@@ -59,7 +59,7 @@ try {
         <input type="hidden" name="csrf" value="<?= Token::generate() ?>">
 
         <!-- Profile Quality Indicator -->
-        <div class="alert alert-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?> mb-4">
+        <div class="alert alert-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?> mb-4">
             <div class="row align-items-center">
                 <div class="col-md-8">
                     <h6 class="mb-1">
@@ -73,7 +73,7 @@ try {
                 </div>
                 <div class="col-md-4 text-end">
                     <div class="progress" style="height: 8px;">
-                        <div class="progress-bar bg-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?>"
+                        <div class="progress-bar bg-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?>"
                              style="width: <?= (int)$qualityScore // nosemgrep: php.lang.security.taint-unsafe-echo-tag.taint-unsafe-echo-tag ?>%"></div>
                     </div>
                 </div>

--- a/app/admin/includes/tab-manage_cars.php
+++ b/app/admin/includes/tab-manage_cars.php
@@ -316,13 +316,13 @@ $qualityScore = $totalCars > 0 ? max(0, 100 - (($carIssues / $totalCars) * 100))
 <div class="row mb-4">
     <!-- Data Health Card -->
     <div class="col-lg-3 col-md-6 mb-3">
-        <div class="card border-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?> h-100">
+        <div class="card border-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?> h-100">
             <div class="card-body text-center">
-                <div class="text-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?> mb-3">
+                <div class="text-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?> mb-3">
                     <i class="fas fa-<?= $qualityScore >= 80 ? 'check-circle' : ($qualityScore >= 60 ? 'exclamation-triangle' : 'times-circle') ?>" style="font-size: 2.5rem;"></i>
                 </div>
                 <h5 class="card-title">Data Health</h5>
-                <h3 class="text-<?= $qualityScore >= 80 ? 'success' : ($qualityScore >= 60 ? 'warning' : 'danger') ?> mb-2"><?= number_format($qualityScore, 1) ?>%</h3>
+                <h3 class="text-<?= ElanRegistryOwner::getQualityBadgeClass($qualityScore) ?> mb-2"><?= number_format($qualityScore, 1) ?>%</h3>
                 <p class="card-text small text-muted">Overall car data quality score</p>
             </div>
         </div>

--- a/app/admin/includes/tab-owner_mgmt.php
+++ b/app/admin/includes/tab-owner_mgmt.php
@@ -259,14 +259,7 @@ function getDuplicateEmailDetails($db, $email): array {
             }
         }
 
-        // Calculate profile quality score
-        $qualityScore = 100;
-        if (!$owner->fname || $owner->fname === '') $qualityScore -= 20;
-        if (!$owner->lname || $owner->lname === '') $qualityScore -= 20;
-        if (!$owner->city || $owner->city === '') $qualityScore -= 15;
-        if (!$owner->state || $owner->state === '') $qualityScore -= 10;
-        if (!$owner->lat || !$owner->lon) $qualityScore -= 20;
-        $owner->quality_score = max(0, $qualityScore);
+        $owner->quality_score = ElanRegistryOwner::qualityScoreFromRow($owner);
     }
 
     return $owners;
@@ -288,13 +281,13 @@ $ownerQualityScore = $totalOwners > 0 ? max(0, 100 - (($qualityIssues / $totalOw
 <div class="row mb-4">
     <!-- Data Health Card -->
     <div class="col-lg-3 col-md-6 mb-3">
-        <div class="card border-<?= $ownerQualityScore >= 80 ? 'success' : ($ownerQualityScore >= 60 ? 'warning' : 'danger') ?> h-100">
+        <div class="card border-<?= ElanRegistryOwner::getQualityBadgeClass($ownerQualityScore) ?> h-100">
             <div class="card-body text-center">
-                <div class="text-<?= $ownerQualityScore >= 80 ? 'success' : ($ownerQualityScore >= 60 ? 'warning' : 'danger') ?> mb-3">
+                <div class="text-<?= ElanRegistryOwner::getQualityBadgeClass($ownerQualityScore) ?> mb-3">
                     <i class="fas fa-<?= $ownerQualityScore >= 80 ? 'check-circle' : ($ownerQualityScore >= 60 ? 'exclamation-triangle' : 'times-circle') ?>" style="font-size: 2.5rem;"></i>
                 </div>
                 <h5 class="card-title">Data Health</h5>
-                <h3 class="text-<?= $ownerQualityScore >= 80 ? 'success' : ($ownerQualityScore >= 60 ? 'warning' : 'danger') ?> mb-2"><?= number_format($ownerQualityScore, 1) ?>%</h3>
+                <h3 class="text-<?= ElanRegistryOwner::getQualityBadgeClass($ownerQualityScore) ?> mb-2"><?= number_format($ownerQualityScore, 1) ?>%</h3>
                 <p class="card-text small text-muted">Overall owner data quality score</p>
             </div>
         </div>
@@ -424,8 +417,7 @@ $ownerQualityScore = $totalOwners > 0 ? max(0, 100 - (($qualityIssues / $totalOw
                                                                     <?php foreach ($owners as $index => $owner) {
                                                                         $isNewer = $index === count($owners) - 1 && count($owners) > 1;
                                                                         $cardClass = $isNewer ? 'owner-comparison-card newer-owner' : 'owner-comparison-card';
-                                                                        $qualityClass = $owner->quality_score >= 80 ? 'success' :
-                                                                                       ($owner->quality_score >= 60 ? 'warning' : 'danger');
+                                                                        $qualityClass = ElanRegistryOwner::getQualityBadgeClass($owner->quality_score);
                                                                     ?>
                                                                         <div class="col-lg-6 col-md-6 mb-3 d-flex">
                                                                             <div class="card <?= $cardClass ?> w-100">

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -325,18 +325,46 @@ class ElanRegistryOwner
             return 0.0;
         }
 
-        $totalFields = 7;
-        $completedFields = 0;
+        return self::qualityScoreFromRow($this->_data);
+    }
 
-        if (!empty($this->_data->fname)) $completedFields++;
-        if (!empty($this->_data->lname)) $completedFields++;
-        if (!empty($this->_data->email)) $completedFields++;
-        if (!empty($this->_data->city)) $completedFields++;
-        if (!empty($this->_data->state)) $completedFields++;
-        if (!empty($this->_data->country)) $completedFields++;
-        if (!empty($this->_data->lat) && !empty($this->_data->lon)) $completedFields++;
+    /**
+     * Calculate quality score from a plain query result row.
+     *
+     * Accepts a raw DB row object so batch loops can score many owners without
+     * constructing a full ElanRegistryOwner for each one.
+     *
+     * @param object $row DB row with owner fields (fname, lname, email, city, state, country, lat, lon)
+     * @return float Score 0–100
+     */
+    public static function qualityScoreFromRow(object $row): float
+    {
+        $completed = 0;
+        if (!empty($row->fname)) $completed++;
+        if (!empty($row->lname)) $completed++;
+        if (!empty($row->email)) $completed++;
+        if (!empty($row->city)) $completed++;
+        if (!empty($row->state)) $completed++;
+        if (!empty($row->country)) $completed++;
+        if (!empty($row->lat) && !empty($row->lon)) $completed++;
+        return round(($completed / 7) * 100, 1);
+    }
 
-        return round(($completedFields / $totalFields) * 100, 1);
+    /**
+     * Return a Bootstrap contextual color class for a quality score.
+     *
+     * @param float $score Quality score 0–100
+     * @return string 'success', 'warning', or 'danger'
+     */
+    public static function getQualityBadgeClass(float $score): string
+    {
+        if ($score >= 80) {
+            return 'success';
+        }
+        if ($score >= 60) {
+            return 'warning';
+        }
+        return 'danger';
     }
 
     /**


### PR DESCRIPTION
## Summary

- **New `ElanRegistryOwner::qualityScoreFromRow(object $row): float`** — static method using the canonical equal-weight logic (7 fields × 100/7 each: fname, lname, email, city, state, country, lat+lon). Accepts a plain DB row so batch loops don't need to construct a full `ElanRegistryOwner` per row.
- **Refactored `getProfileQualityScore()`** to delegate to `qualityScoreFromRow($this->_data)` — no behavior change.
- **New `ElanRegistryOwner::getQualityBadgeClass(float $score): string`** — returns `success`/`warning`/`danger` for Bootstrap contextual classes.
- **`tab-owner_mgmt.php`**: Replaced 7-line penalty-based score calculation with `qualityScoreFromRow()`. Owner management tab now shows the same score as the owner profile page.
- **13 PHP inline ternaries** across 4 admin files replaced with `getQualityBadgeClass()`.
- JS ternary at `tab-owner_mgmt.php:757` left as-is — PHP static methods cannot be called from JavaScript.

## Test plan

- [x] 912 unit tests pass
- [x] phpcs: 0 errors on all 5 changed files
- [x] PHPStan: no errors
- [ ] Manual: open owner management tab and owner profile for the same owner — verify scores match
- [ ] Manual: verify data health cards in owner mgmt, car mgmt, and owner info/profile panels show correct colors

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy