### PR TITLE
fix(location): pass User-Agent header to Photon geocoding requests

### DIFF
--- a/tests/unit/location/LocationServiceUserAgentTest.php
+++ b/tests/unit/location/LocationServiceUserAgentTest.php
@@ -124,10 +124,10 @@ final class LocationServiceUserAgentTest extends TestCase
             dirname(__DIR__, 3) . '/usersc/classes/LocationService.php'
         );
 
-        $this->assertStringContainsString(
-            'makeHttpRequest($url, self::getUserAgent())',
-            $source,
-            'searchPhoton() must pass self::getUserAgent() to makeHttpRequest() — regression guard for #1119'
+        $this->assertSame(
+            3,
+            substr_count($source, 'makeHttpRequest($url, self::getUserAgent())'),
+            'All three makeHttpRequest() call sites must pass self::getUserAgent() — regression guard for #1119'
         );
     }
 }

--- a/tests/unit/location/LocationServiceUserAgentTest.php
+++ b/tests/unit/location/LocationServiceUserAgentTest.php
@@ -110,4 +110,24 @@ final class LocationServiceUserAgentTest extends TestCase
         $this->assertSame('ElanRegistry/unknown (https://elanregistry.org)', $ua);
         $this->assertStringNotContainsString('ElanRegistry/ (', $ua);
     }
+
+    /**
+     * Regression guard for #1119: searchPhoton() must pass getUserAgent() to
+     * makeHttpRequest(). Because makeHttpRequest() is private the call cannot
+     * be intercepted at runtime without modifying source, so this test
+     * verifies the call-site argument in the source text — a structural
+     * assertion that fails immediately if the argument is removed.
+     */
+    public function testSearchPhotonPassesUserAgentToMakeHttpRequest(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__, 3) . '/usersc/classes/LocationService.php'
+        );
+
+        $this->assertStringContainsString(
+            'makeHttpRequest($url, self::getUserAgent())',
+            $source,
+            'searchPhoton() must pass self::getUserAgent() to makeHttpRequest() — regression guard for #1119'
+        );
+    }
 }

--- a/usersc/classes/LocationService.php
+++ b/usersc/classes/LocationService.php
@@ -222,7 +222,7 @@ class LocationService
     {
         $url = self::PHOTON_API_URL . '?q=' . urlencode($query) . '&limit=' . $limit . '&lang=en';
 
-        $response = $this->makeHttpRequest($url);
+        $response = $this->makeHttpRequest($url, self::getUserAgent());
         if (!$response) {
             throw new LocationServiceException('Photon API request failed');
         }


### PR DESCRIPTION
## Summary

- `searchPhoton()` was calling `makeHttpRequest($url)` without a User-Agent while both `searchNominatim()` calls correctly pass `self::getUserAgent()`
- This left Photon requests without the versioned identification header added in #1070
- Fix: one-line addition of `self::getUserAgent()` as the second argument, matching the Nominatim pattern

## Bug Escape Analysis

**Root cause:** The `searchNominatim()` calls were updated in #1070 to include the User-Agent, but `searchPhoton()` was overlooked.

**Prevention:** `testSearchPhotonPassesUserAgentToMakeHttpRequest()` (structural assertion) reads the source text and fails if the argument is removed. `makeHttpRequest()` is private so runtime interception requires source modification; the structural test is the most cost-effective regression guard for this call site.

## Test plan

- [x] `LocationServiceUserAgentTest` — 5 tests, 10 assertions pass (new test added)
- [x] Full unit suite — 1006 tests pass
- [x] PHPStan: no errors
- [x] phpcs: no issues

Closes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPLiFaXmhHFhH5FmzgWxGy