### PR TITLE
refactor(car): collapse duplicate if (!updateResult) guards in Car::update()

### DIFF
--- a/tests/integration/cars/CarUpdateRepositoryFailureTest.php
+++ b/tests/integration/cars/CarUpdateRepositoryFailureTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/IntegrationTestCase.php';
+
+use ElanRegistry\Car\CarRepository;
+use ElanRegistry\Exceptions\CarDatabaseException;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration regression test for Car::update() repository-failure path
+ *
+ * Verifies the #934 fix: when CarRepository::update() returns false, exactly
+ * one log entry is written under LOG_CATEGORY_DATABASE_ERROR and
+ * CarDatabaseException is thrown. The old code had two consecutive
+ * if (!$updateResult) guards — the first logged under LOG_CATEGORY_CAR_UPDATE
+ * ("may indicate no changes") before the second logged the actual failure and
+ * threw. That duplicate guard is now removed.
+ *
+ * This test lives in the integration suite (not unit) because the unit
+ * bootstrap substitutes a framework mock for the Car class that does not
+ * exercise the real update() logic. Here we load the real Car class and
+ * inject a PHPUnit mock via Reflection for the single repository property
+ * we need to control.
+ *
+ * @issue 934
+ * @link https://github.com/unibrain1/elanregistry/issues/934
+ * @see usersc/classes/Car.php Car::update()
+ */
+#[Group('integration')]
+#[Group('car-update')]
+final class CarUpdateRepositoryFailureTest extends IntegrationTestCase
+{
+    private \ReflectionProperty $repositoryProp;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireDatabase();
+
+        $this->repositoryProp = (new \ReflectionClass(\ElanRegistry\Car\Car::class))
+            ->getProperty('repository');
+    }
+
+    /**
+     * Helper: build a Car with a mock repository that always returns false
+     * from update().
+     */
+    private function carWithFailingRepo(): \ElanRegistry\Car\Car
+    {
+        $car = new \ElanRegistry\Car\Car();
+
+        $mockRepo = $this->createMock(CarRepository::class);
+        $mockRepo->method('update')->willReturn(false);
+
+        $this->repositoryProp->setValue($car, $mockRepo);
+
+        return $car;
+    }
+
+    /**
+     * Core assertion: CarDatabaseException is thrown on repo update failure.
+     */
+    public function testUpdateThrowsCarDatabaseExceptionOnRepositoryFailure(): void
+    {
+        $this->expectException(CarDatabaseException::class);
+        $this->expectExceptionMessage('Database update failed');
+
+        $this->carWithFailingRepo()->update([
+            'id'    => 1,
+            'token' => Token::generate(),
+        ]);
+    }
+
+    /**
+     * Regression guard: exactly one log entry under DATABASE_ERROR, none under
+     * CAR_UPDATE. Previously two guards fired two log() calls; now only one.
+     */
+    public function testUpdateLogsExactlyOnceUnderDatabaseErrorOnFailure(): void
+    {
+        $dbErrBefore = $this->countMatchingLogs('DatabaseError', 'Car update failed%');
+        $carUpdBefore = $this->countMatchingLogs('CarUpdate', '%');
+
+        try {
+            $this->carWithFailingRepo()->update([
+                'id'    => 1,
+                'token' => Token::generate(),
+            ]);
+        } catch (CarDatabaseException) {
+            // expected
+        }
+
+        $dbErrAfter  = $this->countMatchingLogs('DatabaseError', 'Car update failed%');
+        $carUpdAfter = $this->countMatchingLogs('CarUpdate', '%');
+
+        $this->assertSame(
+            $dbErrBefore + 1,
+            $dbErrAfter,
+            'Car::update() must log exactly once under DatabaseError when the repository returns false'
+        );
+
+        $this->assertSame(
+            $carUpdBefore,
+            $carUpdAfter,
+            'LOG_CATEGORY_CAR_UPDATE must not fire on update failure after #934 fix'
+        );
+    }
+
+    /**
+     * Count rows in the logs table matching a logtype and lognote pattern.
+     *
+     * @param string $logtype  Exact logtype value (e.g. 'DatabaseError')
+     * @param string $lognote  LIKE pattern for lognote (e.g. 'Car update failed%')
+     */
+    private function countMatchingLogs(string $logtype, string $lognote): int
+    {
+        $result = $this->db->query(
+            'SELECT COUNT(*) AS cnt FROM logs WHERE logtype = ? AND lognote LIKE ?',
+            [$logtype, $lognote]
+        );
+
+        return (int) ($result->first()->cnt ?? 0);
+    }
+}

--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -264,15 +264,11 @@ class Car
         $updateResult = $repo->update($this->tableName, $carId, $filteredFields);
 
         if (!$updateResult) {
-            logger($fields['user_id'] ?? 0, LogCategories::LOG_CATEGORY_CAR_UPDATE, 'DB update returned false (may indicate no changes)');
-        }
-
-        if (!$updateResult) {
             logger($fields['user_id'] ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Car update failed: query returned false');
             throw new CarDatabaseException('Database update failed - check logs for details');
-        } else {
-            $this->find($carId);
         }
+
+        $this->find($carId);
 
         return true;
     }


### PR DESCRIPTION
## Summary

- Removes the first of two consecutive `if (!$updateResult)` guards that both checked the same condition after `CarRepository::update()` returned false
- The first guard logged a misleading "may indicate no changes" message under `LOG_CATEGORY_CAR_UPDATE` — incorrect since a false return is always a database error
- The second guard (now the only one) logs under `LOG_CATEGORY_DATABASE_ERROR` and throws `CarDatabaseException`
- `$this->find($carId)` is moved out of the now-removed `else` branch; it runs unconditionally on success (no behavior change)

## Bug Escape Analysis

**Root cause:** Two `if (!$updateResult)` blocks were added at different times with inconsistent log categories. The first was never cleaned up.

**Testing gap:** The unit test bootstrap replaces `Car` with a framework mock that returns `true` unconditionally from `update()`, so this code path was never exercised in the unit suite.

**Prevention:** `CarUpdateRepositoryFailureTest` (integration) injects a mock `CarRepository` via Reflection that returns `false`, then asserts:
1. `CarDatabaseException` is thrown
2. Exactly one `logs` row is added under `DatabaseError`
3. No `CarUpdate` row is added (regression guard for the removed guard)

## Test plan

- [x] Unit suite: 1005 tests pass
- [x] PHPStan: no errors
- [x] phpcs: no blocking issues
- [x] Integration: `CarUpdateRepositoryFailureTest` — 2 tests, 4 assertions pass against MAMP

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy