### PR TITLE
fix: update claude-code-action inputs for v1 schema

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -174,6 +174,7 @@ jobs:
             Each item must cite `file:line` and the specific rule or reason.
             Keep it concise: if there's nothing to say, say so briefly.
 
+          claude_args: "--allowedTools Task,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git diff --name-only:*),Bash(php -l *),Bash(composer check:php),Bash(vendor/bin/phpstan analyse:*),Bash(npm run lint)"
 
   # Deep review for milestone -> main PRs. Runs on open / ready_for_review
   # and when `deep-review` is explicitly requested.
@@ -322,6 +323,8 @@ jobs:
             straight to the source. Do not restate per-line findings already
             addressed on the issue PRs — assume those are closed.
 
+          claude_args: "--allowedTools Task,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git diff --name-only:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(cat merged-prs.txt),Bash(php -l *),Bash(composer check:php),Bash(vendor/bin/phpstan analyse:*),Bash(npm run lint)"
+
 
   # Deep review triggered by a PR comment: `@claude deep-review`.
   # Restricted to repository owners and collaborators to prevent abuse.
@@ -388,4 +391,6 @@ jobs:
             Aggregate into one sticky comment with Blocking / Important /
             Suggestions / Strengths / Action Plan sections. Every item must
             cite `file:line`.
+
+          claude_args: "--allowedTools Task,Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git diff --name-only:*),Bash(gh pr view:*),Bash(php -l *),Bash(composer check:php),Bash(vendor/bin/phpstan analyse:*),Bash(npm run lint)"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -103,7 +103,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           use_sticky_comment: false
-          direct_prompt: |
+          prompt: |
             You are reviewing an **issue-level PR** targeting a milestone
             branch. Context:
 
@@ -174,19 +174,6 @@ jobs:
             Each item must cite `file:line` and the specific rule or reason.
             Keep it concise: if there's nothing to say, say so briefly.
 
-          allowed_tools: |
-            Task
-            Read
-            Grep
-            Glob
-            Bash(git diff:*)
-            Bash(git log:*)
-            Bash(git show:*)
-            Bash(git diff --name-only:*)
-            Bash(php -l **/*.php)
-            Bash(composer check:php)
-            Bash(vendor/bin/phpstan analyse:*)
-            Bash(npm run lint)
 
   # Deep review for milestone -> main PRs. Runs on open / ready_for_review
   # and when `deep-review` is explicitly requested.
@@ -243,7 +230,7 @@ jobs:
           use_sticky_comment: true
           # Opus is worth it here: this runs once per milestone, not per push.
           model: "claude-opus-4-6"
-          direct_prompt: |
+          prompt: |
             You are reviewing a **milestone release PR** targeting `main`.
 
             - Milestone branch: ${{ github.event.pull_request.head.ref }}
@@ -335,22 +322,6 @@ jobs:
             straight to the source. Do not restate per-line findings already
             addressed on the issue PRs — assume those are closed.
 
-          allowed_tools: |
-            Task
-            Read
-            Grep
-            Glob
-            Bash(git diff:*)
-            Bash(git log:*)
-            Bash(git show:*)
-            Bash(git diff --name-only:*)
-            Bash(gh pr list:*)
-            Bash(gh pr view:*)
-            Bash(cat merged-prs.txt)
-            Bash(php -l **/*.php)
-            Bash(composer check:php)
-            Bash(vendor/bin/phpstan analyse:*)
-            Bash(npm run lint)
 
   # Deep review triggered by a PR comment: `@claude deep-review`.
   # Restricted to repository owners and collaborators to prevent abuse.
@@ -393,7 +364,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           model: "claude-opus-4-6"
-          direct_prompt: |
+          prompt: |
             Deep review requested by `@claude deep-review` comment on
             PR #${{ github.event.issue.number }}.
 
@@ -418,17 +389,3 @@ jobs:
             Suggestions / Strengths / Action Plan sections. Every item must
             cite `file:line`.
 
-          allowed_tools: |
-            Task
-            Read
-            Grep
-            Glob
-            Bash(git diff:*)
-            Bash(git log:*)
-            Bash(git show:*)
-            Bash(git diff --name-only:*)
-            Bash(gh pr view:*)
-            Bash(php -l **/*.php)
-            Bash(composer check:php)
-            Bash(vendor/bin/phpstan analyse:*)
-            Bash(npm run lint)


### PR DESCRIPTION
## Summary

- Renames `direct_prompt` → `prompt` in all three review jobs (renamed in `claude-code-action@v1`)
- Removes invalid `allowed_tools:` input, restoring restrictions via `claude_args: "--allowedTools ..."` instead
- Applies to `pr-to-milestone-review`, `milestone-review`, and `comment-triggered-deep-review` jobs

## Why main directly

Workflow files must match the default branch before GitHub Actions will execute them on PRs. This fix is blocked from self-testing until it lands on `main`.

## Test plan

- [ ] After merge, open or re-sync a PR to confirm the `claude-code-review` job runs and posts a review comment
- [ ] Verify no "unexpected input" warnings in the Actions log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy