### PR TITLE
refactor: update PagePermissionClassifier for app/api/ paths and admin renames

### DIFF
--- a/app/admin/design-system.php
+++ b/app/admin/design-system.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * stat tiles, form fields, charts) so the visual system can be reviewed in
  * one screen before site-wide rollout.
  *
- * Admin-only via UserSpice securePage(). Tokens themselves live in
+ * Admin/Editor access via UserSpice securePage(). Tokens themselves live in
  * usersc/templates/customizer.css.
  */
 

--- a/app/admin/scripts/maintenance/21-Fix-Page-Permissions.php
+++ b/app/admin/scripts/maintenance/21-Fix-Page-Permissions.php
@@ -17,20 +17,24 @@ declare(strict_types=1);
  *
  * ADMIN-ONLY PAGES (will be set to private=1 with Administrator permission only):
  * - app/admin/scripts/* - All admin maintenance & fix scripts
- * - app/admin/manage-maintenance.php - Maintenance portal page
+ * - app/admin/maintenance.php - Maintenance portal page
  * - app/admin/includes/tab-health.php - Health tab include
  * - app/admin/includes/tab-maintenance.php - Maintenance tab include
  *
  * ADMIN+EDITOR PAGES (will be set to private=1 with Admin+Editor permissions):
  * - app/admin/* - All other admin pages (not in admin-only list above)
+ *   Examples: app/admin/index.php, app/admin/design-system.php
  * - *admin* - Any other path containing "admin" (includes docs/admin/*, etc.)
- * - docs/*admin* - Admin documentation pages
  *
  * OWNER/USER PRIVATE PAGES (will be set to private=1 with User permission):
- * - app/cars/actions* - All car action endpoints
+ * - app/api/contact/* - Contact API endpoints (send-feedback, send-owner-email)
  * - app/contact/* - All contact form pages
  * - *edit* - Any path containing "edit" (that doesn't also contain "admin")
  * - usersc/* - All UserSpice customization pages (EXCEPT special cases below)
+ * Note: app/api/cars/* and app/api/shared/* endpoints that don't call
+ * securePage() are not registered in the pages table and not managed here
+ * (some app/api/cars/* endpoints enforce authentication inline without
+ * securePage() and are private, but they are outside this script's scope).
  *
  * SPECIAL CASE PRIVATE PAGES (will be set to private=1 with NO permissions):
  * - usersc/join.php - Registration page (public access, no permissions needed)
@@ -425,18 +429,19 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                                 <p class="mb-2"><strong>Admin-Only (private=1, Administrator permission only):</strong></p>
                                 <ul>
                                     <li><strong>app/admin/scripts/*</strong> - All admin fix &amp; maintenance scripts</li>
-                                    <li><strong>app/admin/manage-maintenance.php</strong> - Maintenance portal</li>
+                                    <li><strong>app/admin/maintenance.php</strong> - Maintenance portal</li>
                                     <li><strong>app/admin/includes/tab-health.php</strong> - Health tab include</li>
                                     <li><strong>app/admin/includes/tab-maintenance.php</strong> - Maintenance tab include</li>
                                 </ul>
                                 <p class="mb-2"><strong>Admin + Editor (private=1, Administrator + Editor permissions):</strong></p>
                                 <ul>
                                     <li><strong>app/admin/*</strong> - All other admin pages</li>
+                                    <li><strong>app/admin/design-system.php</strong> - Design system reference (example; covered by wildcard above)</li>
                                     <li><strong>*admin*</strong> - Any other path containing "admin"</li>
                                 </ul>
                                 <p class="mb-2"><strong>Owner (private=1, User permission):</strong></p>
                                 <ul>
-                                    <li><strong>app/cars/actions*</strong> - All car action endpoints</li>
+                                    <li><strong>app/api/contact/*</strong> - Contact API endpoints</li>
                                     <li><strong>app/contact/*</strong> - All contact form pages</li>
                                     <li><strong>*edit*</strong> - Any path containing "edit"</li>
                                     <li><strong>usersc/*</strong> - All UserSpice customization pages</li>

--- a/app/api/shared/statistics.php
+++ b/app/api/shared/statistics.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 /**
  * statistics.php (formerly statistics-data.php)
- * API endpoint for lazy-loading statistics tab data
+ * Public API endpoint for lazy-loading statistics tab data
  *
  * Returns JSON data for specific tab content to enable progressive loading
- * and improve page performance.
+ * and improve page performance. No authentication required — statistics
+ * data is publicly accessible.
  *
  * @author Elan Registry Development Team
  * @copyright 2025
@@ -16,14 +17,6 @@ declare(strict_types=1);
 require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/classes/StatisticsDataService.php';
 
-// Security check
-if (!securePage($php_self)) {
-    ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized statistics endpoint access attempt')
-        ->send();
-}
-
-// Get requested tab
 $tab = Input::get('tab');
 
 if (empty($tab)) {
@@ -32,7 +25,6 @@ if (empty($tab)) {
         ->send();
 }
 
-// Initialize data service
 try {
     if (!isset($db)) {
         ApiResponse::serverError('Database connection not available')

--- a/docs/releases/RELEASE_NOTES_v2.25.3.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.3.md
@@ -51,6 +51,10 @@ public URL changes.
 - Replace 3 deprecated `$.ajax()` calls in admin settings tab with `ElanRegistryAPI`;
   add `process-admin-settings.php` Pattern A endpoint with explicit field allowlist and
   admin-only (level 2) auth guard; fixes security issues in upstream parser (#528)
+- Update `PagePermissionClassifier` to move `design-system.php` from Admin-only to
+  Editor-level; remove unnecessary `securePage()` from public `statistics.php` API
+  endpoint; update fix script PHPDoc and on-screen alert to reflect current `app/api/`
+  and renamed admin page structure (#1059)
 
 ## Issues Resolved
 

--- a/tests/unit/admin/PagePermissionClassifierTest.php
+++ b/tests/unit/admin/PagePermissionClassifierTest.php
@@ -259,7 +259,7 @@ final class PagePermissionClassifierTest extends TestCase
         }
     }
 
-    public function testPublicApiEndpointClassifierResultIsIrrelevantWhenNotRegistered(): void
+    public function testUnregisteredPublicApiEndpointIsNeverAdminTier(): void
     {
         // statistics.php does not call securePage() and is therefore never registered
         // in the pages table. The classifier marks app/api/* paths as private (matching

--- a/tests/unit/admin/PagePermissionClassifierTest.php
+++ b/tests/unit/admin/PagePermissionClassifierTest.php
@@ -60,6 +60,7 @@ final class PagePermissionClassifierTest extends TestCase
             'user settings (owner page)'        => ['usersc/user_settings.php',                                 false],
             'car listing (public)'              => ['app/cars/index.php',                                       false],
             'car actions (owner)'               => ['app/api/cars/save.php',                                   false],
+            'api send-feedback (not admin)'     => ['app/api/contact/send-feedback.php',                       false],
             'contact form (owner)'              => ['app/contact/form.php',                                     false],
             'error page'                        => ['404.php',                                                  false],
         ];
@@ -84,11 +85,11 @@ final class PagePermissionClassifierTest extends TestCase
             'fix script'                        => ['app/admin/scripts/fix/01-something.php',                   true],
             'scripts root'                      => ['app/admin/scripts/index.php',                              true],
             // Admin-only: maintenance portal pages
-            'manage-maintenance'                => ['app/admin/maintenance.php',                         true],
-            'design-system'                     => ['app/admin/design-system.php',                               true],
+            'maintenance'                       => ['app/admin/maintenance.php',                         true],
             'tab-health'                        => ['app/admin/includes/tab-health.php',                        true],
             'tab-maintenance'                   => ['app/admin/includes/tab-maintenance.php',                   true],
-            // Admin+Editor: general admin panel
+            // Admin+Editor: general admin panel (including design-system)
+            'design-system'                     => ['app/admin/design-system.php',                              false],
             'manage-consolidated'               => ['app/admin/manage-consolidated.php',                        false],
             'admin index (dashboard)'           => ['app/admin/index.php',                                      false],
             'tab-cars'                          => ['app/admin/includes/tab-cars.php',                          false],
@@ -119,6 +120,8 @@ final class PagePermissionClassifierTest extends TestCase
             'docs admin'                        => ['docs/admin/guide.php',               true],
             // Owner pages are private
             'car action'                        => ['app/api/cars/save.php',              true],
+            'api send-feedback (owner)'         => ['app/api/contact/send-feedback.php',    true],
+            'api send-owner-email (owner)'      => ['app/api/contact/send-owner-email.php', true],
             'contact page'                      => ['app/contact/form.php',               true],
             'edit page'                         => ['app/cars/edit-car.php',              true],
             'usersc page'                       => ['usersc/user_settings.php',           true],
@@ -153,7 +156,7 @@ final class PagePermissionClassifierTest extends TestCase
         foreach ($specialPages as $page) {
             $this->assertFalse(
                 PagePermissionClassifier::shouldHaveAdminPermissions($page),
-                "Page '{$page}' is in shouldBePrivateNoPermissions but also matches shouldHaveAdminPermissions — this would cause the conflict guard to skip it"
+                "'{$page}' must not match shouldHaveAdminPermissions — the conflict guard would skip it"
             );
         }
     }
@@ -188,7 +191,6 @@ final class PagePermissionClassifierTest extends TestCase
     {
         $maintenancePages = [
             'app/admin/maintenance.php',
-            'app/admin/design-system.php',
             'app/admin/includes/tab-health.php',
             'app/admin/includes/tab-maintenance.php',
         ];
@@ -215,14 +217,69 @@ final class PagePermissionClassifierTest extends TestCase
         foreach ($scriptPaths as $page) {
             $this->assertTrue(
                 PagePermissionClassifier::shouldBeAdminOnly($page),
-                "Admin script '{$page}' must be admin-only (issue #797)"
+                "'{$page}' must be admin-only (issue #797)"
             );
         }
+    }
+
+    public function testDesignSystemPageIsEditorLevel(): void
+    {
+        $path = 'app/admin/design-system.php';
+
+        $this->assertTrue(
+            PagePermissionClassifier::shouldHaveAdminPermissions($path),
+            'design-system.php must require admin permission'
+        );
+        $this->assertFalse(
+            PagePermissionClassifier::shouldBeAdminOnly($path),
+            'design-system.php must be admin+editor, not admin-only'
+        );
+    }
+
+    public function testContactApiEndpointsAreOwnerTier(): void
+    {
+        $contactEndpoints = [
+            'app/api/contact/send-feedback.php',
+            'app/api/contact/send-owner-email.php',
+        ];
+
+        foreach ($contactEndpoints as $path) {
+            $this->assertTrue(
+                PagePermissionClassifier::shouldBePrivate($path),
+                "'{$path}' must be owner-tier private"
+            );
+            $this->assertFalse(
+                PagePermissionClassifier::shouldHaveAdminPermissions($path),
+                "'{$path}' must not require admin permission (owner-tier, not admin-tier)"
+            );
+            $this->assertFalse(
+                PagePermissionClassifier::shouldBeAdminOnly($path),
+                "'{$path}' must not be admin-only"
+            );
+        }
+    }
+
+    public function testPublicApiEndpointClassifierResultIsIrrelevantWhenNotRegistered(): void
+    {
+        // statistics.php does not call securePage() and is therefore never registered
+        // in the pages table. The classifier marks app/api/* paths as private (matching
+        // #^app/api/#), but that result is never applied — the Fix Page Permissions script
+        // only processes pages that are registered. Public API endpoints must NOT call
+        // securePage() precisely to stay out of the pages table.
+        $this->assertTrue(
+            PagePermissionClassifier::shouldBePrivate('app/api/shared/statistics.php'),
+            'classifier marks app/api/* private, but unregistered paths are never processed'
+        );
+        $this->assertFalse(
+            PagePermissionClassifier::shouldHaveAdminPermissions('app/api/shared/statistics.php'),
+            'public statistics endpoint must not require admin permission'
+        );
     }
 
     public function testGeneralAdminPagesAreNotAdminOnly(): void
     {
         $adminEditorPages = [
+            'app/admin/design-system.php',
             'app/admin/index.php',
             'app/admin/includes/tab-cars.php',
             'docs/admin/guide.php',

--- a/usersc/classes/admin/PagePermissionClassifier.php
+++ b/usersc/classes/admin/PagePermissionClassifier.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * - Special-no-perms: PRIVATE with no permission entries (login, join)
  * - Admin-only: PRIVATE with Administrator only (maintenance scripts, portal)
  * - Admin+Editor: PRIVATE with Administrator + Editor (general admin panel)
- * - Owner: PRIVATE with User permission (usersc/*, edit pages, car actions)
+ * - Owner: PRIVATE with User permission (usersc/*, edit pages, app/api/contact/*)
  * - Public: private=0, no permissions (everything else)
  */
 class PagePermissionClassifier
@@ -34,7 +34,6 @@ class PagePermissionClassifier
      */
     private const ADMIN_ONLY_PAGES = [
         'app/admin/maintenance.php',
-        'app/admin/design-system.php',
         'app/admin/includes/tab-health.php',
         'app/admin/includes/tab-maintenance.php',
     ];
@@ -112,7 +111,11 @@ class PagePermissionClassifier
             '#^app/admin/scripts/#',             // app/admin/scripts/* maintenance & fix scripts
             '#^app/admin/#',                     // app/admin/* pages
             '#admin#',                           // Any path containing "admin"
-            '#^app/api/#',                       // app/api/* endpoints — all treated as owner-tier private
+            '#^app/api/#',                       // app/api/* endpoints registered via securePage() are owner-tier private
+                                             //   (currently only app/api/contact/*). Endpoints that enforce auth
+                                             //   inline without securePage() (e.g. app/api/cars/*) and purely
+                                             //   public endpoints (e.g. app/api/shared/statistics.php) must NOT
+                                             //   call securePage() — they are never registered and never reach here.
             '#^app/contact/#',                   // app/contact/* pages
             '#edit#',                            // Any path containing "edit"
             '#^usersc/#'                         // usersc/* pages

--- a/usersc/classes/admin/PagePermissionClassifier.php
+++ b/usersc/classes/admin/PagePermissionClassifier.php
@@ -112,10 +112,10 @@ class PagePermissionClassifier
             '#^app/admin/#',                     // app/admin/* pages
             '#admin#',                           // Any path containing "admin"
             '#^app/api/#',                       // app/api/* endpoints registered via securePage() are owner-tier private
-                                             //   (currently only app/api/contact/*). Endpoints that enforce auth
-                                             //   inline without securePage() (e.g. app/api/cars/*) and purely
-                                             //   public endpoints (e.g. app/api/shared/statistics.php) must NOT
-                                             //   call securePage() — they are never registered and never reach here.
+                                             //   (currently only app/api/contact/*). Endpoints that enforce auth inline
+                                             //   without securePage() (e.g. app/api/cars/*) and purely public endpoints
+                                             //   (e.g. app/api/shared/statistics.php) must NOT call securePage() —
+                                             //   they are never registered and never reach here.
             '#^app/contact/#',                   // app/contact/* pages
             '#edit#',                            // Any path containing "edit"
             '#^usersc/#'                         // usersc/* pages


### PR DESCRIPTION
## Summary

- Remove `design-system.php` from `ADMIN_ONLY_PAGES` — it should be Admin+Editor level, not Admin-only (all non-maintenance admin pages are Editor-level per the project permission model)
- Remove unnecessary `securePage()` from `app/api/shared/statistics.php` — the endpoint serves public aggregate data; `init.php` still provides session context for anonymous-safe logging (`$user->data()->id ?? 0`)
- Update `21-Fix-Page-Permissions.php` PHPDoc and HTML alert: `maintenance.php` replaces stale `manage-maintenance.php`, `app/api/contact/*` replaces deleted `app/cars/actions*`, `design-system.php` added as Admin+Editor example
- Clarify `#^app/api/#` pattern comment to distinguish three endpoint categories: endpoints registered via `securePage()` (owner-tier, currently only contact/*), endpoints that enforce auth inline without `securePage()` (app/api/cars/*), and purely public endpoints (statistics.php)

## Test plan

- [x] `testDesignSystemPageIsEditorLevel` — asserts `shouldHaveAdminPermissions=true` and `shouldBeAdminOnly=false`
- [x] `testContactApiEndpointsAreOwnerTier` — asserts private + not-admin + not-admin-only for both contact endpoints
- [x] `testPublicApiEndpointClassifierResultIsIrrelevantWhenNotRegistered` — documents that `app/api/shared/statistics.php` is never registered in the pages table and the classifier result is never applied
- [x] Updated `adminOnlyProvider` — `design-system` now `false`; `manage-maintenance` label renamed to `maintenance`
- [x] Updated `testMaintenancePortalPagesAreAdminOnly` — removed `design-system.php`
- [x] Updated `testGeneralAdminPagesAreNotAdminOnly` — added `design-system.php`
- [x] 991/991 tests passing; PHPStan clean; pre-commit hooks passed

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy