### PR TITLE
fix: harden transfer-request.php and chassis-availability.php (#1081)

### DIFF
--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -39,8 +39,14 @@ try {
         ApiResponse::error('Missing required parameters: year, model, and chassis', 400)->send();
     }
 
-    if (strlen($chassis) > 15 || strlen($year) > 4 || strlen($model) > 30) {
-        ApiResponse::error('Invalid parameter length', 400)->send();
+    if (strlen($chassis) > 15) {
+        ApiResponse::error('Chassis number must be 15 characters or less', 400)->send();
+    }
+    if (strlen($year) > 4) {
+        ApiResponse::error('Year must be 4 characters or less', 400)->send();
+    }
+    if (strlen($model) > 30) {
+        ApiResponse::error('Model must be 30 characters or less', 400)->send();
     }
 
     $modelParts = explode('|', $model);

--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -21,7 +21,7 @@ if (!Input::exists('post')) {
 $token = Input::get('csrf');
 if (!Token::check($token)) {
     ApiResponse::forbidden('Invalid CSRF token')
-        ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in chassis check')
+        ->withLogging($user->data()?->id ?? 0, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in chassis check')
         ->send();
 }
 
@@ -31,9 +31,9 @@ if ($command !== 'chassis_check') {
 }
 
 try {
-    $year = Input::get('year');
-    $model = Input::get('model');
-    $chassis = Input::get('chassis');
+    $year = Input::raw('year');
+    $model = Input::raw('model');
+    $chassis = Input::raw('chassis');
 
     if (empty($year) || empty($model) || empty($chassis)) {
         ApiResponse::error('Missing required parameters: year, model, and chassis', 400)->send();
@@ -61,7 +61,7 @@ try {
 } catch (\Throwable $e) {
     ApiResponse::serverError('Failed to check chassis availability')
         ->withLogging(
-            $user->data()->id ?? 0,
+            $user->data()?->id ?? 0,
             LogCategories::LOG_CATEGORY_DATABASE_ERROR,
             'Chassis check error: ' . $e->getMessage()
         )

--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -39,6 +39,10 @@ try {
         ApiResponse::error('Missing required parameters: year, model, and chassis', 400)->send();
     }
 
+    if (strlen($chassis) > 15 || strlen($year) > 4 || strlen($model) > 30) {
+        ApiResponse::error('Invalid parameter length', 400)->send();
+    }
+
     $modelParts = explode('|', $model);
     if (count($modelParts) !== 3) {
         ApiResponse::error('Invalid model format', 400)->send();

--- a/app/api/cars/transfer-request.php
+++ b/app/api/cars/transfer-request.php
@@ -74,6 +74,7 @@ try {
     $variant = $modelParts[1];
     $type = $modelParts[2];
 
+    // Validate model-derived field lengths against DB column widths
     if (strlen($model) > 30) {
         throw new CarTransferException('Model identifier must be 30 characters or less');
     }

--- a/app/api/cars/transfer-request.php
+++ b/app/api/cars/transfer-request.php
@@ -43,7 +43,19 @@ try {
     $engine = trim(Input::raw('engine') ?? '');
     $comments = trim(Input::raw('comments') ?? '');
 
-    // Validate comment length (server-side validation)
+    // Validate input lengths against DB column widths
+    if (strlen($chassis) > 15) {
+        throw new CarTransferException('Chassis number must be 15 characters or less');
+    }
+    if (strlen($year) > 4) {
+        throw new CarTransferException('Year must be 4 characters or less');
+    }
+    if (strlen($color) > 25) {
+        throw new CarTransferException('Color must be 25 characters or less');
+    }
+    if (strlen($engine) > 15) {
+        throw new CarTransferException('Engine must be 15 characters or less');
+    }
     if (strlen($comments) > 1000) {
         throw new CarTransferException('Transfer explanation must be 1000 characters or less');
     }
@@ -61,6 +73,19 @@ try {
     $series = $modelParts[0];
     $variant = $modelParts[1];
     $type = $modelParts[2];
+
+    if (strlen($model) > 30) {
+        throw new CarTransferException('Model identifier must be 30 characters or less');
+    }
+    if (strlen($series) > 12) {
+        throw new CarTransferException('Series must be 12 characters or less');
+    }
+    if (strlen($variant) > 15) {
+        throw new CarTransferException('Variant must be 15 characters or less');
+    }
+    if (strlen($type) > 3) {
+        throw new CarTransferException('Type must be 3 characters or less');
+    }
 
     $db = DB::getInstance();
 
@@ -184,12 +209,12 @@ try {
 
 } catch (CarTransferException $e) {
     ApiResponse::error($e->getUserMessage(), 400)
-        ->withLogging($user->data()->id ?? 0, $e->getLogCategory(), 'Transfer request failed: ' . $e->getMessage())
+        ->withLogging($user->data()?->id ?? 0, $e->getLogCategory(), 'Transfer request failed: ' . $e->getMessage())
         ->send();
 
 } catch (\Throwable $e) {
     ApiResponse::serverError('An unexpected error occurred while processing your transfer request.')
-        ->withLogging($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Transfer request system error [' . get_class($e) . ']: ' . $e->getMessage())
+        ->withLogging($user->data()?->id ?? 0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Transfer request system error [' . get_class($e) . ']: ' . $e->getMessage())
         ->send();
 }
 ?>


### PR DESCRIPTION
## Summary

- **`transfer-request.php`**: Add length validation for all DB-bound fields — `chassis` (15), `year` (4), `color` (25), `engine` (15), and model-derived fields `model` (30), `series` (12), `variant` (15), `type` (3). Limits match DB column widths; prevents MySQL strict-mode truncation errors surfacing as generic 500s instead of clean 400s. Also applies null-safe operator in both catch blocks (`$user->data()?->id ?? 0`) to prevent TypeError if `$user->data()` returns null before user initialization completes.
- **`chassis-availability.php`**: Switch `Input::get()` → `Input::raw()` for `year`, `model`, `chassis` (DB query params; avoids htmlspecialchars encoding mismatch). Apply null-safe operator to both logging calls (`$user->data()?->id ?? 0`), including the CSRF failure path where `$user` may not be initialized.

## Bug Escape Analysis

**Root cause**: The v2.23.0 encode-at-output refactor introduced `Input::raw()` for storage but the length validation and null-safe operator fixes weren't applied at the same time. chassis-availability.php wasn't updated alongside transfer-request.php.

**Testing gap**: Procedural endpoint scripts aren't covered by unit tests. Integration-level tests would be needed to catch these patterns.

## Test Plan

- [x] 991 unit tests pass
- [x] PHPStan: no errors
- [x] phpcs: no issues

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy