### PR TITLE
refactor: relocate process-admin-settings.php to app/api/admin/ (#1099)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ edge caching and CDN for global users (US, EU, AU).
 - `/app/` - Main application pages (car listings, details, forms, actions)
   - `/app/api/` - AJAX JSON endpoints, organized by resource: `cars/` (car CRUD and
     validation), `contact/` (contact forms, auth-required), `shared/` (public endpoints:
-    statistics, location search). All endpoints follow Pattern A / `ApiResponse`.
+    statistics, location search), `admin/` (admin-only settings updates). All endpoints
+    follow Pattern A / `ApiResponse`.
   - `/app/views/` - Reusable view partials: `cars/` (car page components), `email/`
     (transactional email templates)
 - `/docs/` - User-facing documentation: `guides/` (how-to), `reference/` (technical), `stories/` (car histories)

--- a/app/admin/includes/tab-settings.php
+++ b/app/admin/includes/tab-settings.php
@@ -354,7 +354,7 @@ function settingsMessages(msg, type) {
 }
 
 $(document).ready(function() {
-    const settingsEndpoint = '<?= $us_url_root ?>app/admin/includes/process-admin-settings.php';
+    const settingsEndpoint = '<?= $us_url_root ?>app/api/admin/process-settings.php';
     const api = new ElanRegistryAPI();
 
     function postSetting(elem, value) {

--- a/app/api/admin/process-settings.php
+++ b/app/api/admin/process-settings.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * process-admin-settings.php
+ * process-settings.php
  * Pattern A endpoint for updating registry settings from the admin settings tab.
  *
  * Accepts a single field update (field, value, table) and writes it to the settings

--- a/docs/releases/RELEASE_NOTES_v2.25.3.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.3.md
@@ -61,7 +61,7 @@ https://elanregistry.org/app/admin/scripts/maintenance/21-Fix-Page-Permissions.p
 - Add `08-Rename-Admin-Pages.php` fix script to update UserSpice `pages` table URL
   registrations for the three renamed admin pages; run after deployment (#1039)
 - Replace 3 deprecated `$.ajax()` calls in admin settings tab with `ElanRegistryAPI`;
-  add `process-admin-settings.php` Pattern A endpoint with explicit field allowlist and
+  add a Pattern A endpoint (`app/api/admin/process-settings.php`) with explicit field allowlist and
   admin-only (level 2) auth guard; fixes security issues in upstream parser (#528)
 - Update `PagePermissionClassifier` to move `design-system.php` from Admin-only to
   Editor-level; remove unnecessary `securePage()` from public `statistics.php` API
@@ -71,6 +71,8 @@ https://elanregistry.org/app/admin/scripts/maintenance/21-Fix-Page-Permissions.p
   `ElanRegistryAPI` Pattern A client (#968)
 - Migrate `manage-consolidated.php` car deletion path to `CarAdministrationService` for
   consistent service-layer ownership of admin-driven deletion (#932)
+- Relocate `process-admin-settings.php` from `app/admin/includes/` to
+  `app/api/admin/process-settings.php`, completing the `app/api/` consolidation (#1099)
 
 ## Issues Resolved
 
@@ -87,3 +89,4 @@ https://elanregistry.org/app/admin/scripts/maintenance/21-Fix-Page-Permissions.p
 - [#1038](https://github.com/unibrain1/elanregistry/issues/1038) — refactor: rewrite contact form handlers as JSON API endpoints
 - [#1039](https://github.com/unibrain1/elanregistry/issues/1039) — refactor: rename admin pages and update UserSpice page registrations
 - [#1059](https://github.com/unibrain1/elanregistry/issues/1059) — refactor: update 21-Fix-Page-Permissions to handle app/api/ and renamed admin pages
+- [#1099](https://github.com/unibrain1/elanregistry/issues/1099) — refactor: relocate process-admin-settings.php to app/api/admin/ to complete app/api/ consolidation

--- a/tests/playwright/ajax-endpoints.spec.js
+++ b/tests/playwright/ajax-endpoints.spec.js
@@ -319,7 +319,7 @@ test.describe('Registry-Specific AJAX Endpoints', () => {
 
   test('admin settings endpoint requires admin permissions', async ({ page }) => {
     // Test the admin-only (level 2) settings update endpoint
-    const response = await page.request.post('app/admin/includes/process-admin-settings.php', {
+    const response = await page.request.post('app/api/admin/process-settings.php', {
       data: {
         field: 'elan_image_max',
         value: '10',

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -28,7 +28,7 @@ class LogCategoriesUsageTest extends TestCase
         'app/admin/includes/process-transfer-approve.php',
         'app/admin/includes/process-transfer-deny.php',
         'app/admin/includes/process-car-details.php',
-        'app/admin/includes/process-admin-settings.php',
+        'app/api/admin/process-settings.php',
     ];
 
     /**

--- a/usersc/plugins/ai_prompts/custom_prompts/elanregistry_directories.md.php
+++ b/usersc/plugins/ai_prompts/custom_prompts/elanregistry_directories.md.php
@@ -27,6 +27,7 @@ projectroot/
 │   │       ├── fix/          # One-time migration scripts (run once, never again)
 │   │       └── maintenance/  # Repeatable maintenance scripts (safe to re-run)
 │   ├── api/          # AJAX API endpoints
+│   │   ├── admin/    # Admin-only API endpoints (process-settings.php)
 │   │   ├── cars/     # Car-specific API endpoints (save, history, chassis-validate, etc.)
 │   │   ├── contact/  # Contact form API endpoints (send-feedback, send-owner-email)
 │   │   └── shared/   # Shared API endpoints (statistics, location-search, location-reverse)
@@ -76,12 +77,13 @@ In ElanRegistry, **all AJAX API endpoints live under `app/api/`**, organised by 
 | Car operations | `app/api/cars/` |
 | Contact form operations | `app/api/contact/` |
 | Shared / cross-domain data | `app/api/shared/` |
-| Admin operations | `app/admin/` (or `app/admin/includes/` for shared handlers) |
+| Admin settings updates | `app/api/admin/` |
 
 The `parsers/` naming is not required in ElanRegistry. Directories under `app/api/` are generally
 **not** added to the `$path` array in `z_us_root.php` because they do not call `securePage()`.
 The exception is `app/api/contact/`, which is registered because both contact endpoints call
-`securePage()`. Endpoints in `app/api/cars/` and `app/api/shared/` must **not** call `securePage()`.
+`securePage()`. Endpoints in `app/api/cars/`, `app/api/shared/`, and `app/api/admin/` must
+**not** call `securePage()` — they enforce authentication inline.
 All endpoints in `app/api/` must follow the Pattern A / ApiResponse convention.
 
 ---


### PR DESCRIPTION
## Summary

Moves `app/admin/includes/process-admin-settings.php` to `app/api/admin/process-settings.php`,
completing the `app/api/` consolidation established in v2.25.3. All direct-XHR endpoints now
live under `app/api/` organized by resource — `cars/`, `contact/`, `shared/`, and now `admin/`.

No behavior change. Auth (admin-only level 2) and CSRF protection are unchanged. The `require_once`
depth is identical (3 levels up to project root from either location).

## Changes

- `git mv` rename with 99% similarity (only PHPDoc filename updated)
- `tab-settings.php`: `settingsEndpoint` URL updated to new path
- `LogCategoriesUsageTest.php`: path in `ENDPOINT_FILES` array updated
- `ajax-endpoints.spec.js`: Playwright test URL updated
- `CLAUDE.md`: `admin/` added to `app/api/` subdirectory listing
- `elanregistry_directories.md.php`: tree and AJAX endpoint table updated
- `RELEASE_NOTES_v2.25.3.md`: `#528` entry clarified; `#1099` entry added

## Test Plan

- [x] 991/991 unit tests pass
- [x] No remaining references to old path (`grep` clean)
- [x] PHPStan: 0 errors
- [x] Markdown lint: 0 errors
- [ ] Manual: verify admin settings tab still saves values after deployment

Closes #1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy