### PR TITLE
refactor: rename admin pages and update UserSpice page registrations (#1039)

### DIFF
--- a/app/admin/design-system.php
+++ b/app/admin/design-system.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * color-preview.php
+ * design-system.php
  * Living reference page for the Elan Registry color token system (issue #757).
  *
  * Renders every --er-* token in context (buttons, card headers, badges,

--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -63,7 +63,6 @@ if (Input::exists('post')) {
             try {
                 $db = DB::getInstance();
 
-
                 // Get admin user data
                 $adminData = $db->query('SELECT id, email, fname, lname FROM users WHERE id = ?', [$user->data()->id])->first();
                 if (!$adminData) {
@@ -198,10 +197,8 @@ if (Input::exists('post')) {
         }
     }
 
-    // Redirect back to data quality tab
-    Redirect::to($us_url_root . 'app/admin/manage-consolidated.php?tab=data-quality');
+    Redirect::to($us_url_root . 'app/admin/index.php?tab=manage-cars');
 } else {
-    // No POST data
-    Redirect::to($us_url_root . 'app/admin/manage-consolidated.php?tab=data-quality');
+    Redirect::to($us_url_root . 'app/admin/index.php?tab=manage-cars');
 }
 ?>

--- a/app/admin/includes/tab-manage_cars.php
+++ b/app/admin/includes/tab-manage_cars.php
@@ -981,7 +981,7 @@ $qualityScore = $totalCars > 0 ? max(0, 100 - (($carIssues / $totalCars) * 100))
                             </div>
                                 <div class="collapse show" id="group<?= $groupIndex ?>">
                                     <div class="card-body">
-                                        <form action="manage-consolidated.php" method="POST" class="merge-form">
+                                        <form action="index.php" method="POST" class="merge-form">
                                             <input type="hidden" name="command" value="merge" />
                                             <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
 

--- a/app/admin/includes/tab-placeholder.php
+++ b/app/admin/includes/tab-placeholder.php
@@ -90,7 +90,7 @@ declare(strict_types=1);
                     <div class="col-md-4">
                         <h6>Current Implementation</h6>
                         <ul class="list-unstyled small">
-                            <li><strong>File:</strong> manage-consolidated.php</li>
+                            <li><strong>File:</strong> index.php</li>
                             <li><strong>Tab:</strong> <?= htmlspecialchars($activeTab) ?></li>
                             <li><strong>Include:</strong> tab-<?= str_replace('-', '_', $activeTab) ?>.php</li>
                             <li><strong>Framework:</strong> UserSpice 5.x</li>
@@ -99,7 +99,7 @@ declare(strict_types=1);
                     <div class="col-md-4">
                         <h6>URL Routing</h6>
                         <ul class="list-unstyled small">
-                            <li><strong>Base URL:</strong> manage-consolidated.php</li>
+                            <li><strong>Base URL:</strong> index.php</li>
                             <li><strong>Parameter:</strong> ?tab=<?= htmlspecialchars($activeTab) ?></li>
                             <li><strong>Valid Tabs:</strong> <?= count($validTabs) ?></li>
                             <li><strong>Default:</strong> car-mgmt</li>

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -7,7 +7,7 @@ use ElanRegistry\Exceptions\CarNotFoundException;
 use ElanRegistry\Input as ElanInput;
 
 /**
- * manage-consolidated.php
+ * index.php
  * Consolidated Management Interface
  *
  * Unified administrative interface with tabbed structure:

--- a/app/admin/maintenance.php
+++ b/app/admin/maintenance.php
@@ -2,11 +2,11 @@
 declare(strict_types=1);
 
 /**
- * manage-maintenance.php
+ * maintenance.php
  * Registry Maintenance Interface
  *
  * Admin-only management interface focused on system maintenance and
- * registry-wide configuration. Split out from manage-consolidated.php to
+ * registry-wide configuration. Split out from index.php to
  * separate operational maintenance from day-to-day car/owner administration.
  *
  * TAB 1: Health - Read-only system health monitoring

--- a/app/admin/scripts/fix/08-Rename-Admin-Pages.php
+++ b/app/admin/scripts/fix/08-Rename-Admin-Pages.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * 08-Rename-Admin-Pages.php Script
+ *
+ * Administrative script to update the UserSpice `pages` table to reflect three
+ * renamed admin pages.
+ * Issue #1039: Rename admin pages for clarity and add Design System to nav
+ *
+ * The PHP files were renamed via git mv:
+ *   - manage-consolidated.php → index.php       (Admin Dashboard)
+ *   - manage-maintenance.php  → maintenance.php  (Registry Maintenance)
+ *   - color-preview.php       → design-system.php (Design System)
+ *
+ * This script keeps the UserSpice pages registry in sync with those renames so
+ * permission checks and securePage() continue to resolve correctly.
+ *
+ * DEPLOYMENT INSTRUCTIONS:
+ * 1. Run once after deployment via maintenance.php (Maintenance tab) or direct URL
+ * 2. All scripts auto-log completion to fix_script_runs table
+ * 3. See app/admin/scripts/fix/README.md for detailed instructions and best practices
+ */
+
+// UI Constants for progress output
+define('SECTION_SEPARATOR', '═══════════════════════════════════════════════════════');
+
+require_once '../../../../users/init.php';
+require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
+
+if (!securePage($php_self)) {
+    die();
+}
+
+// Set up custom error handler to log through UserSpice logger
+set_error_handler(function($errno, $errstr, $errfile, $errline) {
+    if ($errno !== E_DEPRECATED) {
+        logger(isset($user) ? $user->data()->id : 0, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "Error [$errno]: $errstr in $errfile:$errline");
+    }
+    return true;
+});
+
+$db = DB::getInstance();
+
+?>
+
+<div id="page-wrapper">
+    <div class="container-fluid">
+        <div class="well">
+
+            <?php if (!isset($_POST['start'])): ?>
+            <!-- Initial Description -->
+            <div class="row">
+                <div class="col-lg-12 mb-4">
+                    <div class="card registry-card">
+                        <div class="card-header">
+                            <h2 class="mb-0">
+                                <i class="fa fa-pencil-square-o"></i> Rename Admin Pages
+                            </h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="mb-3">This script updates the UserSpice <code>pages</code> table to reflect three renamed admin pages.</p>
+
+                            <div class="alert alert-info">
+                                <h5><i class="fa fa-info-circle"></i> What this script does:</h5>
+                                <ul class="mb-0">
+                                    <li>Updates <code>manage-consolidated.php</code> → <code>index.php</code> (Admin Dashboard)</li>
+                                    <li>Updates <code>manage-maintenance.php</code> → <code>maintenance.php</code> (Registry Maintenance)</li>
+                                    <li>Updates <code>color-preview.php</code> → <code>design-system.php</code> (Design System)</li>
+                                    <li>Keeps the page title in sync with each renamed page</li>
+                                    <li>Logs completion to the <code>fix_script_runs</code> table</li>
+                                </ul>
+                            </div>
+
+                            <div class="alert alert-warning">
+                                <h5><i class="fa fa-exclamation-triangle"></i> Important Notes:</h5>
+                                <ul class="mb-0">
+                                    <li>Run this once after the renamed PHP files are deployed</li>
+                                    <li>Each row is matched by its old page path; a missing row is reported as a warning, not an error</li>
+                                    <li>No data is deleted — only the <code>page</code> and <code>title</code> columns are updated</li>
+                                </ul>
+                            </div>
+
+                            <div class="text-center">
+                                <form method="post" action="">
+                                    <input type="hidden" name="csrf" value="<?= htmlspecialchars(Token::generate(), ENT_QUOTES, 'UTF-8') ?>">
+                                    <input type="hidden" name="start" value="1">
+                                    <button type="submit" class="btn btn-success btn-lg">
+                                        <i class="fa fa-play"></i> Continue - Start Rename
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <?php elseif (!Token::check($_POST['csrf'] ?? '')): ?>
+            <div class="alert alert-danger">
+                <i class="fa fa-exclamation-triangle"></i> Invalid CSRF token. Please go back and try again.
+            </div>
+            <?php else:
+                // Processing mode - simple text output
+                ob_end_clean(); // Clear template buffering
+                header('Content-Type: text/html; charset=utf-8');
+                echo str_repeat(' ', 1024); // Pad to force initial flush
+                flush();
+            ?>
+
+            <div class="card registry-card">
+                <div class="card-header">
+                    <h2 class="mb-0">
+                        <i class="fa fa-cogs"></i> Renaming Admin Pages
+                    </h2>
+                    <small class="text-muted">
+                        <i class="fa fa-clock-o"></i> Started: <?php echo date('Y-m-d H:i:s'); ?>
+                    </small>
+                </div>
+                <div class="card-body">
+                    <pre style="background: #f5f5f5; padding: 15px; border-radius: 4px; max-height: 600px; overflow-y: auto; font-family: 'Courier New', monospace; font-size: 13px;"><?php
+
+                    /**
+                     * Helper function for progress output
+                     *
+                     * @param string $message Message to display
+                     * @param string $type Type of message: 'info', 'success', 'error', 'warning', 'step'
+                     */
+                    function logProgress(string $message, string $type = 'info'): void {
+                        $icons = [
+                            'info' => 'ℹ️',
+                            'success' => '✅',
+                            'error' => '❌',
+                            'warning' => '⚠️',
+                            'step' => '▶️'
+                        ];
+                        $icon = $icons[$type] ?? '•';
+                        echo date('[H:i:s] ') . $icon . ' ' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . "\n";
+                        flush();
+                    }
+
+                    // Initialize results tracking
+                    $results = [
+                        'processed' => 0,
+                        'errors' => 0,
+                        'warnings' => 0
+                    ];
+
+                    // Each entry: [new page path, new title, old page path]
+                    $renames = [
+                        ['app/admin/index.php', 'Admin Dashboard', 'app/admin/manage-consolidated.php'],
+                        ['app/admin/maintenance.php', 'Registry Maintenance', 'app/admin/manage-maintenance.php'],
+                        ['app/admin/design-system.php', 'Design System', 'app/admin/color-preview.php'],
+                    ];
+
+                    try {
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('STEP 1: Update pages table for renamed admin pages', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        foreach ($renames as [$newPage, $newTitle, $oldPage]) {
+                            $db->query(
+                                "UPDATE pages SET page = ?, title = ? WHERE page = ?",
+                                [$newPage, $newTitle, $oldPage]
+                            );
+
+                            if ($db->error()) {
+                                $results['errors']++;
+                                $dbError = $db->errorString();
+                                logProgress("Database error updating {$oldPage}: {$dbError}", 'error');
+                                logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT_ERROR,
+                                    "Database error updating pages row {$oldPage} → {$newPage}: {$dbError}");
+                                logProgress('Aborting — resolve the database error and re-run.', 'error');
+                                break;
+                            }
+
+                            if ($db->count() > 0) {
+                                $results['processed']++;
+                                logProgress("{$oldPage} → {$newPage} ({$newTitle})", 'success');
+                            } else {
+                                $results['warnings']++;
+                                logProgress("No pages row found for {$oldPage} — skipped", 'warning');
+                            }
+                        }
+
+                        // Display summary
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress($results['errors'] > 0 ? 'Rename aborted — resolve errors and re-run' : 'Rename complete', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress("Pages Updated: {$results['processed']}", 'success');
+                        if ($results['warnings'] > 0) {
+                            logProgress("Warnings: {$results['warnings']}", 'warning');
+                        }
+                        if ($results['errors'] > 0) {
+                            logProgress("Errors: {$results['errors']}", 'error');
+                        }
+
+                        // Only mark as completed when there were no errors
+                        if ($results['errors'] === 0) {
+                            $inserted = $db->insert('fix_script_runs', [
+                                'script_name' => '08-Rename-Admin-Pages.php',
+                                'completed_at' => date('Y-m-d H:i:s')
+                            ]);
+                            if (!$inserted) {
+                                logProgress('Warning: could not write completion record — ' . $db->errorString(), 'warning');
+                                logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT_ERROR,
+                                    'fix_script_runs insert failed: ' . $db->errorString());
+                            }
+                        }
+
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT,
+                            "Script run — Processed: {$results['processed']}, Errors: {$results['errors']}, Warnings: {$results['warnings']}");
+
+                    } catch (\Throwable $e) {
+                        logProgress('FATAL ERROR: ' . $e->getMessage(), 'error');
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT, 'Fatal error: ' . $e->getMessage());
+                    }
+
+                    ?></pre>
+
+                    <div class="text-center mt-3">
+                        <a href="../../maintenance.php?tab=maintenance" class="btn btn-primary btn-lg">
+                            <i class="fa fa-arrow-left"></i> Return to Maintenance
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <?php endif; ?>
+
+        </div>
+    </div>
+</div>
+
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/app/admin/scripts/fix/_TEMPLATE_Fix-Script.php
+++ b/app/admin/scripts/fix/_TEMPLATE_Fix-Script.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * DEPLOYMENT INSTRUCTIONS:
  * 1. Copy this file to app/admin/scripts/fix/ (one-time migrations) or app/admin/scripts/maintenance/ (repeatable tasks) with proper naming: ##-Descriptive-Name.php
  * 2. Replace all [PLACEHOLDERS] with appropriate content
- * 3. Scripts are accessed via manage-maintenance.php (Maintenance tab) or direct URL
+ * 3. Scripts are accessed via maintenance.php (Maintenance tab) or direct URL
  * 4. Use sequential numbering (01, 02, 03...) for proper execution order
  * 5. All scripts auto-log completion to fix_script_runs table
  * 6. See app/admin/scripts/fix/README.md for detailed instructions and best practices
@@ -226,7 +226,7 @@ $db = DB::getInstance();
                     ?></pre>
 
                     <div class="text-center mt-3">
-                        <a href="../../manage-maintenance.php?tab=maintenance" class="btn btn-primary btn-lg">
+                        <a href="../../maintenance.php?tab=maintenance" class="btn btn-primary btn-lg">
                             <i class="fa fa-arrow-left"></i> Return to Maintenance
                         </a>
                     </div>

--- a/app/admin/scripts/maintenance/24-Regenerate-Optimized-Thumbnails.php
+++ b/app/admin/scripts/maintenance/24-Regenerate-Optimized-Thumbnails.php
@@ -242,7 +242,7 @@ $line = 1; // Where messages go
             ${stats}
         </div>
         <div class="text-center">
-            <button onclick="if(window.opener){window.opener.location.reload(); window.close();} else {window.location.href='../../manage-maintenance.php?tab=maintenance';}" class="btn btn-outline-primary">
+            <button onclick="if(window.opener){window.opener.location.reload(); window.close();} else {window.location.href='../../maintenance.php?tab=maintenance';}" class="btn btn-outline-primary">
                 <i class="fa fa-arrow-left"></i> Return to Admin Console
             </button>
         </div>
@@ -689,7 +689,7 @@ $line = 1; // Where messages go
 
 <!-- Return to Admin Console button -->
 <div style="margin-top: 20px; text-align: center;">
-    <button onclick="if(window.opener){window.opener.location.reload(); window.close();} else {window.location.href='../../manage-maintenance.php?tab=maintenance';}" class="btn btn-outline-primary">
+    <button onclick="if(window.opener){window.opener.location.reload(); window.close();} else {window.location.href='../../maintenance.php?tab=maintenance';}" class="btn btn-outline-primary">
         <i class="fa fa-arrow-left" aria-hidden="true"></i> Return to Admin Console
     </button>
 </div>

--- a/docs/development/EMAIL_SYSTEM.md
+++ b/docs/development/EMAIL_SYSTEM.md
@@ -313,6 +313,6 @@ Admin addresses are managed at Admin → Settings → Admin Emails. The default 
 ## Related Documentation
 
 - [CLASSES.md](CLASSES.md) — EmailTemplate class for branded HTML email wrappers
-- [Email Colors (color-preview.php)](../../app/admin/color-preview.php) — Email token → hex mapping and template structure (admin only)
+- [Email Colors (design-system.php)](../../app/admin/design-system.php) — Email token → hex mapping and template structure (admin only)
 - [ADR-012: Adopt Brevo for Transactional Email Delivery](adr/ADR-012-adopt-brevo-for-transactional-email-delivery.md) — Architecture decision record
 - [DATABASE.md](DATABASE.md) — Database schema reference (includes `plg_sendinblue` table)

--- a/docs/development/UI_STANDARDS.md
+++ b/docs/development/UI_STANDARDS.md
@@ -1,6 +1,6 @@
 # UI Standards — Elan Registry
 
-**Live reference:** [`/app/admin/color-preview.php`](../../app/admin/color-preview.php) —
+**Live reference:** [`/app/admin/design-system.php`](../../app/admin/design-system.php) —
 renders every token, card level, and component pattern in context. Admin-only page.
 
 **Token source:** [`usersc/templates/customizer.css`](../../usersc/templates/customizer.css) —
@@ -10,10 +10,10 @@ the single source of truth for all `--er-*` tokens and global utility classes.
 
 ## The Golden Rule
 
-> **Every new UI component or token must be demonstrated in `color-preview.php` before it is used elsewhere on the site.**
+> **Every new UI component or token must be demonstrated in `design-system.php` before it is used elsewhere on the site.**
 
 When you introduce a new pattern — a new CSS class, a new token, a new component — add a section
-to `color-preview.php` showing it in context first. This keeps the reference page authoritative
+to `design-system.php` showing it in context first. This keeps the reference page authoritative
 and ensures the pattern is visually validated before being applied site-wide.
 
 ---
@@ -281,7 +281,7 @@ Three first-party CSS source files (compiled to `.min.css` by `npm run build`):
 
 | File | Loaded by | Contains |
 | --- | --- | --- |
-| `app/admin/assets/manage-consolidated.css` | `manage-consolidated.php` | Admin comparison cards, field-match/differ, timestamp display |
+| `app/admin/assets/manage-consolidated.css` | `index.php` | Admin comparison cards, field-match/differ, timestamp display |
 | `app/assets/css/edit_car.css` | `app/cars/edit.php` | FilePond overrides, `#editCar` focus, card z-index for drag-drop |
 | `app/assets/css/location-picker.css` | `app/cars/edit.php` | `.location-picker-container`-scoped styles |
 
@@ -295,7 +295,7 @@ in a page-specific file should have a comment explaining why it is not global.
 
 When introducing a new component, token, or pattern:
 
-1. **Add a demo to `color-preview.php`** showing the pattern in context with a label and usage note. This is mandatory — it is the visual contract for the pattern.
+1. **Add a demo to `design-system.php`** showing the pattern in context with a label and usage note. This is mandatory — it is the visual contract for the pattern.
 2. **Add the CSS to `customizer.css`** if it is globally applicable, or to the relevant page-specific file with a scope comment if not.
 3. **Document it in this file** under the appropriate section, including any anti-patterns it replaces.
 4. **Run `npm run build`** if you edited a source CSS file other than `customizer.css` (which is served directly without a build step).
@@ -307,5 +307,5 @@ When introducing a new component, token, or pattern:
 
 - [`docs/development/CODING_STANDARDS.md`](CODING_STANDARDS.md) — PHP coding standards
 - [`docs/development/CSS_AND_ASSETS.md`](CSS_AND_ASSETS.md) — asset pipeline, build process, ADR-015
-- [`app/admin/color-preview.php`](../../app/admin/color-preview.php) — live token and component reference
+- [`app/admin/design-system.php`](../../app/admin/design-system.php) — live token and component reference
 - [`usersc/templates/customizer.css`](../../usersc/templates/customizer.css) — token definitions and global CSS

--- a/docs/development/adr/ADR-013-pdf-reference-library-storage.md
+++ b/docs/development/adr/ADR-013-pdf-reference-library-storage.md
@@ -352,7 +352,7 @@ A typed exception class `ReferenceDocumentException` extends the application's
 ### Admin Interface and Integration
 
 The admin interface integrates into the existing consolidated management page
-(`app/admin/manage-consolidated.php`) as a new **Reference Library** tab,
+(`app/admin/index.php`) as a new **Reference Library** tab,
 following the established pattern of tab-based administration:
 
 - **Tab content**: `app/admin/includes/tab-reference_library.php` — document
@@ -423,7 +423,7 @@ The design follows existing UserSpice patterns:
 
 1. Add `'reference-library' => 'Reference Library'`to`$validTabs` in
 
-    `app/admin/manage-consolidated.php`.
+    `app/admin/index.php`.
 
 2. Create `app/admin/includes/tab-reference_library.php` with document list,
 
@@ -759,7 +759,7 @@ ADR-013 Phase 1-3    #350 (DocumentPortalTemplate)
 
 - **Consolidated Admin Page**:
 
-  [app/admin/manage-consolidated.php](../../app/admin/manage-consolidated.php)
+  [app/admin/index.php](../../app/admin/index.php)
   — tabbed admin interface; Reference Library tab integrates here.
 
 - **Reference Library Listing**: [docs/reference-library.php](../reference-library.php) — current `scandir()`-based PDF listing (to be migrated).

--- a/docs/releases/RELEASE_NOTES_v2.25.3.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.3.md
@@ -5,6 +5,12 @@
 
 ## Required Actions After Deployment
 
+Run the Rename Admin Pages fix script first to update the UserSpice pages table:
+
+```
+https://elanregistry.org/app/admin/scripts/fix/08-Rename-Admin-Pages.php
+```
+
 Run the Fix Page Permissions maintenance script after deployment to reclassify
 any page permission rows that reference the new `app/api/` and renamed admin
 paths:
@@ -40,6 +46,8 @@ public URL changes.
   full-page HTML redirect handlers to Pattern A JSON endpoints under `app/api/contact/`;
   wire both contact forms to submit via `ElanRegistryAPI` for inline success/error display
   with no page reload; sender identity read from trusted session, not POST hidden fields (#1038)
+- Add `08-Rename-Admin-Pages.php` fix script to update UserSpice `pages` table URL
+  registrations for the three renamed admin pages; run after deployment (#1039)
 
 ## Issues Resolved
 

--- a/tests/integration/ManageConsolidatedDeletionTest.php
+++ b/tests/integration/ManageConsolidatedDeletionTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Regression guard for the car deletion path in
- * app/admin/manage-consolidated.php after migration to Car::delete().
+ * app/admin/index.php after migration to Car::delete().
  *
  * Prior to #956 that page issued raw DELETE statements directly against
  * car_user and cars. Issue #956 routes deletion through Car::delete() /

--- a/tests/playwright/admin-escapeHtml.spec.js
+++ b/tests/playwright/admin-escapeHtml.spec.js
@@ -2,7 +2,7 @@
 //
 // Tests for escapeHtml() XSS-prevention helper in manage-consolidated.js.
 // Verifies that user-supplied content is safely escaped for DOM insertion.
-// The function is loaded globally on /app/admin/manage-consolidated.php and
+// The function is loaded globally on /app/admin/index.php and
 // is exercised here via page.evaluate() with a battery of XSS vectors.
 //
 // Requires local MAMP at http://localhost:9999/elan-registry
@@ -13,7 +13,7 @@ const { ensureLoggedIn } = require('./auth-helper.js');
 test.describe('escapeHtml() — XSS prevention', () => {
     test.beforeEach(async ({ page }) => {
         await ensureLoggedIn(page);
-        await page.goto('app/admin/manage-consolidated.php?tab=car-mgmt', { waitUntil: 'networkidle' });
+        await page.goto('app/admin/index.php?tab=car-mgmt', { waitUntil: 'networkidle' });
     });
 
     test('escapes <script> tags', async ({ page }) => {

--- a/tests/playwright/admin-modal-confirmation.spec.js
+++ b/tests/playwright/admin-modal-confirmation.spec.js
@@ -10,13 +10,13 @@ const { test, expect } = require('@playwright/test');
 const { ensureLoggedIn } = require('./auth-helper.js');
 
 // ---------------------------------------------------------------------------
-// Area 1: manage-consolidated.php — modal DOM and car merge tab
+// Area 1: index.php — modal DOM and car merge tab
 // ---------------------------------------------------------------------------
 
-test.describe('Admin confirmation modal — manage-consolidated', () => {
+test.describe('Admin confirmation modal — index', () => {
     test.beforeEach(async ({ page }) => {
         await ensureLoggedIn(page);
-        await page.goto('app/admin/manage-consolidated.php?tab=car-mgmt', { waitUntil: 'networkidle' });
+        await page.goto('app/admin/index.php?tab=car-mgmt', { waitUntil: 'networkidle' });
     });
 
     test('confirmation modal element is present in DOM', async ({ page }) => {
@@ -52,13 +52,13 @@ test.describe('Admin confirmation modal — manage-consolidated', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Area 2: manage-maintenance.php — modal DOM and schema maintenance tab
+// Area 2: maintenance.php — modal DOM and schema maintenance tab
 // ---------------------------------------------------------------------------
 
-test.describe('Admin confirmation modal — manage-maintenance', () => {
+test.describe('Admin confirmation modal — maintenance', () => {
     test.beforeEach(async ({ page }) => {
         await ensureLoggedIn(page);
-        await page.goto('app/admin/manage-maintenance.php?tab=maintenance', { waitUntil: 'networkidle' });
+        await page.goto('app/admin/maintenance.php?tab=maintenance', { waitUntil: 'networkidle' });
     });
 
     test('confirmation modal element is present in DOM', async ({ page }) => {
@@ -123,13 +123,13 @@ test.describe('Admin confirmation modal — manage-maintenance', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Area 3: manage-maintenance.php — input modal DOM (#inputModal)
+// Area 3: maintenance.php — input modal DOM (#inputModal)
 // ---------------------------------------------------------------------------
 
-test.describe('Admin input modal — manage-maintenance', () => {
+test.describe('Admin input modal — maintenance', () => {
     test.beforeEach(async ({ page }) => {
         await ensureLoggedIn(page);
-        await page.goto('app/admin/manage-maintenance.php?tab=maintenance', { waitUntil: 'networkidle' });
+        await page.goto('app/admin/maintenance.php?tab=maintenance', { waitUntil: 'networkidle' });
     });
 
     test('input modal and all required child elements are present in DOM', async ({ page }) => {

--- a/tests/unit/admin/PagePermissionClassifierTest.php
+++ b/tests/unit/admin/PagePermissionClassifierTest.php
@@ -53,7 +53,9 @@ final class PagePermissionClassifierTest extends TestCase
             'admin scripts prefix'              => ['app/admin/scripts/maintenance/21-Fix-Page-Permissions.php', true],
             'admin scripts fix'                 => ['app/admin/scripts/fix/01-something.php',                   true],
             'admin manage page'                 => ['app/admin/manage-consolidated.php',                        true],
-            'admin maintenance page'            => ['app/admin/manage-maintenance.php',                         true],
+            'admin index (dashboard)'           => ['app/admin/index.php',                                       true],
+            'admin maintenance page'            => ['app/admin/maintenance.php',                         true],
+            'admin design-system page'          => ['app/admin/design-system.php',                               true],
             'docs admin'                        => ['docs/admin/guide.php',                                     true],
             'user settings (owner page)'        => ['usersc/user_settings.php',                                 false],
             'car listing (public)'              => ['app/cars/index.php',                                       false],
@@ -82,11 +84,13 @@ final class PagePermissionClassifierTest extends TestCase
             'fix script'                        => ['app/admin/scripts/fix/01-something.php',                   true],
             'scripts root'                      => ['app/admin/scripts/index.php',                              true],
             // Admin-only: maintenance portal pages
-            'manage-maintenance'                => ['app/admin/manage-maintenance.php',                         true],
+            'manage-maintenance'                => ['app/admin/maintenance.php',                         true],
+            'design-system'                     => ['app/admin/design-system.php',                               true],
             'tab-health'                        => ['app/admin/includes/tab-health.php',                        true],
             'tab-maintenance'                   => ['app/admin/includes/tab-maintenance.php',                   true],
             // Admin+Editor: general admin panel
             'manage-consolidated'               => ['app/admin/manage-consolidated.php',                        false],
+            'admin index (dashboard)'           => ['app/admin/index.php',                                      false],
             'tab-cars'                          => ['app/admin/includes/tab-cars.php',                          false],
             'docs admin'                        => ['docs/admin/guide.php',                                     false],
             'non-admin page'                    => ['app/cars/index.php',                                       false],
@@ -108,7 +112,9 @@ final class PagePermissionClassifierTest extends TestCase
     {
         return [
             // Admin pages are private
-            'admin page'                        => ['app/admin/manage-consolidated.php',  true],
+            'admin index (dashboard)'           => ['app/admin/index.php',                true],
+            'admin maintenance'                 => ['app/admin/maintenance.php',           true],
+            'admin design-system'               => ['app/admin/design-system.php',        true],
             'admin script'                      => ['app/admin/scripts/maintenance/21-Fix-Page-Permissions.php', true],
             'docs admin'                        => ['docs/admin/guide.php',               true],
             // Owner pages are private
@@ -181,7 +187,8 @@ final class PagePermissionClassifierTest extends TestCase
     public function testMaintenancePortalPagesAreAdminOnly(): void
     {
         $maintenancePages = [
-            'app/admin/manage-maintenance.php',
+            'app/admin/maintenance.php',
+            'app/admin/design-system.php',
             'app/admin/includes/tab-health.php',
             'app/admin/includes/tab-maintenance.php',
         ];
@@ -216,7 +223,7 @@ final class PagePermissionClassifierTest extends TestCase
     public function testGeneralAdminPagesAreNotAdminOnly(): void
     {
         $adminEditorPages = [
-            'app/admin/manage-consolidated.php',
+            'app/admin/index.php',
             'app/admin/includes/tab-cars.php',
             'docs/admin/guide.php',
         ];

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -271,7 +271,7 @@ class LogCategoriesUsageTest extends TestCase
     public function testManageConsolidatedPhpCatchBlocksDoNotExposeGetMessage(): void
     {
         $this->assertNoGetMessageInErrorsArray(
-            'app/admin/manage-consolidated.php',
+            'app/admin/index.php',
             'Use a safe static message instead (Issue #659).'
         );
     }
@@ -304,9 +304,9 @@ class LogCategoriesUsageTest extends TestCase
      */
     public function testManageConsolidatedPhpHasNoUserIdFallback(): void
     {
-        $filePath = $this->rootDir . '/app/admin/manage-consolidated.php';
+        $filePath = $this->rootDir . '/app/admin/index.php';
         if (!file_exists($filePath)) {
-            $this->markTestSkipped('manage-consolidated.php not found');
+            $this->markTestSkipped('index.php not found');
         }
 
         $content = (string)file_get_contents($filePath);

--- a/usersc/classes/Transfer/TransferEmailService.php
+++ b/usersc/classes/Transfer/TransferEmailService.php
@@ -169,7 +169,7 @@ class TransferEmailService
                 'expires_at'         => $transferData->expires_at ?? '',
             ];
 
-            $reviewUrl = getBaseUrl() . '/app/admin/manage-consolidated.php';
+            $reviewUrl = getBaseUrl() . '/app/admin/index.php';
 
             ob_start();
             include $this->basePath . 'app/views/email/_transfer_admin.php';

--- a/usersc/classes/admin/PagePermissionClassifier.php
+++ b/usersc/classes/admin/PagePermissionClassifier.php
@@ -33,7 +33,8 @@ class PagePermissionClassifier
      * Administrator only (no Editor access).
      */
     private const ADMIN_ONLY_PAGES = [
-        'app/admin/manage-maintenance.php',
+        'app/admin/maintenance.php',
+        'app/admin/design-system.php',
         'app/admin/includes/tab-health.php',
         'app/admin/includes/tab-maintenance.php',
     ];

--- a/usersc/templates/customizer/file_nav_custom.php
+++ b/usersc/templates/customizer/file_nav_custom.php
@@ -163,20 +163,24 @@ if ($navActive === '') {
         </a>
         <ul class='us_sub-menu' aria-labelledby='menu_1_638b71f2ed026_dropdown_admin' style=' z-index: 50;'>
           <li class=''>
-            <a class='' href='<?= $us_url_root ?>app/admin/manage-consolidated.php'>
+            <a class='' href='<?= $us_url_root ?>app/admin/index.php'>
               <i class='fa fa-car'></i>
               <span class='labelText'>Manage Cars/Owners</span>
             </a>
           </li>
           <?php if (hasPerm([2], $user->data()->id)): ?>
           <li class=''>
-            <a class='' href='<?= $us_url_root ?>app/admin/manage-maintenance.php'>
+            <a class='' href='<?= $us_url_root ?>app/admin/maintenance.php'>
               <i class='fa fa-tools'></i>
               <span class='labelText'>Registry Maintenance</span>
             </a>
           </li>
-          <?php endif; ?>
-          <?php if (hasPerm([2], $user->data()->id)): ?>
+          <li class=''>
+            <a class='' href='<?= $us_url_root ?>app/admin/design-system.php'>
+              <i class='fa fa-palette'></i>
+              <span class='labelText'>Design System</span>
+            </a>
+          </li>
           <div class='dropdown-divider'></div>
           <li class=''>
             <a class='' href='<?= $us_url_root ?>users/admin.php'>


### PR DESCRIPTION
## Summary

- Rename three admin pages via `git mv` for clarity: `manage-consolidated.php` → `index.php`, `manage-maintenance.php` → `maintenance.php`, `color-preview.php` → `design-system.php`
- Add Design System link to admin nav dropdown (Administrator-only via `hasPerm([2])`)
- Add `08-Rename-Admin-Pages.php` fix script to update UserSpice `pages` table registrations; must be run once after deployment before `21-Fix-Page-Permissions.php`
- Update all cross-references in views, actions, classes, tests, and docs
- Fix `design-system.php` missing from `ADMIN_ONLY_PAGES` in `PagePermissionClassifier` (nav gated it Admin-only but classifier granted Admin+Editor access)
- Fix pre-existing broken redirect in `process-admin-contact.php` (`?tab=data-quality` tab never existed; corrected to `?tab=manage-cars`)

## Test plan

- [ ] 983/983 unit tests pass (4 new classifier cases added; named invariant updated to include `design-system.php`)
- [ ] Pre-commit hooks: PHPStan clean, phpcs warnings only (advisory), markdown lint clean, ESLint clean
- [ ] Manual: `app/admin/index.php`, `app/admin/maintenance.php`, `app/admin/design-system.php` all load; old URLs 404
- [ ] Manual: Design System link visible in admin nav for Administrator, hidden for Editor
- [ ] Manual: Run `08-Rename-Admin-Pages.php` → all three renames report ✅
- [ ] Manual: Admin contact form submission redirects to `index.php?tab=manage-cars`

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy