### PR TITLE
fix(images): guard mvTmpImages() failures and upload error check before save (#1084)

### DIFF
--- a/app/api/cars/save.php
+++ b/app/api/cars/save.php
@@ -85,6 +85,19 @@ if (!empty($_POST)) {
                 }
 
                 uploadImages($cardetails);
+
+                if (!empty($errors)) {
+                    ApiResponse::validationError(
+                        ['general' => $errors],
+                        'Cannot add car: image upload failed'
+                    )->withData('cardetails', $cardetails)
+                    ->withLogging(
+                        $user->data()->id,
+                        LogCategories::LOG_CATEGORY_FILE_ERROR,
+                        'Car add aborted: image upload errors: ' . json_encode($errors)
+                    )->send();
+                }
+
                 addCar($cardetails);
                 mvTmpImages($cardetails);
 
@@ -150,6 +163,19 @@ if (!empty($_POST)) {
                 }
 
                 uploadImages($cardetails);
+
+                if (!empty($errors)) {
+                    ApiResponse::validationError(
+                        ['general' => $errors],
+                        'Cannot update car: image upload failed'
+                    )->withData('cardetails', $cardetails)
+                    ->withLogging(
+                        $user->data()->id,
+                        LogCategories::LOG_CATEGORY_FILE_ERROR,
+                        'Car update aborted: image upload errors: ' . json_encode($errors)
+                    )->send();
+                }
+
                 updateCar($cardetails);
 
                 if (!empty($errors)) {
@@ -801,19 +827,23 @@ function fetchImages(int $car_id): void
 function mvTmpImages(array &$cardetails): void
 {
     global $targetFilePath;
+    global $errors;
+    global $user;
 
     $tempPath = $targetFilePath . 'temp' . '/';
-
     $filePath = $targetFilePath . $cardetails['id'] . '/';
+    $userId   = isset($user) ? (int)$user->data()->id : 0;
+
     if (!is_dir($filePath)) {
-        mkdir($filePath, 0755, true);
+        if (!mkdir($filePath, 0755, true)) {
+            logger($userId, LogCategories::LOG_CATEGORY_FILE_ERROR, "mvTmpImages: failed to create directory: {$filePath}");
+            $errors[] = 'Failed to create image directory for car ID ' . $cardetails['id'];
+            return;
+        }
     }
 
-    // Get the car images
-    // Turn images into array
     // Images can be encoded as JSON or simple CSV
     $carImages = json_decode($cardetails['image']);
-
     if (is_null($carImages)) {
         $carImages = explode(',', $cardetails['image']);
     }
@@ -823,8 +853,10 @@ function mvTmpImages(array &$cardetails): void
 
         foreach (glob($tempPath . $tmpfile['filename'] . '*' . $tmpfile['extension']) as $name) {
             $file = pathinfo($name);
-
-            rename($name, $filePath . $file['basename']);
+            if (!rename($name, $filePath . $file['basename'])) {
+                logger($userId, LogCategories::LOG_CATEGORY_FILE_ERROR, "mvTmpImages: failed to move {$name} to {$filePath}{$file['basename']}");
+                $errors[] = "Failed to move image file: {$file['basename']}";
+            }
         }
     }
 }

--- a/app/api/cars/save.php
+++ b/app/api/cars/save.php
@@ -101,6 +101,16 @@ if (!empty($_POST)) {
                 addCar($cardetails);
                 mvTmpImages($cardetails);
 
+                if (!empty($errors)) {
+                    ApiResponse::serverError('Car saved but images could not be moved from temp storage')
+                        ->withData('cardetails', $cardetails)
+                        ->withLogging(
+                            $user->data()->id,
+                            LogCategories::LOG_CATEGORY_FILE_ERROR,
+                            'Car ID ' . ($cardetails['id'] ?? 'unknown') . ' saved but image move errors: ' . json_encode($errors)
+                        )->send();
+                }
+
                 // Blanks instead of NULL for display
                 foreach ($cardetails as $key => $value) {
                     if (is_null($value)) {


### PR DESCRIPTION
## Summary

Two data integrity bugs in `app/api/cars/save.php` that allowed a car record to be saved with broken image references:

**Bug 1 — `mvTmpImages()` silently drops images on `mkdir()` failure:**
- `mkdir()` was called with no return-value check
- If the directory could not be created (permissions, disk full), `rename()` silently failed for every image
- The car was saved with a JSON image list pointing to files that were never moved
- Fix: check `mkdir()` return, log and push to `$errors[]`, return early; also log each `rename()` failure

**Bug 2 — `uploadImages()` errors did not prevent the car save:**
- When `uploadImages()` failed (e.g. resize error), `$errors[]` was populated but execution continued to `updateCar()`/`addCar()`
- The car was saved with a broken image reference
- Fix: add `if (!empty($errors))` guard between `uploadImages()` and each save call in both the `addCar` and `updateCar` cases

Closes #1084

## Test plan

- [ ] `composer test:quick` passes
- [ ] Simulate `mkdir()` failure in `mvTmpImages()` — verify error is surfaced and car not saved with broken path
- [ ] Simulate `uploadImages()` resize failure — verify car is not saved
- [ ] Happy path: normal car add/update with images works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy