### PR TITLE
test: add TransferEmailService success-path and partial-failure unit tests (#1092)

### DIFF
--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -1285,11 +1285,15 @@ if (!function_exists('getFeedbackEmail')) {
 // Mock getAdminEmails function - needed by transfer email templates
 if (!function_exists('getAdminEmails')) {
     /**
-     * Mock getAdminEmails function for testing
-     * Returns a predictable admin email for assertions
+     * Mock getAdminEmails function for testing.
+     * Set $GLOBALS['mockAdminEmails'] to override the default in a test.
      */
     function getAdminEmails(): string
     {
+        global $mockAdminEmails;
+        if (isset($mockAdminEmails)) {
+            return $mockAdminEmails;
+        }
         return 'admin@elanregistry.org';
     }
 }

--- a/tests/unit/transfer/TransferEmailServiceTest.php
+++ b/tests/unit/transfer/TransferEmailServiceTest.php
@@ -11,8 +11,43 @@ use PHPUnit\Framework\TestCase;
 #[Group('transfer')]
 final class TransferEmailServiceTest extends TestCase
 {
+    /** Temporary directory holding minimal email templates for success-path tests. */
+    private static string $fakeBasePath = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        $dir = sys_get_temp_dir() . '/transfer_email_test_' . uniqid() . '/';
+        mkdir($dir . 'app/views/email/', 0755, true);
+        foreach (['_transfer_request', '_transfer_admin', '_transfer_response', '_transfer_previous_owner'] as $tpl) {
+            file_put_contents($dir . 'app/views/email/' . $tpl . '.php', '<?php // test stub ?>');
+        }
+        self::$fakeBasePath = $dir;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$fakeBasePath !== '' && is_dir(self::$fakeBasePath)) {
+            foreach (glob(self::$fakeBasePath . 'app/views/email/*.php') ?: [] as $f) {
+                unlink($f);
+            }
+            rmdir(self::$fakeBasePath . 'app/views/email/');
+            rmdir(self::$fakeBasePath . 'app/views/');
+            rmdir(self::$fakeBasePath . 'app/');
+            rmdir(self::$fakeBasePath);
+        }
+        parent::tearDownAfterClass();
+    }
+
+    protected function tearDown(): void
+    {
+        // Remove any per-test global overrides
+        unset($GLOBALS['mockAdminEmails']);
+        parent::tearDown();
+    }
+
     /**
-     * Creates a mock DB whose query() always returns count=0 and first()=null.
+     * Creates a mock DB whose query() always returns count=0 (transfer not found).
      */
     private function createMockDb(int $rowCount = 0): object
     {
@@ -30,6 +65,62 @@ final class TransferEmailServiceTest extends TestCase
             }
         };
     }
+
+    /**
+     * Creates a mock DB that dispatches by table name:
+     * queries against `car_transfer_requests` return $transferRow,
+     * queries against `cars` return $carRow.
+     */
+    private function createFoundMockDb(object $transferRow, object $carRow): object
+    {
+        return new class($transferRow, $carRow) {
+            public function __construct(
+                private object $transferRow,
+                private object $carRow,
+            ) {}
+
+            public function query(string $sql, array $params = []): object
+            {
+                $row = str_contains($sql, 'car_transfer_requests') ? $this->transferRow : $this->carRow;
+                return new class($row) {
+                    public function __construct(private object $row) {}
+                    public function count(): int { return 1; }
+                    public function first(): object { return $this->row; }
+                };
+            }
+        };
+    }
+
+    private function makeTransferRow(array $overrides = []): object
+    {
+        return (object) array_merge([
+            'id'                  => 1,
+            'existing_car_id'     => 10,
+            'requested_by_user_id' => 2,
+            'submitted_comments'  => 'Test comments',
+            'request_date'        => '2024-01-01 00:00:00',
+            'expires_at'          => '2024-02-01 00:00:00',
+            'completed_date'      => null,
+        ], $overrides);
+    }
+
+    private function makeCarRow(array $overrides = []): object
+    {
+        return (object) array_merge([
+            'id'      => 10,
+            'user_id' => 1,
+            'year'    => '1973',
+            'series'  => 'S4',
+            'variant' => 'SE',
+            'chassis' => 'TEST001',
+            'color'   => 'Red',
+            'engine'  => 'ENG001',
+        ], $overrides);
+    }
+
+    // -------------------------------------------------------------------------
+    // Early-exit (not-found) tests — existing coverage
+    // -------------------------------------------------------------------------
 
     public function testSendRequestReturnsFalseWhenTransferNotFound(): void
     {
@@ -71,5 +162,95 @@ final class TransferEmailServiceTest extends TestCase
         $service->sendRequest(999);
 
         $this->assertFalse($called);
+    }
+
+    // -------------------------------------------------------------------------
+    // Success-path and partial-failure tests — new coverage
+    // -------------------------------------------------------------------------
+
+    /**
+     * sendRequest() calls the mailer when a valid transfer + car row exist.
+     * The mailer receives the current owner's email address.
+     */
+    public function testSendRequestCallsMailerWhenRecordFound(): void
+    {
+        $db = $this->createFoundMockDb($this->makeTransferRow(), $this->makeCarRow());
+
+        $capturedTo = null;
+        $mailer = function (string $to, string $subject, string $body) use (&$capturedTo): bool {
+            $capturedTo = $to;
+            return true;
+        };
+
+        $service = new TransferEmailService($db, $mailer, self::$fakeBasePath);
+        $result  = $service->sendRequest(1);
+
+        $this->assertTrue($result);
+        // getUserWithProfile() mock always returns 'test@example.com'
+        $this->assertSame('test@example.com', $capturedTo);
+    }
+
+    /**
+     * sendAdminAlert() returns true when at least one of two admin addresses succeeds.
+     * The first delivery fails; the second succeeds. Loop-return condition is verified.
+     */
+    public function testSendAdminAlertReturnsTrueWhenAtLeastOneSucceeds(): void
+    {
+        $GLOBALS['mockAdminEmails'] = 'fail@example.com,pass@example.com';
+
+        $db      = $this->createFoundMockDb($this->makeTransferRow(), $this->makeCarRow());
+        $attempt = 0;
+        $mailer  = function (string $to) use (&$attempt): bool {
+            $attempt++;
+            return $attempt > 1; // first call fails, second succeeds
+        };
+
+        $service = new TransferEmailService($db, $mailer, self::$fakeBasePath);
+        $result  = $service->sendAdminAlert(1);
+
+        $this->assertTrue($result);
+        $this->assertSame(2, $attempt, 'Mailer must be called once per admin address');
+    }
+
+    /**
+     * sendAdminAlert() returns false immediately when no admin email is configured.
+     */
+    public function testSendAdminAlertReturnsFalseWhenNoAdminEmailConfigured(): void
+    {
+        $GLOBALS['mockAdminEmails'] = '';
+
+        $db     = $this->createFoundMockDb($this->makeTransferRow(), $this->makeCarRow());
+        $called = false;
+        $mailer = function () use (&$called): bool {
+            $called = true;
+            return true;
+        };
+
+        $service = new TransferEmailService($db, $mailer, self::$fakeBasePath);
+        $result  = $service->sendAdminAlert(1);
+
+        $this->assertFalse($result);
+        $this->assertFalse($called, 'Mailer must not be called when there are no admin addresses');
+    }
+
+    /**
+     * sendResponse() returns true when the requester email succeeds even if
+     * the previous-owner notification fails — verifying the OR logic in
+     * `return $requesterNotificationSent || $previousOwnerNotificationSent`.
+     */
+    public function testSendResponseReturnsTrueWhenRequesterSucceedsAndPreviousOwnerFails(): void
+    {
+        $db      = $this->createFoundMockDb($this->makeTransferRow(), $this->makeCarRow());
+        $attempt = 0;
+        $mailer  = function () use (&$attempt): bool {
+            $attempt++;
+            return $attempt === 1; // first call (requester) succeeds; second (previous owner) fails
+        };
+
+        $service = new TransferEmailService($db, $mailer, self::$fakeBasePath);
+        // Pass previousOwnerId so sendPreviousOwnerNotification() resolves an owner
+        $result  = $service->sendResponse(1, true, '', 1);
+
+        $this->assertTrue($result);
     }
 }


### PR DESCRIPTION
## Summary

- Extends `TransferEmailServiceTest` with a configurable mock DB that dispatches by table name (transfer vs car row), plus minimal fake template stubs created once per test class
- Adds `$mockAdminEmails` global override to the bootstrap `getAdminEmails()` mock, following the existing `$mockIsRegistryAdmin` pattern
- Adds 4 tests covering the branches that were unreachable with the old count=0-only mock:
  1. `testSendRequestCallsMailerWhenRecordFound` — mailer is called; captures recipient address
  2. `testSendAdminAlertReturnsTrueWhenAtLeastOneSucceeds` — 2 admins, first fails second succeeds → `true`; verifies the loop-return condition
  3. `testSendAdminAlertReturnsFalseWhenNoAdminEmailConfigured` — empty config → early `false`; mailer never called
  4. `testSendResponseReturnsTrueWhenRequesterSucceedsAndPreviousOwnerFails` — partial success verifies the `||` in the return

## Test plan

- [x] `composer test:quick` — 1001/1001 pass, no warnings
- [x] Pre-commit hooks pass (PHPStan, phpcs, unit suite)
- [x] No production code changed — test files only

Closes #1092

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM