### PR TITLE
ux: replace setCustomValidity tooltip with Bootstrap inline feedback on website field

### DIFF
--- a/app/views/_edit_car_2.php
+++ b/app/views/_edit_car_2.php
@@ -53,18 +53,16 @@
             <span class='input-group-text'><i aria-hidden='true' class='fas fa-globe'></i></span>
             <input class='form-control' type='url' name='website' id='website' placeholder='<?= htmlspecialchars($carprompt['website'], ENT_QUOTES, 'UTF-8') ?>' value='<?= htmlspecialchars((string)($cardetails['website'] ?? ''), ENT_QUOTES, 'UTF-8') ?>' pattern="https?://.+" />
         </div>
+        <div class='invalid-feedback'>URL must start with http:// or https:// (e.g. https://example.com)</div>
     </div>
 </div>
 <script>
 (function () {
     var el = document.getElementById('website');
     function validate() {
-        el.setCustomValidity('');
-        if (el.value !== '' && !el.validity.valid) {
-            el.setCustomValidity('URL must start with http:// or https:// (e.g. https://example.com)');
-        }
+        el.classList.toggle('is-invalid', el.value !== '' && !el.validity.valid);
     }
     el.addEventListener('input', validate);
-    el.addEventListener('blur', function () { validate(); if (el.value !== '') el.reportValidity(); });
+    el.addEventListener('blur', validate);
 }());
 </script>


### PR DESCRIPTION
## Summary

- Removes native browser OS tooltip from the website URL field on the car edit form
- Adds Bootstrap 5 `.invalid-feedback` div with inline error text, consistent with all other validation feedback on the form
- Replaces `setCustomValidity()` + `reportValidity()` with `classList.toggle('is-invalid', condition)` — one-liner using `toggle`'s force argument

## Bonus improvement

`NotificationHelper.showValidationErrors()` already adds `is-invalid` to `[name="website"]` on AJAX errors, so the new `.invalid-feedback` div also surfaces for server-returned validation errors — no additional changes needed.

## Test plan

- [ ] Enter an invalid URL (e.g. `ftp://example.com`) in the website field and blur — inline error appears below the field (no OS tooltip)
- [ ] Enter a valid URL (e.g. `https://example.com`) — error clears
- [ ] Clear the field entirely — error does not show (field is optional)
- [ ] Submit a form with an invalid URL — AJAX response returns server error, both the top-level red alert and the inline field error are shown

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kLk37X98cmJDVKDeGQNup