### PR TITLE
refactor: migrate admin settings $.ajax() calls to ElanRegistryAPI (#528)

### DIFF
--- a/app/admin/includes/process-admin-settings.php
+++ b/app/admin/includes/process-admin-settings.php
@@ -6,9 +6,9 @@ declare(strict_types=1);
  * process-admin-settings.php
  * Pattern A endpoint for updating registry settings from the admin settings tab.
  *
- * Accepts a single field update (field, value, type, table) and writes it to the
- * settings table. Field names are validated against an explicit allowlist to prevent
- * unauthorised column access.
+ * Accepts a single field update (field, value, table) and writes it to the settings
+ * table. Field type is derived server-side from FIELD_TYPES — never from POST — to
+ * prevent type-mismatch bypasses on per-field numeric or boolean validation.
  *
  * Called by: app/admin/includes/tab-settings.php via ElanRegistryAPI
  * Issue #528 — Migrate admin settings $.ajax() calls to ElanRegistryAPI
@@ -30,24 +30,24 @@ if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
         ->send();
 }
 
-// Field allowlist — must match $allSettingsFields in processSettingsAutoCreation() (tab-settings.php)
-const ALLOWED_SETTINGS_FIELDS = [
-    'elan_image_dir',
-    'elan_image_max',
-    'elan_image_upload_max_size',
-    'elan_image_display_max_size',
-    'elan_image_thumbnail_sizes',
-    'elan_admin_emails',
-    'elan_feedback_email',
+// Field-to-type map — type is always server-derived, never from POST.
+// Must match $allSettingsFields in processSettingsAutoCreation() (tab-settings.php).
+const FIELD_TYPES = [
+    'elan_image_dir'              => 'txt',
+    'elan_image_max'              => 'num',
+    'elan_image_upload_max_size'  => 'num',
+    'elan_image_display_max_size' => 'num',
+    'elan_image_thumbnail_sizes'  => 'txt',
+    'elan_admin_emails'           => 'txt',
+    'elan_feedback_email'         => 'txt',
 ];
 
 $field = (string)($_POST['field'] ?? '');
 $table = (string)($_POST['table'] ?? 'settings');
-$type  = (string)($_POST['type'] ?? '');
 $value = $_POST['value'] ?? '';
 $desc  = trim((string)($_POST['desc'] ?? $field));
 
-if (!in_array($field, ALLOWED_SETTINGS_FIELDS, true)) {
+if (!array_key_exists($field, FIELD_TYPES)) {
     ApiResponse::error('Invalid setting field', 400)
         ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, "Rejected unknown settings field: {$field}")
         ->send();
@@ -59,12 +59,7 @@ if ($table !== 'settings') {
         ->send();
 }
 
-if (!in_array($type, ['toggle', 'num', 'txt'], true)) {
-    ApiResponse::error('Invalid type', 400)
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY,
-            "Rejected invalid type '{$type}' for settings field: {$field}")
-        ->send();
-}
+$type = FIELD_TYPES[$field];
 
 if ($type === 'num' && !is_numeric($value)) {
     ApiResponse::error('Value must be numeric', 400)
@@ -75,13 +70,13 @@ if ($type === 'num' && !is_numeric($value)) {
 
 $processedValue = match ($type) {
     'toggle' => filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 1 : 0,
-    'num'    => $value,
+    'num'    => $value + 0,
     default  => (string) $value,
 };
 
 try {
     $db = DB::getInstance();
-    $updated = $db->update('settings', 1, [$field => $processedValue]);
+    $updated = $db->update($table, 1, [$field => $processedValue]);
 
     if (!$updated || $db->error()) {
         ApiResponse::serverError('Database error updating setting')

--- a/app/admin/includes/process-admin-settings.php
+++ b/app/admin/includes/process-admin-settings.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * process-admin-settings.php
+ * Pattern A endpoint for updating registry settings from the admin settings tab.
+ *
+ * Accepts a single field update (field, value, type, table) and writes it to the
+ * settings table. Field names are validated against an explicit allowlist to prevent
+ * unauthorised column access.
+ *
+ * Called by: app/admin/includes/tab-settings.php via ElanRegistryAPI
+ * Issue #528 — Migrate admin settings $.ajax() calls to ElanRegistryAPI
+ */
+
+require_once '../../../users/init.php';
+
+// Admin-only (level 2) — matches maintenance.php access requirement
+if (!$user->isLoggedIn() || !hasPerm([2], $user->data()->id)) {
+    ApiResponse::forbidden('Access denied')
+        ->withLogging(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized admin settings update attempt')
+        ->send();
+}
+
+// CSRF protection
+if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
+    ApiResponse::forbidden('Invalid CSRF token')
+        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in admin settings update')
+        ->send();
+}
+
+// Field allowlist — must match $allSettingsFields in processSettingsAutoCreation() (tab-settings.php)
+const ALLOWED_SETTINGS_FIELDS = [
+    'elan_image_dir',
+    'elan_image_max',
+    'elan_image_upload_max_size',
+    'elan_image_display_max_size',
+    'elan_image_thumbnail_sizes',
+    'elan_admin_emails',
+    'elan_feedback_email',
+];
+
+$field = (string)($_POST['field'] ?? '');
+$table = (string)($_POST['table'] ?? 'settings');
+$type  = (string)($_POST['type'] ?? '');
+$value = $_POST['value'] ?? '';
+$desc  = trim((string)($_POST['desc'] ?? $field));
+
+if (!in_array($field, ALLOWED_SETTINGS_FIELDS, true)) {
+    ApiResponse::error('Invalid setting field', 400)
+        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, "Rejected unknown settings field: {$field}")
+        ->send();
+}
+
+if ($table !== 'settings') {
+    ApiResponse::error('Invalid table', 400)
+        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, "Rejected unexpected settings table: {$table}")
+        ->send();
+}
+
+if (!in_array($type, ['toggle', 'num', 'txt'], true)) {
+    ApiResponse::error('Invalid type', 400)
+        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY,
+            "Rejected invalid type '{$type}' for settings field: {$field}")
+        ->send();
+}
+
+if ($type === 'num' && !is_numeric($value)) {
+    ApiResponse::error('Value must be numeric', 400)
+        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY,
+            "Rejected non-numeric value for numeric settings field: {$field}")
+        ->send();
+}
+
+$processedValue = match ($type) {
+    'toggle' => filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 1 : 0,
+    'num'    => $value,
+    default  => (string) $value,
+};
+
+try {
+    $db = DB::getInstance();
+    $updated = $db->update('settings', 1, [$field => $processedValue]);
+
+    if (!$updated || $db->error()) {
+        ApiResponse::serverError('Database error updating setting')
+            ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SYSTEM_ERROR,
+                "DB error updating settings.{$field}: " . $db->errorString())
+            ->send();
+    }
+
+    $label = $desc !== '' ? htmlspecialchars($desc, ENT_QUOTES, 'UTF-8') : $field;
+
+    ApiResponse::success($label . ' updated successfully')
+        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SETTINGS_UPDATE,
+            "Admin settings: {$field} updated")
+        ->send();
+} catch (\Throwable $e) {
+    ApiResponse::serverError('Failed to update setting')
+        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SYSTEM_ERROR,
+            'Admin settings update exception: ' . $e->getMessage())
+        ->send();
+}

--- a/app/admin/includes/tab-settings.php
+++ b/app/admin/includes/tab-settings.php
@@ -339,104 +339,42 @@ $autoCreationMessages = processSettingsAutoCreation();
 
 <script>
 // Settings management JavaScript
-function settingsMessages(data) {
-    console.log(data.msg);
+function settingsMessages(msg, type) {
     $('#settingsMessages').removeClass();
-    $('#settingsMessage').text("");
+    $('#settingsMessage').text('');
     $('#settingsMessages').show();
-    if (data.success == "true") {
-        $('#settingsMessages').addClass("alert alert-success alert-dismissible fade show");
-        $('#settingsMessage').text(data.msg || 'Setting updated successfully');
+    if (type === 'success') {
+        $('#settingsMessages').addClass('alert alert-success alert-dismissible fade show');
+        $('#settingsMessage').text(msg || 'Setting updated successfully');
     } else {
-        $('#settingsMessages').addClass("alert alert-danger alert-dismissible fade show");
-        $('#settingsMessage').text(data.msg || 'Error updating setting');
+        $('#settingsMessages').addClass('alert alert-danger alert-dismissible fade show');
+        $('#settingsMessage').text(msg || 'Error updating setting');
     }
     $('#settingsMessages').delay(3000).fadeOut('slow');
 }
 
 $(document).ready(function() {
-    // Handle toggle switches
-    $(".toggle").change(function() {
-        var value = $(this).prop("checked");
-        $(this).prop("checked", value);
+    const settingsEndpoint = '<?= $us_url_root ?>app/admin/includes/process-admin-settings.php';
 
-        var field = $(this).attr("id");
-        var desc = $(this).attr("data-desc");
-        var table = $(this).attr("data-table") || 'settings';
-        var formData = {
-            'value': value,
-            'field': field,
-            'desc': desc,
-            'table': table,
-            'type': 'toggle',
-            'token': "<?= Token::generate() ?>",
-        };
+    function postSetting(elem, value, type) {
+        new ElanRegistryAPI().post(settingsEndpoint, {
+            field: elem.attr('id'),
+            value: value,
+            desc:  elem.data('desc') || elem.attr('id'),
+            table: elem.data('table') || 'settings',
+            type:  type
+        })
+        .then(function(r) { settingsMessages(r.message, 'success'); })
+        .catch(function(e) {
+            if (!(e instanceof ApiCancelledError)) {
+                settingsMessages(e.message, 'error');
+            }
+        });
+    }
 
-        // @deprecated - migrate to ElanRegistryAPI (Issue #481)
-        $.ajax({
-                type: 'POST',
-                url: '../../users/parsers/admin_settings.php',
-                data: formData,
-                dataType: 'json',
-            })
-            .done(function(data) {
-                settingsMessages(data);
-            });
-    });
-
-    // Handle numeric fields
-    $(".ajxnum").change(function() {
-        var value = $(this).val();
-        var field = $(this).attr("id");
-        var desc = $(this).attr("data-desc");
-        var table = $(this).attr("data-table") || 'settings';
-        var formData = {
-            'value': value,
-            'field': field,
-            'desc': desc,
-            'table': table,
-            'type': 'num',
-            'token': "<?= Token::generate() ?>",
-        };
-
-        // @deprecated - migrate to ElanRegistryAPI (Issue #481)
-        $.ajax({
-                type: 'POST',
-                url: '../../users/parsers/admin_settings.php',
-                data: formData,
-                dataType: 'json',
-            })
-            .done(function(data) {
-                settingsMessages(data);
-            });
-    });
-
-    // Handle text fields
-    $(".ajxtxt").change(function() {
-        var value = $(this).val();
-        var field = $(this).attr("id");
-        var desc = $(this).attr("data-desc");
-        var table = $(this).attr("data-table") || 'settings';
-        var formData = {
-            'value': value,
-            'field': field,
-            'desc': desc,
-            'table': table,
-            'type': 'txt',
-            'token': "<?= Token::generate() ?>",
-        };
-
-        // @deprecated - migrate to ElanRegistryAPI (Issue #481)
-        $.ajax({
-                type: 'POST',
-                url: '../../users/parsers/admin_settings.php',
-                data: formData,
-                dataType: 'json',
-            })
-            .done(function(data) {
-                settingsMessages(data);
-            });
-    });
+    $('.toggle').change(function() { postSetting($(this), $(this).prop('checked'), 'toggle'); });
+    $('.ajxnum').change(function() { postSetting($(this), $(this).val(), 'num'); });
+    $('.ajxtxt').change(function() { postSetting($(this), $(this).val(), 'txt'); });
 });
 
 // Test Email Configuration

--- a/app/admin/includes/tab-settings.php
+++ b/app/admin/includes/tab-settings.php
@@ -355,14 +355,14 @@ function settingsMessages(msg, type) {
 
 $(document).ready(function() {
     const settingsEndpoint = '<?= $us_url_root ?>app/admin/includes/process-admin-settings.php';
+    const api = new ElanRegistryAPI();
 
-    function postSetting(elem, value, type) {
-        new ElanRegistryAPI().post(settingsEndpoint, {
+    function postSetting(elem, value) {
+        api.post(settingsEndpoint, {
             field: elem.attr('id'),
             value: value,
             desc:  elem.data('desc') || elem.attr('id'),
             table: elem.data('table') || 'settings',
-            type:  type
         })
         .then(function(r) { settingsMessages(r.message, 'success'); })
         .catch(function(e) {
@@ -372,9 +372,9 @@ $(document).ready(function() {
         });
     }
 
-    $('.toggle').change(function() { postSetting($(this), $(this).prop('checked'), 'toggle'); });
-    $('.ajxnum').change(function() { postSetting($(this), $(this).val(), 'num'); });
-    $('.ajxtxt').change(function() { postSetting($(this), $(this).val(), 'txt'); });
+    $('.toggle').change(function() { postSetting($(this), $(this).prop('checked')); });
+    $('.ajxnum').change(function() { postSetting($(this), $(this).val()); });
+    $('.ajxtxt').change(function() { postSetting($(this), $(this).val()); });
 });
 
 // Test Email Configuration

--- a/docs/releases/RELEASE_NOTES_v2.25.3.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.3.md
@@ -48,6 +48,9 @@ public URL changes.
   with no page reload; sender identity read from trusted session, not POST hidden fields (#1038)
 - Add `08-Rename-Admin-Pages.php` fix script to update UserSpice `pages` table URL
   registrations for the three renamed admin pages; run after deployment (#1039)
+- Replace 3 deprecated `$.ajax()` calls in admin settings tab with `ElanRegistryAPI`;
+  add `process-admin-settings.php` Pattern A endpoint with explicit field allowlist and
+  admin-only (level 2) auth guard; fixes security issues in upstream parser (#528)
 
 ## Issues Resolved
 

--- a/tests/playwright/ajax-endpoints.spec.js
+++ b/tests/playwright/ajax-endpoints.spec.js
@@ -323,12 +323,11 @@ test.describe('Registry-Specific AJAX Endpoints', () => {
       data: {
         field: 'elan_image_max',
         value: '10',
-        type: 'num',
         csrf: 'test_token'
       }
     });
 
-    // Regular user should get 403 Forbidden
+    // Unauthenticated request should get 403 Forbidden
     expect(response.status()).toBe(403);
 
     try {

--- a/tests/playwright/ajax-endpoints.spec.js
+++ b/tests/playwright/ajax-endpoints.spec.js
@@ -317,6 +317,30 @@ test.describe('Registry-Specific AJAX Endpoints', () => {
     }
   });
 
+  test('admin settings endpoint requires admin permissions', async ({ page }) => {
+    // Test the admin-only (level 2) settings update endpoint
+    const response = await page.request.post('app/admin/includes/process-admin-settings.php', {
+      data: {
+        field: 'elan_image_max',
+        value: '10',
+        type: 'num',
+        csrf: 'test_token'
+      }
+    });
+
+    // Regular user should get 403 Forbidden
+    expect(response.status()).toBe(403);
+
+    try {
+      const jsonResponse = await response.json();
+      expect(jsonResponse).toHaveProperty('success', false);
+      expect(jsonResponse).toHaveProperty('message');
+    } catch (error) {
+      // If not JSON, should still be 403
+      expect(response.status()).toBe(403);
+    }
+  });
+
   test('feedback endpoint requires CSRF and returns JSON', async ({ page }) => {
     const response = await page.request.post('app/api/contact/send-feedback.php', {
       form: {

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -28,6 +28,7 @@ class LogCategoriesUsageTest extends TestCase
         'app/admin/includes/process-transfer-approve.php',
         'app/admin/includes/process-transfer-deny.php',
         'app/admin/includes/process-car-details.php',
+        'app/admin/includes/process-admin-settings.php',
     ];
 
     /**


### PR DESCRIPTION
## Summary

- Replace 3 deprecated `$.ajax()` calls in `tab-settings.php` with `ElanRegistryAPI` using the standard `.then/.catch` pattern
- Add `process-admin-settings.php` — a native Pattern A endpoint with explicit field allowlist, admin-only (level 2) auth guard, CSRF validation, and DB update return-value check
- Eliminates reliance on `users/parsers/admin_settings.php` (upstream UserSpice, non-standard response format, unsanitized column names) for registry settings updates
- Add `process-admin-settings.php` to `LogCategoriesUsageTest` scan list and Playwright 403 auth guard test

## Key design decisions

- **New endpoint over proxy wrapper**: A proxy would inherit the upstream parser's security issues (unsanitized `$field` column name, SQL-interpolated table name). The new endpoint uses an explicit allowlist matching `processSettingsAutoCreation()` in `tab-settings.php`.
- **`hasPerm([2])` not `isRegistryAdmin()`**: Settings live under `maintenance.php` which is admin-only (level 2). `isRegistryAdmin()` includes level-3 Editors; that would be incorrect here.
- **DB return value guard**: `$updated = $db->update(...); if (!$updated || $db->error())` catches both thrown exceptions (via `catch \Throwable`) and silent structural failures (via the return value check).

## Test plan

- [x] 985/985 unit tests pass (includes new LogCategories scan of the new endpoint)
- [x] ESLint clean
- [x] Pre-commit hooks pass (phpcs, PHPStan, unit tests)
- [ ] Manual: open `maintenance.php?tab=settings`, change a text/numeric field, verify green inline alert and DB update
- [ ] Playwright: `npm run playwright:security` — new 403 test for `process-admin-settings.php`

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy