### PR TITLE
fix(cars): add FILTER_VALIDATE_URL check in updateWebsite() (#1055)

### DIFF
--- a/app/api/cars/save.php
+++ b/app/api/cars/save.php
@@ -590,6 +590,10 @@ function updateWebsite(array &$cardetails): void
     global $errors;
     $website = Input::raw('website');
     if ($website !== null && $website !== '') {
+        if (!filter_var($website, FILTER_VALIDATE_URL)) {
+            $errors[] = 'Website URL is not valid';
+            return;
+        }
         $scheme = strtolower((string) parse_url($website, PHP_URL_SCHEME));
         if (!in_array($scheme, ['http', 'https'], true)) {
             $errors[] = 'Website URL must start with http:// or https://';

--- a/app/api/cars/save.php
+++ b/app/api/cars/save.php
@@ -591,7 +591,7 @@ function updateWebsite(array &$cardetails): void
     $website = Input::raw('website');
     if ($website !== null && $website !== '') {
         if (!filter_var($website, FILTER_VALIDATE_URL)) {
-            $errors[] = 'Website URL is not valid';
+            $errors[] = 'Website URL must start with http:// or https:// (e.g. https://example.com)';
             return;
         }
         $scheme = strtolower((string) parse_url($website, PHP_URL_SCHEME));

--- a/tests/regression/Issue1055RegressionTest.php
+++ b/tests/regression/Issue1055RegressionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for Issue #1055: updateWebsite() skips FILTER_VALIDATE_URL
+ *
+ * updateWebsite() in app/api/cars/save.php previously only checked the URL
+ * scheme, allowing malformed URLs such as "https://" (valid scheme, empty host)
+ * to be stored verbatim. A FILTER_VALIDATE_URL guard was added before the
+ * scheme check to match the validation level already present in
+ * ElanRegistryOwner::validateAndSanitizeFields().
+ *
+ * These tests verify the validation contract: the same URLs that
+ * ElanRegistryOwner already rejected must now also be rejected by
+ * updateWebsite(). Since updateWebsite() is a procedural function inside a
+ * script that requires the full framework, we test the shared PHP validation
+ * primitive (filter_var FILTER_VALIDATE_URL) and the scheme-whitelist rule
+ * directly. CarValidatorTest covers the identical rules through
+ * CarValidator::validateAndSanitizeFields().
+ *
+ * @issue 1055
+ * @link https://github.com/unibrain1/elanregistry/issues/1055
+ * @category regression
+ */
+final class Issue1055RegressionTest extends TestCase
+{
+    // ----------------------------------------------------------------
+    // URLs that FILTER_VALIDATE_URL must reject
+    // ----------------------------------------------------------------
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function malformedUrlProvider(): array
+    {
+        return [
+            'scheme only — no host'      => ['https://'],
+            'http scheme only — no host' => ['http:'],
+            'not a url'                  => ['not-a-url'],
+            'relative path'              => ['/path/to/page'],
+            'domain without scheme'      => ['example.com'],
+        ];
+    }
+
+    #[DataProvider('malformedUrlProvider')]
+    public function testMalformedUrlsFailFilterValidateUrl(string $url): void
+    {
+        $this->assertFalse(
+            (bool) filter_var($url, FILTER_VALIDATE_URL),
+            "Expected FILTER_VALIDATE_URL to reject '{$url}' — updateWebsite() now uses this guard"
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // Valid URLs must still be accepted (no regression)
+    // ----------------------------------------------------------------
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validUrlProvider(): array
+    {
+        return [
+            'https with path'  => ['https://example.com/cars'],
+            'http with port'   => ['http://example.com:8080/'],
+            'with query string' => ['https://example.com/cars?a=1&b=2'],
+            'www prefix'       => ['https://www.elanregistry.org'],
+        ];
+    }
+
+    #[DataProvider('validUrlProvider')]
+    public function testValidUrlsPassFilterValidateUrl(string $url): void
+    {
+        $this->assertNotFalse(
+            filter_var($url, FILTER_VALIDATE_URL),
+            "Expected FILTER_VALIDATE_URL to accept '{$url}'"
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // Scheme whitelist — valid URL but non-http(s) scheme must be
+    // blocked by the second guard in updateWebsite()
+    // ----------------------------------------------------------------
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function nonHttpSchemeProvider(): array
+    {
+        return [
+            'javascript protocol' => ['javascript:void(0)'],
+            'ftp url'             => ['ftp://files.example.com'],
+            'data uri'            => ['data:text/html,<h1>x</h1>'],
+        ];
+    }
+
+    #[DataProvider('nonHttpSchemeProvider')]
+    public function testNonHttpSchemeIsBlockedBySchemeWhitelist(string $url): void
+    {
+        $isValidUrl = (bool) filter_var($url, FILTER_VALIDATE_URL);
+        $scheme     = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        $schemeOk   = in_array($scheme, ['http', 'https'], true);
+
+        // At least one of the two guards must reject the URL
+        $this->assertFalse(
+            $isValidUrl && $schemeOk,
+            "URL '{$url}' must be rejected by either FILTER_VALIDATE_URL or the scheme whitelist"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `updateWebsite()` in `app/api/cars/save.php` now calls `filter_var($website, FILTER_VALIDATE_URL)` before the scheme check, matching the validation depth already present in `ElanRegistryOwner::validateAndSanitizeFields()` for the same field
- Malformed URLs such as `https://` (valid scheme, empty host) are now rejected by both car and owner write paths
- Regression test (`Issue1055RegressionTest`) documents the validation contract: which URLs fail FILTER_VALIDATE_URL, which pass, and how the scheme whitelist applies as a second guard

Closes #1055

## Test plan

- [ ] CI passes
- [ ] Regression suite: `./vendor/bin/phpunit tests/regression/Issue1055RegressionTest.php` — 12 tests, all pass
- [ ] Full unit suite: `composer test:quick` — passes
- [ ] Manual: try saving a car with website `https://` — verify validation error returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy