### PR TITLE
fix(contact): exit on car-details query failure in send-owner-email.php (#1056)

### DIFF
--- a/app/api/contact/send-owner-email.php
+++ b/app/api/contact/send-owner-email.php
@@ -116,23 +116,29 @@ $toName    = $toUser->fname . ' ' . $toUser->lname;
 $fromEmail = $fromUser->email;
 $fromName  = $fromUser->fname . ' ' . $fromUser->lname;
 
-// Query car details for the email body (non-fatal — template uses nulls gracefully)
 $db->query('SELECT chassis, year, series, variant, type FROM cars WHERE id = ?', [$carId]);
 if ($db->error()) {
-    logger($logUserId ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'send-owner-email.php: DB error fetching car details for car_id=' . $carId . ' — email will send without car details');
+    ApiResponse::serverError()
+        ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'send-owner-email.php: DB error fetching car details for car_id=' . $carId)
+        ->send();
 }
 $carRow = $db->first();
+if (!$carRow) {
+    ApiResponse::serverError()
+        ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'send-owner-email.php: car not found for car_id=' . $carId . ' (concurrent delete?)')
+        ->send();
+}
 $carUrl = $current_origin . $us_url_root . 'app/cars/details.php?car_id=' . $carId;
 
 $template = array(
     'message'      => $message,
     'from'         => $fromName,
     'to'           => $toName,
-    'car_year'     => $carRow ? (int)$carRow->year     : null,
-    'car_series'   => $carRow ? (string)$carRow->series  : null,
-    'car_variant'  => $carRow ? (string)$carRow->variant : null,
-    'car_type'     => $carRow ? (string)$carRow->type    : null,
-    'car_chassis'  => $carRow ? (string)$carRow->chassis : null,
+    'car_year'     => (int)$carRow->year,
+    'car_series'   => (string)$carRow->series,
+    'car_variant'  => (string)$carRow->variant,
+    'car_type'     => (string)$carRow->type,
+    'car_chassis'  => (string)$carRow->chassis,
     'carUrl'       => $carUrl,
 );
 


### PR DESCRIPTION
## Summary

- DB errors on the car-details query now return `serverError` instead of logging and continuing
- Null `$carRow` (car concurrently deleted after IDOR check) now returns `serverError` instead of sending an email with all-null car fields
- Null-guard ternaries in `$template` removed — `$carRow` is guaranteed non-null past the new guard
- Matches the pattern already used by the three other DB queries in the same file (lines 76–87, 92–97, 100–104)

Closes #1056

## Bug Escape Analysis

**Root cause:** The car-details query was originally marked "non-fatal — template uses nulls gracefully," trading data integrity for resilience. The acceptance criteria requires exit on failure, consistent with every other query in the file.

**Testing gap:** The "car not found at send time" scenario requires a concurrent delete between the IDOR check (line 76) and the car-details query (line 120) — a window of a few milliseconds. No automated test covered this path. The fix is self-evidently correct: it follows the identical pattern used three times above it in the same file. The existing Playwright IDOR test (`contact-owner-idor.spec.js`) covers the endpoint's error-path behaviour under invalid inputs.

## Test plan

- [ ] Verify CI passes
- [ ] Manual: send an owner contact email; confirm it delivers with correct car details
- [ ] Verify the existing IDOR Playwright test still passes: `npm run playwright:security`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy