### PR TITLE
fix(errors): replace undefined LOG_CATEGORY_ERROR and add CarPermissionException catch (#995)

### DIFF
--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -196,7 +196,7 @@ if (Input::exists('post')) {
                         }
                     } catch (CarPermissionException $e) {
                         $errors[] = "Permission denied for car ID {$car_id}.";
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_SECURITY, "Car reassignment permission denied for Car ID {$car_id}: " . $e->getMessage());
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_ACCESS_DENIED, "Car reassignment permission denied for Car ID {$car_id}: " . $e->getMessage());
                     } catch (Exception $e) {
                         $errors[] = 'Transfer failed. Please try again.';
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed for Car ID $car_id: " . $e->getMessage());

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarDeletionException;
 use ElanRegistry\Exceptions\CarNotFoundException;
+use ElanRegistry\Exceptions\CarPermissionException;
 use ElanRegistry\Input as ElanInput;
 
 /**
@@ -193,6 +194,9 @@ if (Input::exists('post')) {
                         } else {
                             $errors[] = "Failed to reassign car ID $car_id";
                         }
+                    } catch (CarPermissionException $e) {
+                        $errors[] = "Permission denied for car ID {$car_id}.";
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_SECURITY, "Car reassignment permission denied for Car ID {$car_id}: " . $e->getMessage());
                     } catch (Exception $e) {
                         $errors[] = 'Transfer failed. Please try again.';
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed for Car ID $car_id: " . $e->getMessage());

--- a/app/reports/statistics.php
+++ b/app/reports/statistics.php
@@ -31,7 +31,7 @@ $db->query(
      FROM cars WHERE lat != 0 AND lon != 0"
 );
 if ($db->error()) {
-    logger(0, LogCategories::LOG_CATEGORY_ERROR, 'Map marker query failed: ' . $db->errorString());
+    logger(0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Map marker query failed: ' . $db->errorString());
 }
 $markerRows = $db->results();
 
@@ -349,7 +349,7 @@ window.statisticsConfig = {
 try {
     $mapMarkersJson = json_encode($mapMarkers, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR);
 } catch (\JsonException $e) {
-    logger(0, LogCategories::LOG_CATEGORY_ERROR, 'Failed to encode map markers: ' . $e->getMessage());
+    logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Failed to encode map markers: ' . $e->getMessage());
     $mapMarkersJson = '[]';
 }
 ?>


### PR DESCRIPTION
## Summary

- **`app/reports/statistics.php`**: `LogCategories::LOG_CATEGORY_ERROR` is not a defined constant — at runtime it would throw `Error: Undefined class constant`. Replace both occurrences with typed constants:
  - Line 34 (DB query failure): → `LOG_CATEGORY_DATABASE_ERROR`
  - Line 352 (`\JsonException` catch): → `LOG_CATEGORY_SYSTEM_ERROR`
- **`app/admin/index.php`**: Add `CarPermissionException` import and a specific catch before the broad `catch (Exception $e)` in the car reassignment block. `Car::transfer()` throws `CarPermissionException` when the user is not authenticated; the broad catch masked this with a generic error message and wrong log category.

Closes #995

## Test plan

- [ ] `composer test:quick` passes
- [ ] PHPStan passes
- [ ] Verify `statistics.php` loads without error on the public maps page
- [ ] Verify no PHP fatal errors in admin car reassignment flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy