### PR TITLE
fix: return correct HTTP 400/404 from owner AJAX endpoints on validation errors

### DIFF
--- a/app/admin/includes/load-owner-info.php
+++ b/app/admin/includes/load-owner-info.php
@@ -31,6 +31,7 @@ if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
 // Validate owner ID
 $ownerId = (int)($_POST['owner_id'] ?? 0);
 if ($ownerId <= 0) {
+    http_response_code(400);
     echo '<div class="alert alert-danger">Invalid owner ID</div>';
     exit;
 }
@@ -41,6 +42,7 @@ try {
     $ownerData = $owner->data();
 
     if (!$ownerData) {
+        http_response_code(404);
         echo '<div class="alert alert-warning">Owner not found</div>';
         exit;
     }

--- a/app/admin/includes/load-owner-profile.php
+++ b/app/admin/includes/load-owner-profile.php
@@ -31,6 +31,7 @@ if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
 // Validate owner ID
 $ownerId = (int)($_POST['owner_id'] ?? 0);
 if ($ownerId <= 0) {
+    http_response_code(400);
     echo '<div class="alert alert-danger">Invalid owner ID</div>';
     exit;
 }
@@ -41,6 +42,7 @@ try {
     $ownerData = $owner->data();
 
     if (!$ownerData) {
+        http_response_code(404);
         echo '<div class="alert alert-warning">Owner not found</div>';
         exit;
     }


### PR DESCRIPTION
## Summary

- `load-owner-info.php`: adds `http_response_code(400)` before "Invalid owner ID" and `http_response_code(404)` before "Owner not found"
- `load-owner-profile.php`: same two additions
- Auth/CSRF failure paths already return 403 — no change there
- JS callers can now branch on response status code instead of parsing body HTML

## Test plan

- [x] 912 unit tests pass
- [x] phpcs: 0 errors
- [x] PHPStan: no errors
- [ ] Manual: trigger an invalid owner ID in the admin panel — confirm DevTools shows HTTP 400
- [ ] Manual: trigger a not-found owner — confirm HTTP 404

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy