### PR TITLE
test: add integration tests for 3 admin owner-management endpoints (#989)

### DIFF
--- a/tests/integration/AdminOwnerManagementTest.php
+++ b/tests/integration/AdminOwnerManagementTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for the three admin owner-management AJAX endpoints.
+ *
+ * The endpoint files (process-owner-search.php, process-owner-update.php,
+ * process-owner-sync-location.php) call `send()` (which exits) so they
+ * cannot be included in unit/integration tests directly. This class uses:
+ *
+ * - Source-inspection for auth-guard and CSRF-guard contracts (pins that
+ *   the guard code is present in each file).
+ * - Behavioral integration tests for the happy-path logic via the underlying
+ *   ElanRegistryOwner class and real database fixtures.
+ */
+#[Group('integration')]
+#[Group('admin')]
+final class AdminOwnerManagementTest extends IntegrationTestCase
+{
+    /** @var int[] Profile IDs to clean up in tearDown */
+    private array $createdProfileIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdProfileIds as $profileId) {
+            try {
+                $this->db->query("DELETE FROM profiles WHERE id = ?", [$profileId]);
+            } catch (\Throwable $e) {
+                // Ignore cleanup errors
+            }
+        }
+        $this->createdProfileIds = [];
+        parent::tearDown();
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * Create a profile row for a test user with optional lat/lon coordinates.
+     * Tracked for cleanup in tearDown().
+     */
+    private function createTestProfile(int $userId, array $overrides = []): void
+    {
+        $defaults = [
+            'user_id' => $userId,
+            'bio'     => '',
+            'city'    => 'Portland',
+            'state'   => 'Oregon',
+            'country' => 'United States',
+            'lat'     => null,
+            'lon'     => null,
+        ];
+
+        $this->db->insert('profiles', array_merge($defaults, $overrides));
+
+        $row = $this->db->query("SELECT id FROM profiles WHERE user_id = ? ORDER BY id DESC LIMIT 1", [$userId])->first();
+        if ($row) {
+            $this->createdProfileIds[] = (int) $row->id;
+        }
+    }
+
+    /**
+     * Seed a valid CSRF token into the session and return it.
+     * The token is a 64-char hex string matching Token::check() format requirements.
+     */
+    private function seedCsrfToken(): string
+    {
+        $token = bin2hex(random_bytes(32));
+        $_SESSION['token'] = $token;
+        return $token;
+    }
+
+    // =========================================================================
+    // Auth-guard and CSRF-guard source-inspection tests
+    // =========================================================================
+
+    /**
+     * process-owner-search.php must require registry-admin before doing any work.
+     */
+    public function testOwnerSearchEndpointRequiresRegistryAdmin(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-search.php');
+        $this->assertStringContainsString(
+            'isRegistryAdmin',
+            $content,
+            'process-owner-search.php must check isRegistryAdmin()'
+        );
+        $this->assertStringContainsString(
+            "ApiResponse::forbidden(",
+            $content,
+            'process-owner-search.php must call ApiResponse::forbidden() for unauthorized requests'
+        );
+    }
+
+    /**
+     * process-owner-search.php must validate the CSRF token before acting.
+     */
+    public function testOwnerSearchEndpointValidatesCsrfToken(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-search.php');
+        $this->assertStringContainsString(
+            'Token::check(',
+            $content,
+            'process-owner-search.php must call Token::check() for CSRF validation'
+        );
+    }
+
+    /**
+     * process-owner-update.php must require registry-admin before doing any work.
+     */
+    public function testOwnerUpdateEndpointRequiresRegistryAdmin(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-update.php');
+        $this->assertStringContainsString(
+            'isRegistryAdmin',
+            $content,
+            'process-owner-update.php must check isRegistryAdmin()'
+        );
+        $this->assertStringContainsString(
+            "ApiResponse::forbidden(",
+            $content,
+            'process-owner-update.php must call ApiResponse::forbidden() for unauthorized requests'
+        );
+    }
+
+    /**
+     * process-owner-update.php must validate the CSRF token before acting.
+     */
+    public function testOwnerUpdateEndpointValidatesCsrfToken(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-update.php');
+        $this->assertStringContainsString(
+            'Token::check(',
+            $content,
+            'process-owner-update.php must call Token::check() for CSRF validation'
+        );
+    }
+
+    /**
+     * process-owner-sync-location.php must require registry-admin before doing any work.
+     */
+    public function testOwnerSyncLocationEndpointRequiresRegistryAdmin(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-sync-location.php');
+        $this->assertStringContainsString(
+            'isRegistryAdmin',
+            $content,
+            'process-owner-sync-location.php must check isRegistryAdmin()'
+        );
+        $this->assertStringContainsString(
+            "ApiResponse::forbidden(",
+            $content,
+            'process-owner-sync-location.php must call ApiResponse::forbidden() for unauthorized requests'
+        );
+    }
+
+    /**
+     * process-owner-sync-location.php must validate the CSRF token before acting.
+     */
+    public function testOwnerSyncLocationEndpointValidatesCsrfToken(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-sync-location.php');
+        $this->assertStringContainsString(
+            'Token::check(',
+            $content,
+            'process-owner-sync-location.php must call Token::check() for CSRF validation'
+        );
+    }
+
+    // =========================================================================
+    // Happy-path behavioral tests via ElanRegistryOwner
+    // =========================================================================
+
+    /**
+     * Happy path for owner-search: a test user created in the DB is returned
+     * by ElanRegistryOwner::searchOwners() when searched by email prefix.
+     *
+     * Validates that the search logic used by process-owner-search.php finds
+     * real owners from the database.
+     */
+    public function testSearchOwnersReturnsMatchingOwner(): void
+    {
+        $userId = $this->createTestUser(['fname' => 'SearchHappy', 'lname' => 'PathTest']);
+
+        $ownerManager = new ElanRegistryOwner();
+        $results = $ownerManager->searchOwners('SearchHappy', 25);
+
+        $this->assertIsArray($results);
+        $this->assertNotEmpty($results, 'searchOwners() must return the newly created test user');
+
+        $ids = array_column((array) $results, 'id');
+        $this->assertContains((string) $userId, array_map('strval', $ids),
+            'searchOwners() must include the test user in results'
+        );
+    }
+
+    /**
+     * Happy path for owner-update: ElanRegistryOwner::update() persists a
+     * changed city to the profiles table when called with a valid CSRF token.
+     *
+     * Validates the DB write path used by process-owner-update.php.
+     */
+    public function testUpdateOwnerProfilePersistsToDatabase(): void
+    {
+        $userId = $this->createTestUser();
+        $this->createTestProfile($userId, ['city' => 'Salem']);
+
+        $token = $this->seedCsrfToken();
+
+        $owner = new ElanRegistryOwner($userId);
+        $result = $owner->update([
+            'id'   => $userId,
+            'csrf' => $token,
+            'city' => 'Eugene',
+        ]);
+
+        $this->assertTrue($result, 'ElanRegistryOwner::update() must return true on success');
+
+        $row = $this->db->query(
+            "SELECT city FROM profiles WHERE user_id = ?",
+            [$userId]
+        )->first();
+
+        $this->assertNotNull($row, 'profiles row must exist after update');
+        $this->assertSame('Eugene', $row->city, 'City must be persisted to the profiles table');
+    }
+
+    /**
+     * Happy path for owner-sync-location: ElanRegistryOwner::syncLocationToCars()
+     * copies the owner's lat/lon to all owned cars and returns the count of
+     * cars updated.
+     *
+     * Validates the sync logic used by process-owner-sync-location.php.
+     */
+    public function testSyncLocationToCarsCopiesCoordinatesToOwnedCar(): void
+    {
+        $userId = $this->createTestUser();
+        $this->createTestProfile($userId, [
+            'city'    => 'Portland',
+            'state'   => 'Oregon',
+            'country' => 'United States',
+            'lat'     => 45.5231,
+            'lon'     => -122.6765,
+        ]);
+        $carId = $this->createTestCar($userId);
+
+        // Load owner with full profile data (lat/lon present)
+        $owner = new ElanRegistryOwner($userId);
+        $this->assertNotNull($owner->data(), 'Owner must load successfully after profile creation');
+
+        $carsUpdated = $owner->syncLocationToCars();
+
+        $this->assertSame(1, $carsUpdated, 'syncLocationToCars() must update the one owned car');
+
+        $car = $this->db->query("SELECT lat, lon FROM cars WHERE id = ?", [$carId])->first();
+        $this->assertNotNull($car);
+        $this->assertEqualsWithDelta(45.5231, (float) $car->lat, 0.001, 'Car lat must match owner lat');
+        $this->assertEqualsWithDelta(-122.6765, (float) $car->lon, 0.001, 'Car lon must match owner lon');
+    }
+}

--- a/tests/integration/AdminOwnerManagementTest.php
+++ b/tests/integration/AdminOwnerManagementTest.php
@@ -67,9 +67,10 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
         $this->db->insert('profiles', array_merge($defaults, $overrides));
 
         $row = $this->db->query("SELECT id FROM profiles WHERE user_id = ? ORDER BY id DESC LIMIT 1", [$userId])->first();
-        if ($row) {
-            $this->createdProfileIds[] = (int) $row->id;
+        if (!$row) {
+            throw new \RuntimeException("createTestProfile: insert failed for user_id={$userId}");
         }
+        $this->createdProfileIds[] = (int) $row->id;
     }
 
     /**
@@ -93,6 +94,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     public function testOwnerSearchEndpointRequiresRegistryAdmin(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-search.php');
+        $this->assertNotFalse($content, 'Could not read process-owner-search.php');
         $this->assertStringContainsString(
             'isRegistryAdmin',
             $content,
@@ -111,6 +113,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     public function testOwnerSearchEndpointValidatesCsrfToken(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-search.php');
+        $this->assertNotFalse($content, 'Could not read process-owner-search.php');
         $this->assertStringContainsString(
             'Token::check(',
             $content,
@@ -124,6 +127,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     public function testOwnerUpdateEndpointRequiresRegistryAdmin(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-update.php');
+        $this->assertNotFalse($content, 'Could not read process-owner-update.php');
         $this->assertStringContainsString(
             'isRegistryAdmin',
             $content,
@@ -142,6 +146,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     public function testOwnerUpdateEndpointValidatesCsrfToken(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-update.php');
+        $this->assertNotFalse($content, 'Could not read process-owner-update.php');
         $this->assertStringContainsString(
             'Token::check(',
             $content,
@@ -155,6 +160,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     public function testOwnerSyncLocationEndpointRequiresRegistryAdmin(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-sync-location.php');
+        $this->assertNotFalse($content, 'Could not read process-owner-sync-location.php');
         $this->assertStringContainsString(
             'isRegistryAdmin',
             $content,
@@ -173,6 +179,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     public function testOwnerSyncLocationEndpointValidatesCsrfToken(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-sync-location.php');
+        $this->assertNotFalse($content, 'Could not read process-owner-sync-location.php');
         $this->assertStringContainsString(
             'Token::check(',
             $content,
@@ -186,7 +193,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
 
     /**
      * Happy path for owner-search: a test user created in the DB is returned
-     * by ElanRegistryOwner::searchOwners() when searched by email prefix.
+     * by ElanRegistryOwner::searchOwners() when searched by first name.
      *
      * Validates that the search logic used by process-owner-search.php finds
      * real owners from the database.


### PR DESCRIPTION
## Summary

- Adds `AdminOwnerManagementTest` (integration) with 9 tests covering the three previously-untested admin owner-management AJAX endpoints
- 6 source-inspection tests: auth guard (`isRegistryAdmin`) and CSRF guard (`Token::check`) verified present in each of the three endpoint files
- 3 behavioral integration tests: happy-path via `ElanRegistryOwner` with real DB fixtures — search returns a test user, update persists to `profiles` table, sync copies lat/lon to owned car

## Test plan

- [x] `composer test:medium` — 1174 tests, 1 pre-existing failure (`Issue317RegressionTest`), all new tests pass
- [x] Pre-commit hooks: coding standards, PHPStan, unit tests — all pass

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM