### PR TITLE
refactor(owner): rename sanitizeString to normalizeString, remove strip_tags (#941)

### DIFF
--- a/app/admin/includes/tab-manage_cars.php
+++ b/app/admin/includes/tab-manage_cars.php
@@ -1155,17 +1155,17 @@ $qualityScore = $totalCars > 0 ? max(0, 100 - (($carIssues / $totalCars) * 100))
                                                                         <h6 class="card-header-er-l4-text">Owner Info</h6>
                                                                         <p class="mb-1 <?= $ownerMatches['fname'] && $ownerMatches['lname'] ? 'field-match' : 'field-differ' ?>">
                                                                             <strong>Owner:</strong>
-                                                                            <span class="field-value"><?= $car->fname ?> <?= $car->lname ?></span>
+                                                                            <span class="field-value"><?= htmlspecialchars($car->fname ?? '', ENT_QUOTES, 'UTF-8') ?> <?= htmlspecialchars($car->lname ?? '', ENT_QUOTES, 'UTF-8') ?></span>
                                                                             <?= !($ownerMatches['fname'] && $ownerMatches['lname']) ? '<i class="fas fa-exclamation-triangle text-warning ms-1" title="Different values"></i>' : '<i class="fas fa-check text-primary ms-1" title="Values match"></i>' ?>
                                                                         </p>
                                                                         <p class="mb-1 <?= $ownerMatches['email'] ? 'field-match' : 'field-differ' ?>">
                                                                             <strong>Email:</strong>
-                                                                            <span class="field-value"><?= $car->email ?></span>
+                                                                            <span class="field-value"><?= htmlspecialchars($car->email ?? '', ENT_QUOTES, 'UTF-8') ?></span>
                                                                             <?= !$ownerMatches['email'] ? '<i class="fas fa-exclamation-triangle text-warning ms-1" title="Different values"></i>' : '<i class="fas fa-check text-primary ms-1" title="Values match"></i>' ?>
                                                                         </p>
                                                                         <p class="mb-1 <?= $ownerMatches['city'] && $ownerMatches['state'] && $ownerMatches['country'] ? 'field-match' : 'field-differ' ?>">
                                                                             <strong>Location:</strong>
-                                                                            <span class="field-value"><?= $car->city ?>, <?= $car->state ?> <?= $car->country ?></span>
+                                                                            <span class="field-value"><?= htmlspecialchars($car->city ?? '', ENT_QUOTES, 'UTF-8') ?>, <?= htmlspecialchars($car->state ?? '', ENT_QUOTES, 'UTF-8') ?> <?= htmlspecialchars($car->country ?? '', ENT_QUOTES, 'UTF-8') ?></span>
                                                                             <?= !($ownerMatches['city'] && $ownerMatches['state'] && $ownerMatches['country']) ? '<i class="fas fa-exclamation-triangle text-warning ms-1" title="Different values"></i>' : '<i class="fas fa-check text-primary ms-1" title="Values match"></i>' ?>
                                                                         </p>
                                                                     </div>

--- a/docs/development/CLASSES.md
+++ b/docs/development/CLASSES.md
@@ -389,7 +389,7 @@ if (!CarModel::exists($series, $variant, $type)) {
 
 - `validateAndSanitizeFields(array $fields, bool $requireAll): array` - Main validation method
 - `validateRequiredFields(array $fields, array $required): void` - Check required fields are present
-- `sanitizeString(string $input, int $maxLength): string` - HTML strip and truncate
+- `normalizeString(string $input, int $maxLength): string` - Trim whitespace and truncate to max length; caller must apply `htmlspecialchars()` at the render layer
 
 **Exceptions**:
 

--- a/tests/unit/classes/ElanRegistryOwnerNormalizeTest.php
+++ b/tests/unit/classes/ElanRegistryOwnerNormalizeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Unit tests for ElanRegistryOwner::normalizeString()
+ *
+ * Verifies the encode-at-output pattern: special characters and HTML tags
+ * must be stored raw (unencoded) — htmlspecialchars() is applied only at
+ * the render layer.
+ *
+ * @see https://github.com/unibrain1/elanregistry/issues/941
+ */
+#[Group('fast')]
+#[Group('unit')]
+final class ElanRegistryOwnerNormalizeTest extends TestCase
+{
+    private \ReflectionMethod $method;
+    private \ElanRegistryOwner $owner;
+
+    protected function setUp(): void
+    {
+        $this->owner  = new \ElanRegistryOwner();
+        $ref          = new \ReflectionClass(\ElanRegistryOwner::class);
+        $this->method = $ref->getMethod('normalizeString');
+    }
+
+    private function normalize(string $input, int $maxLength = 255): string
+    {
+        return $this->method->invoke($this->owner, $input, $maxLength);
+    }
+
+    public function testPreservesHtmlTags(): void
+    {
+        $this->assertSame('<b>Bold</b> name', $this->normalize('<b>Bold</b> name'));
+    }
+
+    public function testPreservesLessThanAndGreaterThan(): void
+    {
+        $this->assertSame('A < B > C', $this->normalize('A < B > C'));
+    }
+
+    public function testPreservesAmpersand(): void
+    {
+        $this->assertSame('Smith & Jones', $this->normalize('Smith & Jones'));
+    }
+
+    public function testPreservesDoubleQuotes(): void
+    {
+        $this->assertSame('"quoted"', $this->normalize('"quoted"'));
+    }
+
+    public function testTrimsLeadingAndTrailingWhitespace(): void
+    {
+        $this->assertSame('Alice', $this->normalize('  Alice  '));
+    }
+
+    public function testEnforcesMaxLength(): void
+    {
+        $this->assertSame('Al', $this->normalize('Alice', 2));
+    }
+
+    public function testReturnsEmptyStringUnchanged(): void
+    {
+        $this->assertSame('', $this->normalize(''));
+    }
+
+    public function testDoesNotStripTagsUnlikeOldSanitizeString(): void
+    {
+        $input = '<script>alert(1)</script>';
+        $this->assertSame($input, $this->normalize($input));
+    }
+}

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -701,7 +701,7 @@ class ElanRegistryOwner
      *
      * @param string $input Input string to normalize
      * @param int $maxLength Maximum allowed length
-     * @return string Normalized string with preserved HTML entities
+     * @return string Normalized string (raw — caller must apply htmlspecialchars() at the render layer)
      * @since v2.25.4 Renamed from sanitizeString() - no longer strips HTML tags
      * @see https://github.com/unibrain1/elanregistry/issues/941
      */

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -609,7 +609,7 @@ class ElanRegistryOwner
                 case 'fname':
                 case 'lname':
                     if (!empty($value)) {
-                        $validatedFields[$key] = $this->sanitizeString($value, 25);
+                        $validatedFields[$key] = $this->normalizeString($value, 25);
                         if (strlen($validatedFields[$key]) < 1) {
                             throw OwnerValidationException::withUserMessage(
                                 "{$key} must be at least 1 character long",
@@ -643,7 +643,7 @@ class ElanRegistryOwner
                 case 'state':
                 case 'country':
                     if (!empty($value)) {
-                        $validatedFields[$key] = $this->sanitizeString($value, 50);
+                        $validatedFields[$key] = $this->normalizeString($value, 50);
                     }
                     break;
 
@@ -693,17 +693,22 @@ class ElanRegistryOwner
     }
 
     /**
-     * Sanitize string input
+     * Normalize string input by trimming whitespace and enforcing a maximum length.
      *
-     * @param string $input Input string to sanitize
+     * IMPORTANT: HTML tags and special characters are preserved as part of the
+     * encode-at-output pattern. The caller MUST apply htmlspecialchars() at the
+     * output context (HTML templates, emails) to prevent XSS vulnerabilities.
+     *
+     * @param string $input Input string to normalize
      * @param int $maxLength Maximum allowed length
-     * @return string Sanitized string
+     * @return string Normalized string with preserved HTML entities
+     * @since v2.25.4 Renamed from sanitizeString() - no longer strips HTML tags
+     * @see https://github.com/unibrain1/elanregistry/issues/941
      */
-    private function sanitizeString(string $input, int $maxLength = 255): string
+    private function normalizeString(string $input, int $maxLength = 255): string
     {
-        // Replace deprecated FILTER_SANITIZE_STRING with strip_tags and trim
-        $sanitized = strip_tags(trim($input));
-        return substr($sanitized, 0, $maxLength);
+        $normalized = trim($input);
+        return strlen($normalized) > $maxLength ? substr($normalized, 0, $maxLength) : $normalized;
     }
 
     /**


### PR DESCRIPTION
## Summary

- `ElanRegistryOwner::sanitizeString()` renamed to `normalizeString()` — `strip_tags()` removed, preserving HTML tags and special characters before DB storage
- Both call sites (`fname`/`lname` at max 25, and `city`/`state`/`country` at max 50) updated to `normalizeString()`
- PHPDoc matches the encode-at-output warning on `CarValidator::normalizeString()` per #841
- Unescaped owner fields (`fname`, `lname`, `email`, `city`, `state`, `country`) in the admin car comparison panel (`tab-manage_cars.php`) wrapped with `htmlspecialchars()` — pre-existing XSS risk found during verification
- Unit test (`ElanRegistryOwnerNormalizeTest`) verifies that `<`, `>`, `&`, HTML tags, and double quotes are preserved through the method; confirms the old `strip_tags` behavior is gone

Closes #941

## XSS fix

The admin car comparison panel was echoing five owner fields without escaping (lines 1158, 1163, 1168 of `tab-manage_cars.php`). These are admin-only pages (admin permission required), but defence in depth applies regardless. Fixed in this PR per the issue acceptance criteria.

## Test plan

- [ ] CI passes
- [ ] Unit: `composer test:quick` — 1001 tests, all pass (run locally)
- [ ] Manual: update an owner profile with a name like `O'Brien & Co` — verify it stores raw and displays correctly in account page and admin panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy