### PR TITLE
refactor: create app/owner/ directory and migrate owner-facing pages (Phase 2)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -61,3 +61,13 @@ RewriteRule ^FIX/(?!index\.php$|[0-9]+-.*\.php$|[A-Za-z]+-.*\.php$) - [F,L]
 
 # Redirects for migrated pages (#559)
 Redirect 301 /app/cars/identify.php /docs/reference/identification-guide.php
+
+# Redirects for app/owner/ migration (#1040)
+Redirect 301 /app/cars/index.php /app/owner/cars/index.php
+Redirect 301 /app/cars/details.php /app/owner/cars/details.php
+Redirect 301 /app/cars/edit.php /app/owner/cars/edit.php
+Redirect 301 /app/cars/factory.php /app/owner/cars/factory.php
+Redirect 301 /app/contact/index.php /app/owner/contact/index.php
+Redirect 301 /app/contact/owner.php /app/owner/contact/owner.php
+Redirect 301 /app/reports/statistics.php /app/owner/reports/statistics.php
+Redirect 301 /app/privacy.php /app/owner/privacy.php

--- a/app/admin/includes/tab-manage_cars.php
+++ b/app/admin/includes/tab-manage_cars.php
@@ -1104,7 +1104,7 @@ $qualityScore = $totalCars > 0 ? max(0, 100 - (($carIssues / $totalCars) * 100))
                                                                         <?php } ?>
                                                                     </label>
                                                                 </div>
-                                                                <a class="btn btn-outline-primary btn-sm" target="_blank" href='<?= $us_url_root ?>app/cars/details.php?car_id=<?= $car->id ?>'>
+                                                                <a class="btn btn-outline-primary btn-sm" target="_blank" href='<?= $us_url_root ?>app/owner/cars/details.php?car_id=<?= $car->id ?>'>
                                                                     <i class="fas fa-external-link-alt"></i> View Details
                                                                 </a>
                                                             </div>

--- a/app/admin/includes/tab-owner_mgmt.php
+++ b/app/admin/includes/tab-owner_mgmt.php
@@ -515,7 +515,7 @@ $ownerQualityIcon  = match (true) {
                                                                                                             <?php foreach ($owner->cars as $car) { ?>
                                                                                                                 <tr>
                                                                                                                     <td>
-                                                                                                                        <a href="<?= $us_url_root ?>app/cars/details.php?car_id=<?= $car->id ?>"
+                                                                                                                        <a href="<?= $us_url_root ?>app/owner/cars/details.php?car_id=<?= $car->id ?>"
                                                                                                                            target="_blank" class="badge text-bg-primary">
                                                                                                                             <?= $car->id ?>
                                                                                                                         </a>

--- a/app/admin/scripts/maintenance/21-Fix-Page-Permissions.php
+++ b/app/admin/scripts/maintenance/21-Fix-Page-Permissions.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
  *
  * OWNER/USER PRIVATE PAGES (will be set to private=1 with User permission):
  * - app/api/contact/* - Contact API endpoints (send-feedback, send-owner-email)
- * - app/contact/* - All contact form pages
+ * - app/owner/contact/* - All contact form pages
  * - *edit* - Any path containing "edit" (that doesn't also contain "admin")
  * - usersc/* - All UserSpice customization pages (EXCEPT special cases below)
  * Note: app/api/cars/* and app/api/shared/* endpoints that don't call
@@ -36,15 +36,15 @@ declare(strict_types=1);
  * (some app/api/cars/* endpoints enforce authentication inline without
  * securePage() and are private, but they are outside this script's scope).
  *
- * SPECIAL CASE PRIVATE PAGES (will be set to private=1 with NO permissions):
- * - usersc/join.php - Registration page (public access, no permissions needed)
- * - usersc/login.php - Login page (public access, no permissions needed)
+ * PUBLIC PAGES (usersc/* special cases — mirroring UserSpice installer defaults):
+ * - usersc/login.php - Login page (private=0, no permissions — same as users/login.php)
+ * - usersc/join.php  - Registration page (private=0, no permissions — same as users/join.php)
  *
  * PUBLIC PAGES (will be set to private=0 with no permissions):
  * - Everything else in app/* that doesn't match PRIVATE patterns
  * - Error pages in root: 404.php, 403.php, etc.
  * - docs/* (except docs/*admin*) - Documentation pages
- * - Examples: app/cars/index.php, app/cars/details.php, app/reports/statistics.php, docs/guides/index.php
+ * - Examples: app/owner/cars/index.php, app/owner/cars/details.php, app/owner/reports/statistics.php, docs/guides/index.php
  *
  * USERS/* PAGES (corrected to UserSpice installer defaults):
  * - users/account.php, users/user_settings.php, users/admin_pin.php → PRIVATE, User permission
@@ -510,7 +510,7 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                                 <p class="mb-2"><strong>Owner (private=1, User permission):</strong></p>
                                 <ul>
                                     <li><strong>app/api/contact/*</strong> - Contact API endpoints</li>
-                                    <li><strong>app/contact/*</strong> - All contact form pages</li>
+                                    <li><strong>app/owner/contact/*</strong> - All contact form pages</li>
                                     <li><strong>*edit*</strong> - Any path containing "edit"</li>
                                     <li><strong>usersc/*</strong> - All UserSpice customization pages</li>
                                 </ul>
@@ -542,10 +542,10 @@ require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
                                 <h5><i class="fa fa-info-circle"></i> PUBLIC Pages (will be private=0 with no permissions):</h5>
                                 <p class="mb-2">All other pages in app/*, including:</p>
                                 <ul class="mb-0">
-                                    <li><strong>app/cars/index.php</strong> - Car listing</li>
-                                    <li><strong>app/cars/details.php</strong> - Car details</li>
-                                    <li><strong>app/reports/statistics.php</strong> - Public statistics</li>
-                                    <li><strong>app/privacy.php</strong> - Privacy policy</li>
+                                    <li><strong>app/owner/cars/index.php</strong> - Car listing</li>
+                                    <li><strong>app/owner/cars/details.php</strong> - Car details</li>
+                                    <li><strong>app/owner/reports/statistics.php</strong> - Public statistics</li>
+                                    <li><strong>app/owner/privacy.php</strong> - Privacy policy</li>
                                     <li>Other public-facing pages</li>
                                 </ul>
                             </div>

--- a/app/admin/verify/verify_car.php
+++ b/app/admin/verify/verify_car.php
@@ -110,7 +110,7 @@ if (Input::exists('get') && Input::get('code') && Input::get('action')) {
                 "Car verified successfully - ID: {$car->id} Chassis: {$car->chassis}"
             );
 
-            $redirect = $base_url . $us_url_root . 'app/cars/details.php?car_id=' . (int) $car->id;
+            $redirect = $base_url . $us_url_root . 'app/owner/cars/details.php?car_id=' . (int) $car->id;
             break;
 
         case 'edit':
@@ -130,7 +130,7 @@ if (Input::exists('get') && Input::get('code') && Input::get('action')) {
                 "Car reported as sold via verification - ID: {$car->id} Chassis: {$car->chassis}"
             );
 
-            $redirect = $base_url . $us_url_root . 'app/cars/details.php?car_id=' . (int) $car->id;
+            $redirect = $base_url . $us_url_root . 'app/owner/cars/details.php?car_id=' . (int) $car->id;
             break;
     }
 }

--- a/app/api/contact/send-owner-email.php
+++ b/app/api/contact/send-owner-email.php
@@ -128,7 +128,7 @@ if (!$carRow) {
         ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'send-owner-email.php: car not found for car_id=' . $carId . ' (concurrent delete?)')
         ->send();
 }
-$carUrl = $current_origin . $us_url_root . 'app/cars/details.php?car_id=' . $carId;
+$carUrl = $current_origin . $us_url_root . 'app/owner/cars/details.php?car_id=' . $carId;
 
 $template = array(
     'message'      => $message,

--- a/app/assets/css/edit_car.css
+++ b/app/assets/css/edit_car.css
@@ -1,6 +1,6 @@
 /**
  * edit_car.css
- * Page-specific styles for the Edit Car form (app/cars/form.php).
+ * Page-specific styles for the Edit Car form (app/owner/cars/edit.php).
  *
  * Globally reusable rules (.form-section-heading, .fit-image) now live in
  * customizer.css. Each block here is intentionally scoped to #editCar or to

--- a/app/assets/css/location-picker.css
+++ b/app/assets/css/location-picker.css
@@ -4,7 +4,7 @@
  * Modern location collection component styles
  *
  * All rules scoped to .location-picker-container — component used on the
- * Edit Car form (app/cars/form.php).
+ * Edit Car form (app/owner/cars/edit.php).
  *
  * @package ElanRegistry
  * @version 2.11.0

--- a/app/assets/js/statistics.js
+++ b/app/assets/js/statistics.js
@@ -535,10 +535,14 @@ function renderQualityTab(container, data) {
     `;
 
   wrapper.querySelector('[data-metric="total"]').textContent = totalCars.toLocaleString();
-  [['chassis', completeness.has_chassis], ['color', completeness.has_color],
-   ['engine', completeness.has_engine], ['purchase_date', completeness.has_purchase_date],
-   ['image', completeness.has_image], ['location', completeness.has_location]]
-    .forEach(([key, value]) => {
+  [
+    ['chassis',       completeness.has_chassis],
+    ['color',         completeness.has_color],
+    ['engine',        completeness.has_engine],
+    ['purchase_date', completeness.has_purchase_date],
+    ['image',         completeness.has_image],
+    ['location',      completeness.has_location],
+  ].forEach(([key, value]) => {
       const pct = totalCars > 0 ? Math.round((value / totalCars) * 100) : 0;
       wrapper.querySelector(`[data-metric="${key}"]`).textContent = pct + '%';
     });

--- a/app/owner/cars/details.php
+++ b/app/owner/cars/details.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * @copyright 2025
  */
 
-require_once '../../users/init.php';
+require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 if (!securePage($php_self)) {
@@ -31,7 +31,7 @@ if (!empty($_GET)) {
         // Log car not found error
         logger($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, "Car details requested for non-existent car ID: $carID");
         // Redirect to list if car not found
-        Redirect::to($us_url_root . '/app/cars/index.php');
+        Redirect::to($us_url_root . 'app/owner/cars/index.php');
     }
     
     // Cache car data objects to eliminate repeated method calls (Performance Optimization)
@@ -75,7 +75,7 @@ if (!empty($_GET)) {
 } else {
     // Shouldn't be here unless someone is mangling the url
     logger($user->data()->id ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'Car details page accessed without car_id parameter');
-    Redirect::to($us_url_root . '/app/cars/index.php');
+    Redirect::to($us_url_root . 'app/owner/cars/index.php');
 }
 ?>
 <div class="page-wrapper">
@@ -88,7 +88,7 @@ if (!empty($_GET)) {
                     <nav aria-label="breadcrumb">
                         <ol class="breadcrumb">
                             <li class="breadcrumb-item"><a href="<?= $us_url_root ?>" class="text-primary"><i class="fas fa-home"></i> Home</a></li>
-                            <li class="breadcrumb-item"><a href="<?= $us_url_root ?>app/cars/index.php" class="text-primary"><i class="fas fa-list"></i> Cars</a></li>
+                            <li class="breadcrumb-item"><a href="<?= $us_url_root ?>app/owner/cars/index.php" class="text-primary"><i class="fas fa-list"></i> Cars</a></li>
                             <li class="breadcrumb-item active text-muted" aria-current="page">
                                 <i class="fas fa-car"></i> <?= htmlspecialchars((string)($carData->year ?? ''), ENT_QUOTES, 'UTF-8') ?> <?= htmlspecialchars($carData->series ?? '', ENT_QUOTES, 'UTF-8') ?> 
                             </li>

--- a/app/owner/cars/edit.php
+++ b/app/owner/cars/edit.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * @package ElanRegistry
  * @version 2.0
  */
-require_once '../../users/init.php';
+require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 use ElanRegistry\Documentation\DocumentPortalTemplate;
@@ -920,7 +920,7 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
                 const data = await response.json();
 
                 if (data.success === true) {
-                    window.location = '<?= $us_url_root ?>app/cars/details.php?car_id=' + data.cardetails.id;
+                    window.location = '<?= $us_url_root ?>app/owner/cars/details.php?car_id=' + data.cardetails.id;
                 } else {
                     submitBtn.disabled = false;
                     submitBtn.textContent = submitBtn.dataset.label;
@@ -1266,7 +1266,7 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
 
     // Handle success modal OK button
     $('#transferSuccessOkBtn').click(function() {
-        window.location.href = '<?= $us_url_root ?>app/cars/';
+        window.location.href = '<?= $us_url_root ?>app/owner/cars/';
     });
 
     // Character counter for transfer comments

--- a/app/owner/cars/factory.php
+++ b/app/owner/cars/factory.php
@@ -9,7 +9,7 @@
  * @author Elan Registry Team
  * @copyright 2025
  */
-require_once '../../users/init.php';
+require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 if (!securePage($php_self)) {
@@ -94,7 +94,7 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
     'serverMethod': 'post',
 
     "ajax": {
-      "url": "../api/cars/factory-list.php",
+      "url": "../../api/cars/factory-list.php",
       "dataSrc": "data",
       data: function(d) {
         d.csrf = csrf;
@@ -182,7 +182,7 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
           const carId = parseInt(response.car_id, 10);
           if (Number.isFinite(carId) && carId > 0) {
             // Car exists - create link to car details
-            const detailsUrl = us_url_root + 'app/cars/details.php?car_id=' + carId;
+            const detailsUrl = us_url_root + 'app/owner/cars/details.php?car_id=' + carId;
             container.html(
               '<a href="' + detailsUrl + '" class="btn btn-sm btn-primary" target="_blank">' +
               '<i class="fas fa-car"></i> View Car #' + carId +

--- a/app/owner/cars/index.php
+++ b/app/owner/cars/index.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * @package ElanRegistry
  */
-require_once '../../users/init.php';
+require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 use ElanRegistry\Documentation\DocumentPortalTemplate;
@@ -157,7 +157,7 @@ window.ELAN_CONFIG = {
     serverSide: true,
     serverMethod: 'post',
     ajax: {
-      url: '../api/cars/list.php',
+      url: '../../api/cars/list.php',
       dataSrc: 'data',
       data: function(d) {
         d.csrf = csrf;
@@ -175,7 +175,7 @@ window.ELAN_CONFIG = {
         const isNew = typeof NEW_CAR_IDS !== 'undefined'
           && NEW_CAR_IDS.includes(parseInt(data, 10));
         const badge = isNew ? ' <span class="badge er-badge-yellow badge-sm">NEW</span>' : '';
-        return '<a class="btn btn-primary btn-sm" href="' + us_url_root + 'app/cars/details.php?car_id=' + data + '"><i class="fas fa-eye"></i> Details' + badge + '</a>';
+        return '<a class="btn btn-primary btn-sm" href="' + us_url_root + 'app/owner/cars/details.php?car_id=' + data + '"><i class="fas fa-eye"></i> Details' + badge + '</a>';
       }
     }, {
       data: 'year',

--- a/app/owner/contact/index.php
+++ b/app/owner/contact/index.php
@@ -11,7 +11,7 @@
  */
 use ElanRegistry\OwnerView;
 
-require_once '../../users/init.php';
+require_once '../../../users/init.php';
 require_once $abs_us_root.$us_url_root.'usersc/includes/elanregistry_prep.php';
 
 if (!securePage($php_self)) {

--- a/app/owner/contact/owner.php
+++ b/app/owner/contact/owner.php
@@ -9,7 +9,7 @@
  */
 use ElanRegistry\OwnerView;
 
-require_once '../../users/init.php';
+require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 if (!securePage($php_self)) {

--- a/app/owner/privacy.php
+++ b/app/owner/privacy.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * @author Elan Registry Admin
  * @copyright 2025
  */
-require_once '../users/init.php';
+require_once '../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 if (!securePage($php_self)) {

--- a/app/owner/reports/statistics.php
+++ b/app/owner/reports/statistics.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @author Elan Registry Analytics Team
  * @copyright 2025
  */
-require_once '../../users/init.php';
+require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 require_once $abs_us_root . $us_url_root . 'usersc/classes/StatisticsDataService.php';
 
@@ -338,7 +338,7 @@ window.statisticsRawData = {
 
 // Configuration
 window.statisticsConfig = {
-    baseUrl: '<?= $us_url_root ?>app/reports/',
+    baseUrl: '<?= $us_url_root ?>app/owner/reports/',
     statisticsDataUrl: '<?= $us_url_root ?>app/api/shared/statistics.php',
     imageUrl: '<?= $us_url_root . $settings->elan_image_dir ?>',
     versatileStyleUrl: '<?= $us_url_root ?>usersc/js/versatiles-colorful.json'

--- a/app/views/cars/_car_hero_actions.php
+++ b/app/views/cars/_car_hero_actions.php
@@ -6,7 +6,7 @@ $heroCarId = (int)($heroCarId ?? 0);
 
 switch ($context) {
     case 'owner_detail': ?>
-        <form method="POST" action="<?= $_baseUrl ?>app/cars/edit.php" class="d-inline">
+        <form method="POST" action="<?= $_baseUrl ?>app/owner/cars/edit.php" class="d-inline">
             <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
             <input type="hidden" name="action" value="updateCar" />
             <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
@@ -21,7 +21,7 @@ switch ($context) {
             <i class="fas fa-shield-alt" aria-hidden="true"></i> <strong>Administrative Override:</strong>
             You are editing a car that you do not own using Administrator/Editor privileges.
         </div>
-        <form method="POST" action="<?= $_baseUrl ?>app/cars/edit.php" class="d-inline me-2">
+        <form method="POST" action="<?= $_baseUrl ?>app/owner/cars/edit.php" class="d-inline me-2">
             <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
             <input type="hidden" name="action" value="updateCar" />
             <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
@@ -30,7 +30,7 @@ switch ($context) {
                 <i class="fas fa-edit" aria-hidden="true"></i> Admin Edit Car
             </button>
         </form>
-        <form method="POST" action="<?= $_baseUrl ?>app/contact/owner.php" class="d-inline">
+        <form method="POST" action="<?= $_baseUrl ?>app/owner/contact/owner.php" class="d-inline">
             <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
             <input type="hidden" name="action" value="contact_owner" />
             <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
@@ -41,7 +41,7 @@ switch ($context) {
         <?php break;
 
     case 'visitor_detail': ?>
-        <form method="POST" action="<?= $_baseUrl ?>app/contact/owner.php" class="d-inline">
+        <form method="POST" action="<?= $_baseUrl ?>app/owner/contact/owner.php" class="d-inline">
             <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
             <input type="hidden" name="action" value="contact_owner" />
             <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
@@ -58,7 +58,7 @@ switch ($context) {
         <?php break;
 
     case 'owner_account': ?>
-        <form method="POST" action="<?= $_baseUrl ?>app/cars/edit.php" class="d-inline me-2">
+        <form method="POST" action="<?= $_baseUrl ?>app/owner/cars/edit.php" class="d-inline me-2">
             <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
             <input type="hidden" name="action" value="updateCar" />
             <input type="hidden" name="car_id" value="<?= $heroCarId ?>" />
@@ -66,7 +66,7 @@ switch ($context) {
                 <i class="fas fa-edit" aria-hidden="true"></i> Update Car
             </button>
         </form>
-        <a class="btn btn-outline-light btn-lg" role="button" href="<?= $_baseUrl ?>app/cars/details.php?car_id=<?= $heroCarId ?>">
+        <a class="btn btn-outline-light btn-lg" role="button" href="<?= $_baseUrl ?>app/owner/cars/details.php?car_id=<?= $heroCarId ?>">
             <i class="fas fa-eye" aria-hidden="true"></i> View Details
         </a>
         <?php break;

--- a/app/views/email/_admin_to_owner.php
+++ b/app/views/email/_admin_to_owner.php
@@ -57,9 +57,9 @@ $content = "
 if ($hasCarContext) {
     $baseUrl = getBaseUrl();
     if ($hasQualityIssue) {
-        $content .= $emailTemplate->createButton('Update Your Car Record', $baseUrl . '/app/cars/edit.php?car_id=' . (int)$carContext['id'], 'primary');
+        $content .= $emailTemplate->createButton('Update Your Car Record', $baseUrl . '/app/owner/cars/edit.php?car_id=' . (int)$carContext['id'], 'primary');
     } else {
-        $content .= $emailTemplate->createButton('View Your Car', $baseUrl . '/app/cars/details.php?car_id=' . (int)$carContext['id'], 'primary');
+        $content .= $emailTemplate->createButton('View Your Car', $baseUrl . '/app/owner/cars/details.php?car_id=' . (int)$carContext['id'], 'primary');
     }
 } else {
     $content .= "

--- a/app/views/email/_transfer_request.php
+++ b/app/views/email/_transfer_request.php
@@ -43,7 +43,7 @@ $content = "
 
     <p>No changes have been made to your registration. Registry administrators will review this request carefully before any transfer is considered.</p>
 
-    " . $emailTemplate->createButton('View Your Car in the Registry', getBaseUrl() . '/app/cars/details.php?car_id=' . $carInfo->id, 'primary') . "
+    " . $emailTemplate->createButton('View Your Car in the Registry', getBaseUrl() . '/app/owner/cars/details.php?car_id=' . $carInfo->id, 'primary') . "
 
     <p><strong>What happens next?</strong></p>
     <ul>

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ project, structured for different audiences and use cases.
 **Access:** Public (no authentication required)
 
 - **[index.php](guides/index.php)** - Owner guides portal
-- **[Privacy Policy](../app/privacy.php)** - Privacy policy and data handling practices
+- **[Privacy Policy](../app/owner/privacy.php)** - Privacy policy and data handling practices
 - **[Transfer FAQ](guides/car-transfer-faq.php)** - Frequently asked questions about car ownership transfers
 
 ### `/reference/` - Technical Reference

--- a/docs/development/CLASSES.md
+++ b/docs/development/CLASSES.md
@@ -943,7 +943,7 @@ EmailTemplate
 └── Used by: Transfer requests, notifications
 
 DocumentPortalTemplate
-└── Used by: docs/guides/index.php, docs/reference/*, app/cars/index.php, app/reports/statistics.php
+└── Used by: docs/guides/index.php, docs/reference/*, app/owner/cars/index.php, app/owner/reports/statistics.php
 ```
 
 ## Testing

--- a/docs/development/DATATABLES.md
+++ b/docs/development/DATATABLES.md
@@ -30,7 +30,7 @@ As of v2.11.0, we use **only 3 DataTables extensions** for optimal performance:
 
 ### Car Listing Pages
 
-**File**: `/app/cars/index.php` (List Cars)
+**File**: `/app/owner/cars/index.php` (List Cars)
 
 **Configuration**:
 
@@ -60,7 +60,7 @@ const table = $("#cartable").DataTable({
 
 ### Factory Information Page
 
-**File**: `/app/cars/factory.php` (List Factory)
+**File**: `/app/owner/cars/factory.php` (List Factory)
 
 **Configuration**:
 
@@ -167,13 +167,13 @@ vendored frontend libraries.
 
 ```bash
 # Check for FixedHeader usage
-grep -r "fixedHeader:\s*true" app/cars/
+grep -r "fixedHeader:\s*true" app/owner/cars/
 
 # Check for Responsive usage
-grep -r "responsive:\s*true" app/cars/
+grep -r "responsive:\s*true" app/owner/cars/
 
 # Check for unused extensions
-grep -r "rowGroup\|scroller\|searchBuilder\|searchPanes" app/cars/
+grep -r "rowGroup\|scroller\|searchBuilder\|searchPanes" app/owner/cars/
 ```
 
 ### Server-Side vs Client-Side Processing
@@ -250,13 +250,13 @@ server-side processing or assess if the UX trade-offs are acceptable.
 
 **Manual Testing Checklist**:
 
-1. Navigate to List Cars page (`/app/cars/index.php`)
+1. Navigate to List Cars page (`/app/owner/cars/index.php`)
 2. Verify table loads without JavaScript errors
 3. Test search functionality (type in search box)
 4. Test sorting (click column headers)
 5. Test pagination (navigate between pages)
 6. Test responsive layout (resize browser window)
-7. Repeat for Factory Information page (`/app/cars/factory.php`)
+7. Repeat for Factory Information page (`/app/owner/cars/factory.php`)
 
 **Automated Testing**:
 
@@ -366,7 +366,7 @@ Tests the Registry Link feature on the factory page:
 ```javascript
 test('should load factory page without errors', async ({ page }) => {
   // Navigate to Factory page
-  await page.goto('/app/cars/factory.php');
+  await page.goto('/app/owner/cars/factory.php');
   await page.waitForLoadState('domcontentloaded');
 
   // Verify table renders

--- a/docs/development/FRONTEND_API_GUIDE.md
+++ b/docs/development/FRONTEND_API_GUIDE.md
@@ -411,7 +411,7 @@ $('#carForm').on('submit', async function(e) {
 
         // Optional: Redirect or update UI
         if (result.data.carId) {
-            window.location.href = `/app/cars/details.php?id=${result.data.carId}`;
+            window.location.href = `/app/owner/cars/details.php?id=${result.data.carId}`;
         }
 
     } catch (error) {

--- a/docs/development/PAGE_LOADING_FLOW.md
+++ b/docs/development/PAGE_LOADING_FLOW.md
@@ -571,7 +571,7 @@ if ($method === 'POST') {
 }
 
 // Build redirect URL
-$redirect = $current_origin . '/app/cars/details.php?id=' . $carId;
+$redirect = $current_origin . '/app/owner/cars/details.php?id=' . $carId;
 
 // Log with IP
 logger($userId, LogCategories::LOG_CATEGORY_LOGIN, "Login from $remote_addr");

--- a/docs/development/UI_STANDARDS.md
+++ b/docs/development/UI_STANDARDS.md
@@ -282,8 +282,8 @@ Three first-party CSS source files (compiled to `.min.css` by `npm run build`):
 | File | Loaded by | Contains |
 | --- | --- | --- |
 | `app/admin/assets/manage-consolidated.css` | `index.php` | Admin comparison cards, field-match/differ, timestamp display |
-| `app/assets/css/edit_car.css` | `app/cars/edit.php` | FilePond overrides, `#editCar` focus, card z-index for drag-drop |
-| `app/assets/css/location-picker.css` | `app/cars/edit.php` | `.location-picker-container`-scoped styles |
+| `app/assets/css/edit_car.css` | `app/owner/cars/edit.php` | FilePond overrides, `#editCar` focus, card z-index for drag-drop |
+| `app/assets/css/location-picker.css` | `app/owner/cars/edit.php` | `.location-picker-container`-scoped styles |
 
 **Everything else is global in `customizer.css`.** If you find yourself writing a style in a page
 file that could apply to multiple pages, move it to `customizer.css` instead. Each rule retained

--- a/docs/development/adr/ADR-006-use-database-stored-cdn-urls-for-frontend-dependencies.md
+++ b/docs/development/adr/ADR-006-use-database-stored-cdn-urls-for-frontend-dependencies.md
@@ -75,9 +75,9 @@ echo html_entity_decode($settings->elan_fontawesome_cdn);
 
 **Page-specific dependencies** loaded only where needed:
 
-- `app/cars/index.php`, `app/cars/factory.php`, `app/cars/details.php` — DataTables JS/CSS
-- `app/cars/edit.php` — FilePond 4.x + 6 plugins (JS/CSS), Flatpickr (JS/CSS)
-- `app/reports/statistics.php` — Chart.js (with hardcoded fallback if setting not present)
+- `app/owner/cars/index.php`, `app/owner/cars/factory.php`, `app/owner/cars/details.php` — DataTables JS/CSS
+- `app/owner/cars/edit.php` — FilePond 4.x + 6 plugins (JS/CSS), Flatpickr (JS/CSS)
+- `app/owner/reports/statistics.php` — Chart.js (with hardcoded fallback if setting not present)
 
 ### SRI Protection
 

--- a/docs/development/adr/ADR-008-implement-self-service-car-ownership-transfer-workflow.md
+++ b/docs/development/adr/ADR-008-implement-self-service-car-ownership-transfer-workflow.md
@@ -281,8 +281,8 @@ Dedicated button on car detail page to initiate transfer, visible even before us
 
 | Item | File |
 | --- | --- |
-| Transfer request creation | [/app/cars/actions/request-transfer.php](../../app/cars/actions/request-transfer.php) |
-| Chassis collision detection | [/app/cars/actions/check-chassis.php](../../app/cars/actions/check-chassis.php) |
+| Transfer request creation | [/app/api/cars/transfer-request.php](../../app/api/cars/transfer-request.php) |
+| Chassis collision detection | [/app/api/cars/chassis-availability.php](../../app/api/cars/chassis-availability.php) |
 | Admin approval endpoint | [/app/admin/includes/process-transfer-approve.php](../../app/admin/includes/process-transfer-approve.php) |
 | Admin denial endpoint | [/app/admin/includes/process-transfer-deny.php](../../app/admin/includes/process-transfer-deny.php) |
 | Car::transfer() facade | [/usersc/classes/Car.php](../../usersc/classes/Car.php) |
@@ -292,8 +292,8 @@ Dedicated button on car detail page to initiate transfer, visible even before us
 | Email templates | [/usersc/views/emails/](../../usersc/views/emails/) (4 templates) |
 | Admin UI (requests table) | [/app/admin/includes/tab-car_mgmt.php](../../app/admin/includes/tab-car_mgmt.php) |
 | Admin JS handlers | [/app/admin/assets/manage-consolidated.js](../../app/admin/assets/manage-consolidated.js) |
-| Owner UI modals | [/app/cars/edit.php](../../app/cars/edit.php) |
-| Chassis check UI | [/app/cars/includes/_edit_car_1.php](../../app/cars/includes/_edit_car_1.php) |
+| Owner UI modals | [/app/owner/cars/edit.php](../../app/owner/cars/edit.php) |
+| Chassis check UI | [/app/owner/cars/edit.php](../../app/owner/cars/edit.php) (integrated into edit page) |
 | Database schema | [/database/1-schema.sql](../../database/1-schema.sql) |
 | Integration tests | [/tests/integration/transfer/CarTransferWorkflowTest.php](../../tests/integration/transfer/CarTransferWorkflowTest.php) |
 | Car repository | [/usersc/classes/Car/CarRepository.php](../../usersc/classes/Car/CarRepository.php) |

--- a/docs/development/adr/ADR-011-adopt-datatables-with-server-side-processing.md
+++ b/docs/development/adr/ADR-011-adopt-datatables-with-server-side-processing.md
@@ -70,7 +70,7 @@ Each endpoint:
 
 ### Frontend: Cars Listing
 
-**File**: `/app/cars/index.php`
+**File**: `/app/owner/cars/index.php`
 
 Configuration:
 
@@ -104,7 +104,7 @@ $('#cartable').DataTable({
 
 ### Frontend: Factory Build Records
 
-**File**: `/app/cars/factory.php`
+**File**: `/app/owner/cars/factory.php`
 
 Configuration:
 
@@ -286,8 +286,8 @@ Custom backend endpoint returning DataTables-compatible JSON, but frontend uses 
 - **DataTables Server-Side Processing**: [https://datatables.net/manual/server-side](https://datatables.net/manual/server-side)
 - **Backend Endpoints**: [app/api/cars/list.php](../../app/api/cars/list.php), [app/api/cars/factory-list.php](../../app/api/cars/factory-list.php), [app/api/cars/chassis-lookup.php](../../app/api/cars/chassis-lookup.php)
 - **Service Class**: [usersc/classes/Car/CarDataTablesService.php](../../usersc/classes/Car/CarDataTablesService.php)
-- **Cars Listing Page**: [app/cars/index.php](../../app/cars/index.php)
-- **Factory Listing Page**: [app/cars/factory.php](../../app/cars/factory.php)
+- **Cars Listing Page**: [app/owner/cars/index.php](../../app/owner/cars/index.php)
+- **Factory Listing Page**: [app/owner/cars/factory.php](../../app/owner/cars/factory.php)
 - **DataTables Documentation**: [docs/development/DATATABLES.md](../development/DATATABLES.md)
 - **ADR-001 (UserSpice)**: [docs/adr/ADR-001-userspice-authentication-framework.md](ADR-001-userspice-authentication-framework.md)
 - **ADR-002 (Denormalized cars)**: [docs/adr/ADR-002-denormalized-cars-table-cached-owner-data.md](ADR-002-denormalized-cars-table-cached-owner-data.md)

--- a/docs/releases/RELEASE_NOTES_v2.25.5.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.5.md
@@ -5,8 +5,34 @@
 
 ## Required Actions After Deployment
 
-TBD — will be updated as issues are completed. Expected: UserSpice `pages` table
-URL migration script for #1040 (app/owner/ path registration).
+### #1040 — app/owner/ page re-registration
+
+After deploying this release, the 8 moved pages must be re-registered in the
+UserSpice `pages` table with their new slugs and assigned correct permissions.
+
+1. **Visit each new URL** to trigger UserSpice auto-registration. Pages requiring
+   login (`edit`, both `contact` pages) must be visited while logged in as an admin;
+   public pages auto-register for any visitor:
+   - `/app/owner/cars/index.php`
+   - `/app/owner/cars/details.php` (any car)
+   - `/app/owner/cars/edit.php` (any car — **must be admin**)
+   - `/app/owner/cars/factory.php`
+   - `/app/owner/contact/index.php` (**must be admin**)
+   - `/app/owner/contact/owner.php` (any car — **must be admin**)
+   - `/app/owner/reports/statistics.php`
+   - `/app/owner/privacy.php`
+
+2. **Run the Fix Page Permissions maintenance script**
+   (`Admin → Maintenance → Fix Page Permissions`) to apply the correct
+   permission tier to the newly registered entries.
+
+3. **Optional: Remove stale old pages table entries.** The old slugs
+   (`app/cars/index.php`, `app/cars/details.php`, `app/cars/edit.php`,
+   `app/cars/factory.php`, `app/contact/index.php`, `app/contact/owner.php`,
+   `app/reports/statistics.php`, `app/privacy.php`) remain in the `pages` table
+   pointing to files that no longer exist. They cause no runtime errors but
+   inflate the page list. Delete them from the `pages` table after confirming
+   the new entries are registered correctly.
 
 ## User-Facing Changes
 

--- a/index.php
+++ b/index.php
@@ -190,7 +190,7 @@ try {
 								</dl>
 								<div class="mt-2 mb-3">
 									<a class='btn btn-primary btn-sm'
-									   href='<?= htmlspecialchars($us_url_root, ENT_QUOTES, 'UTF-8') ?>app/cars/details.php?car_id=<?= (int) $carData->id ?>'>
+									   href='<?= htmlspecialchars($us_url_root, ENT_QUOTES, 'UTF-8') ?>app/owner/cars/details.php?car_id=<?= (int) $carData->id ?>'>
 										<i class='fas fa-eye'></i> Details
 									</a>
 								</div>

--- a/tests/playwright/ajax-endpoints.spec.js
+++ b/tests/playwright/ajax-endpoints.spec.js
@@ -77,7 +77,7 @@ test.describe('Registry-Specific AJAX Endpoints', () => {
 
   test('DataTables AJAX endpoint returns car data', async ({ page }) => {
     // Navigate to car listing page to establish session
-    await page.goto('app/cars/index.php', { waitUntil: 'networkidle' });
+    await page.goto('app/owner/cars/index.php', { waitUntil: 'networkidle' });
 
     const response = await page.request.post('app/api/cars/list.php', {
       form: {
@@ -145,7 +145,7 @@ test.describe('Registry-Specific AJAX Endpoints', () => {
   test('NEW_CAR_IDS on car list page is a JSON int array', async ({ page }) => {
     // Verifies that CarShowcaseService::getNewCarIds() emits valid JSON to the page.
     // The const is embedded in the inline script block — shape must be int[].
-    await page.goto('app/cars/index.php', { waitUntil: 'networkidle' });
+    await page.goto('app/owner/cars/index.php', { waitUntil: 'networkidle' });
 
     const newCarIds = await page.evaluate(() => {
       if (typeof NEW_CAR_IDS === 'undefined') return null;

--- a/tests/playwright/car-details-output-escaping.spec.js
+++ b/tests/playwright/car-details-output-escaping.spec.js
@@ -11,7 +11,7 @@
 
 const { test, expect } = require('@playwright/test');
 
-const DETAILS_URL = 'app/cars/details.php?car_id=1091';
+const DETAILS_URL = 'app/owner/cars/details.php?car_id=1091';
 
 test.describe('Car details — output escaping (issue #840)', () => {
 

--- a/tests/playwright/car-edit-text-save.spec.js
+++ b/tests/playwright/car-edit-text-save.spec.js
@@ -154,7 +154,7 @@ test.describe('Car edit form — text-only save (regression #796)', () => {
         //    we need the page DOM to be present. We therefore also mock the
         //    page navigation itself only when the page is inaccessible.
         // ------------------------------------------------------------------
-        await page.goto('app/cars/edit.php?car_id=1', { waitUntil: 'domcontentloaded' });
+        await page.goto('app/owner/cars/edit.php?car_id=1', { waitUntil: 'domcontentloaded' });
 
         // If the page redirected to login, skip rather than fail — this test
         // requires an authenticated session with a page that renders the form.
@@ -326,7 +326,7 @@ test.describe('Car edit form — text-only save (regression #796)', () => {
             await route.fallback();
         });
 
-        await page.goto('app/cars/edit.php?car_id=1', { waitUntil: 'domcontentloaded' });
+        await page.goto('app/owner/cars/edit.php?car_id=1', { waitUntil: 'domcontentloaded' });
 
         const currentUrl = page.url();
         if (currentUrl.includes('login')) {
@@ -540,7 +540,7 @@ test.describe('Car edit form — text-only save (regression #796)', () => {
         // 2. Navigate to the car edit form (car 650 from the bug report).
         //    The PHP page renders server-side; we only mock the JS API calls.
         // ------------------------------------------------------------------
-        await page.goto('app/cars/edit.php?car_id=650', { waitUntil: 'domcontentloaded' });
+        await page.goto('app/owner/cars/edit.php?car_id=650', { waitUntil: 'domcontentloaded' });
 
         const currentUrl = page.url();
         if (currentUrl.includes('login') || currentUrl.includes('Please Log In')) {
@@ -751,7 +751,7 @@ test.describe('Car edit form — text-only save (regression #796)', () => {
             await route.fallback();
         });
 
-        await page.goto('app/cars/edit.php?car_id=1', { waitUntil: 'domcontentloaded' });
+        await page.goto('app/owner/cars/edit.php?car_id=1', { waitUntil: 'domcontentloaded' });
 
         const currentUrl = page.url();
         if (currentUrl.includes('login')) {
@@ -912,7 +912,7 @@ test.describe('encode-at-output regression — special chars in car text fields 
         });
 
         // 2. Navigate to edit form for car_id=1
-        await page.goto('app/cars/edit.php?car_id=1', { waitUntil: 'domcontentloaded' });
+        await page.goto('app/owner/cars/edit.php?car_id=1', { waitUntil: 'domcontentloaded' });
 
         const currentUrl = page.url();
         if (currentUrl.includes('login') || currentUrl.includes('Please Log In') || currentUrl.includes('Permission Denied')) {
@@ -958,7 +958,7 @@ test.describe('encode-at-output regression — special chars in car text fields 
 
     test('details page renders special chars as readable text', async ({ page }) => {
         // Navigate to the details page for a car with known special chars
-        await page.goto(`app/cars/details.php?car_id=${CAR_ID_WITH_SPECIAL_CHARS}`, {
+        await page.goto(`app/owner/cars/details.php?car_id=${CAR_ID_WITH_SPECIAL_CHARS}`, {
             waitUntil: 'domcontentloaded',
         });
 
@@ -983,7 +983,7 @@ test.describe('encode-at-output regression — special chars in car text fields 
 
     test('edit form textarea pre-fills with plain readable text', async ({ page }) => {
         // Navigate to the edit form for a car with known special chars
-        await page.goto(`app/cars/edit.php?car_id=${CAR_ID_WITH_SPECIAL_CHARS}`, {
+        await page.goto(`app/owner/cars/edit.php?car_id=${CAR_ID_WITH_SPECIAL_CHARS}`, {
             waitUntil: 'domcontentloaded',
         });
 

--- a/tests/playwright/chassis-availability-error.spec.js
+++ b/tests/playwright/chassis-availability-error.spec.js
@@ -35,7 +35,7 @@ const AVAILABLE_RESPONSE = JSON.stringify({ success: true, taken: false, availab
  * Navigate to the add-car form and return false if the session isn't active.
  */
 async function gotoAddCarForm(page) {
-    await page.goto('app/cars/edit.php', { waitUntil: 'domcontentloaded' });
+    await page.goto('app/owner/cars/edit.php', { waitUntil: 'domcontentloaded' });
     const url = page.url();
     if (url.includes('login') || url.includes('Please Log In')) {
         return false;

--- a/tests/playwright/csp-validation.spec.js
+++ b/tests/playwright/csp-validation.spec.js
@@ -54,7 +54,7 @@ test.describe('CSP Validation Tests', () => {
     const cspViolations = setupCSPViolationMonitoring(page);
     
     // Navigate to statistics page
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     
     // Wait for page to fully load including external resources
     await page.waitForLoadState('networkidle');
@@ -74,7 +74,7 @@ test.describe('CSP Validation Tests', () => {
     const cspViolations = setupCSPViolationMonitoring(page);
     
     // First get a car ID to test with
-    await page.goto('app/cars/index.php');
+    await page.goto('app/owner/cars/index.php');
     await page.waitForLoadState('networkidle');
     
     // Click on first car link if available
@@ -94,7 +94,7 @@ test.describe('CSP Validation Tests', () => {
   test('Car listing page should not have CSP violations', async ({ page }) => {
     const cspViolations = setupCSPViolationMonitoring(page);
     
-    await page.goto('app/cars/index.php');
+    await page.goto('app/owner/cars/index.php');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(2000);
     
@@ -136,7 +136,7 @@ test.describe('CSP Validation Tests', () => {
       }
     });
     
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(3000);
     
@@ -177,7 +177,7 @@ test.describe('CSP Validation Tests', () => {
     });
 
     // Check statistics page
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForTimeout(2000);
 
     expect(googleMapsRequests, 'No Google Maps requests on statistics page').toHaveLength(0);
@@ -186,7 +186,7 @@ test.describe('CSP Validation Tests', () => {
 
     // Check a car details page (use a stable car ID or skip if none)
     try {
-      await page.goto('app/cars/details.php?car_id=1');
+      await page.goto('app/owner/cars/details.php?car_id=1');
       await page.waitForTimeout(2000);
       expect(googleMapsRequests, 'No Google Maps requests on car details page').toHaveLength(0);
     } catch {

--- a/tests/playwright/e2e/factory-registry-link.spec.js
+++ b/tests/playwright/e2e/factory-registry-link.spec.js
@@ -10,7 +10,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
 
   test('should load factory page without errors', async ({ page }) => {
     // Navigate to Factory page
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
     await page.waitForLoadState('domcontentloaded');
 
     console.log('✓ Factory page loaded');
@@ -44,7 +44,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
   });
 
   test('should display Registry Link column in table header', async ({ page }) => {
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
     await page.waitForLoadState('domcontentloaded');
 
     // Look for Registry Link column header
@@ -54,7 +54,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
   });
 
   test('should show spinner while Registry Link is loading', async ({ page }) => {
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     // Wait for DataTable to initialize
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
@@ -81,7 +81,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
   test('should display matched chassis with "View Car" button', async ({ page, context }) => {
     // Note: This test assumes test data exists. In production, skip if not available.
 
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     // Wait for table to load
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
@@ -109,7 +109,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
   });
 
   test('should display unmatched chassis with informational message', async ({ page }) => {
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     // Wait for table to load
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
@@ -136,7 +136,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
   });
 
   test('should handle null/missing chassis gracefully', async ({ page }) => {
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
     console.log('✓ DataTable loaded');
@@ -173,7 +173,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
       }
     });
 
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     // Wait for table and AJAX calls
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
@@ -222,7 +222,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
       }
     });
 
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     // Wait for factory table and AJAX calls to complete
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
@@ -242,7 +242,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
   });
 
   test('should maintain Registry Link functionality across pagination', async ({ page }) => {
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     // Wait for initial table
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
@@ -283,7 +283,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
   test('should load Registry Links within reasonable time', async ({ page }) => {
     const startTime = Date.now();
 
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     // Wait for table
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
@@ -308,7 +308,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
   });
 
   test('"View Car" button should navigate to car details page', async ({ page, context }) => {
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     // Wait for table and AJAX
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
@@ -347,7 +347,7 @@ test.describe('Factory Page - Registry Link Feature', () => {
       }
     });
 
-    await page.goto('/app/cars/factory.php');
+    await page.goto('/app/owner/cars/factory.php');
 
     await page.waitForSelector('.dataTables_wrapper', { timeout: 10000 });
     await page.waitForLoadState('networkidle');

--- a/tests/playwright/e2e/logged-in.spec.js
+++ b/tests/playwright/e2e/logged-in.spec.js
@@ -135,10 +135,10 @@ test.describe('Elan Registry - All Pages (Logged In)', () => {
 
   const pages = [
     { path: '/', name: 'Home' },
-    { path: '/app/cars/index.php', name: 'List Cars' },
-    { path: '/app/reports/statistics.php', name: 'Statistics' },
+    { path: '/app/owner/cars/index.php', name: 'List Cars' },
+    { path: '/app/owner/reports/statistics.php', name: 'Statistics' },
     { path: '/docs/reference/identification-guide.php', name: 'Identification Guide' },
-    { path: '/app/cars/factory.php', name: 'Factory Data' },
+    { path: '/app/owner/cars/factory.php', name: 'Factory Data' },
     { path: '/docs/reference/index.php', name: 'Reference Library' },
     { path: '/docs/car-stories.php', name: 'Car Stories' },
     { path: '/docs/guides/index.php', name: 'Guides' },
@@ -174,10 +174,10 @@ test.describe('Internal Links Discovery and Testing (Logged In)', () => {
 
   const pages = [
     { path: '/', name: 'Home' },
-    { path: '/app/cars/index.php', name: 'List Cars' },
-    { path: '/app/reports/statistics.php', name: 'Statistics' },
+    { path: '/app/owner/cars/index.php', name: 'List Cars' },
+    { path: '/app/owner/reports/statistics.php', name: 'Statistics' },
     { path: '/docs/reference/identification-guide.php', name: 'Identification Guide' },
-    { path: '/app/cars/factory.php', name: 'Factory Data' },
+    { path: '/app/owner/cars/factory.php', name: 'Factory Data' },
     { path: '/docs/reference/index.php', name: 'Reference Library' },
     { path: '/docs/car-stories.php', name: 'Car Stories' },
     { path: '/docs/guides/index.php', name: 'Guides' },

--- a/tests/playwright/e2e/not-logged-in.spec.js
+++ b/tests/playwright/e2e/not-logged-in.spec.js
@@ -15,7 +15,7 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
       expectedText: 'Lotus Elan Registry',
     },
     {
-      path: '/app/cars/index.php',
+      path: '/app/owner/cars/index.php',
       name: 'List Cars',
       selector: 'h2',
       expectedText: 'List Cars',
@@ -27,7 +27,7 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
       expectedText: 'Join the Lotus Elan Registry',
     },
     {
-      path: '/app/reports/statistics.php',
+      path: '/app/owner/reports/statistics.php',
       name: 'Statistics',
       selector: 'h1',
       expectedText: 'Registry Analytics & Statistics',
@@ -39,7 +39,7 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
       expectedText: 'Lotus Elan Identification Guide',
     },
     {
-      path: '/app/cars/factory.php',
+      path: '/app/owner/cars/factory.php',
       name: 'Factory Data',
       selector: 'h2',
       expectedText: 'Elan Factory Information',
@@ -113,11 +113,11 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
 test.describe('Internal Links Discovery and Testing (Not Logged In)', () => {
   const pages = [
     { path: '/', name: 'Home' },
-    { path: '/app/cars/index.php', name: 'List Cars' },
+    { path: '/app/owner/cars/index.php', name: 'List Cars' },
     { path: '/users/join.php', name: 'Register' },
-    { path: '/app/reports/statistics.php', name: 'Statistics' },
+    { path: '/app/owner/reports/statistics.php', name: 'Statistics' },
     { path: '/docs/reference/identification-guide.php', name: 'Identification Guide' },
-    { path: '/app/cars/factory.php', name: 'Factory Data' },
+    { path: '/app/owner/cars/factory.php', name: 'Factory Data' },
     { path: '/docs/reference-library.php', name: 'Reference Library' },
     { path: '/docs/car-stories.php', name: 'Car Stories' },
     { path: '/docs/faq/index.php', name: 'FAQ' },
@@ -254,8 +254,8 @@ test.describe('Internal Links Discovery and Testing (Not Logged In)', () => {
       if (isDownloadable) {
         downloadableLinks.push(link);
       } else {
-        // Exclude /app/cars/details.php links except for car_id=1 (to avoid testing many individual car pages)
-        if (link.includes('/app/cars/details.php') && !link.includes('car_id=1')) {
+        // Exclude /app/owner/cars/details.php links except for car_id=1 (to avoid testing many individual car pages)
+        if (link.includes('/app/owner/cars/details.php') && !link.includes('car_id=1')) {
           // Skip this link - it's a car details page other than car_id=1
           return;
         }

--- a/tests/playwright/filepond-load-error.spec.js
+++ b/tests/playwright/filepond-load-error.spec.js
@@ -49,7 +49,7 @@ const FETCH_IMAGES_RESPONSE = JSON.stringify({
  * Call before page.goto(); each test sets its own fetchImages API mock.
  */
 async function injectFakeCarId(page) {
-    await page.route('**/app/cars/edit.php', async (route) => {
+    await page.route('**/app/owner/cars/edit.php', async (route) => {
         const response = await route.fetch();
         const rawBody = await response.text();
         // Inject a fake car_id into the hidden input so the fetchImages
@@ -95,7 +95,7 @@ async function gotoEditFormWithFakeImages(page) {
         }
     });
 
-    await page.goto('app/cars/edit.php', { waitUntil: 'domcontentloaded' });
+    await page.goto('app/owner/cars/edit.php', { waitUntil: 'domcontentloaded' });
 
     const url = page.url();
     const bodyText = await page.textContent('body').catch(() => '');
@@ -185,7 +185,7 @@ test.describe('fetchImages API failure handling (#1031)', () => {
             }
         });
 
-        await page.goto('app/cars/edit.php', { waitUntil: 'domcontentloaded' });
+        await page.goto('app/owner/cars/edit.php', { waitUntil: 'domcontentloaded' });
 
         const url = page.url();
         const bodyText = await page.textContent('body').catch(() => '');
@@ -215,7 +215,7 @@ test.describe('fetchImages API failure handling (#1031)', () => {
             }
         });
 
-        await page.goto('app/cars/edit.php', { waitUntil: 'domcontentloaded' });
+        await page.goto('app/owner/cars/edit.php', { waitUntil: 'domcontentloaded' });
 
         const url = page.url();
         const bodyText = await page.textContent('body').catch(() => '');

--- a/tests/playwright/functionality.spec.js
+++ b/tests/playwright/functionality.spec.js
@@ -4,7 +4,7 @@ const { ensureLoggedIn, navigateAndWait, waitForDataTables, handleAuthRequired }
 
 test.describe('Core Functionality After Refactoring', () => {
   test('DataTables loads and works on car listing', async ({ page }) => {
-    await page.goto('app/cars/index.php', { waitUntil: 'networkidle' });
+    await page.goto('app/owner/cars/index.php', { waitUntil: 'networkidle' });
 
     const searchBox = await waitForDataTables(page, 15000);
 
@@ -17,7 +17,7 @@ test.describe('Core Functionality After Refactoring', () => {
 
   test('car edit form workflow functions', async ({ page }) => {
     // Navigate to car edit page — accordion only appears when authenticated with a valid car_id
-    await navigateAndWait(page, 'app/cars/edit.php');
+    await navigateAndWait(page, 'app/owner/cars/edit.php');
     await expect(page).not.toHaveTitle(/404|Not Found|Server Error/i);
 
     // Skip deep assertions if the accordion isn't present (requires auth + car_id locally)
@@ -38,7 +38,7 @@ test.describe('Core Functionality After Refactoring', () => {
   });
 
   test('chassis validation works', async ({ page }) => {
-    await navigateAndWait(page, 'app/cars/edit.php');
+    await navigateAndWait(page, 'app/owner/cars/edit.php');
     await expect(page).not.toHaveTitle(/404|Not Found|Server Error/i);
 
     // Skip deep assertions if the form fields aren't present (requires auth + car_id locally)
@@ -62,7 +62,7 @@ test.describe('Core Functionality After Refactoring', () => {
   });
 
   test('contact form submission works', async ({ page }) => {
-    await navigateAndWait(page, 'app/contact/index.php');
+    await navigateAndWait(page, 'app/owner/contact/index.php');
 
     await handleAuthRequired(
       page,
@@ -82,7 +82,7 @@ test.describe('Core Functionality After Refactoring', () => {
   });
 
   test('NEW_CAR_IDS is emitted on car list page and badge renders when applicable', async ({ page }) => {
-    await page.goto('app/cars/index.php', { waitUntil: 'networkidle' });
+    await page.goto('app/owner/cars/index.php', { waitUntil: 'networkidle' });
 
     // NEW_CAR_IDS must be defined as a JS array of integers
     const newCarIds = await page.evaluate(() => {
@@ -109,7 +109,7 @@ test.describe('Core Functionality After Refactoring', () => {
   });
 
   test('NEW badge does not appear on factory listing page', async ({ page }) => {
-    await page.goto('app/cars/factory.php', { waitUntil: 'networkidle' });
+    await page.goto('app/owner/cars/factory.php', { waitUntil: 'networkidle' });
 
     // Factory page must NOT define NEW_CAR_IDS
     const defined = await page.evaluate(() => typeof NEW_CAR_IDS !== 'undefined');
@@ -117,7 +117,7 @@ test.describe('Core Functionality After Refactoring', () => {
   });
 
   test('factory listing page functions', async ({ page }) => {
-    await page.goto('app/cars/factory.php', { waitUntil: 'networkidle' });
+    await page.goto('app/owner/cars/factory.php', { waitUntil: 'networkidle' });
 
     await expect(page.locator('h2')).toContainText(/Factory/);
     await waitForDataTables(page, 15000);
@@ -151,7 +151,7 @@ test.describe('Add Car form — no premature validation on page load', () => {
       test.skip(true, 'Set TEST_USERNAME and TEST_PASSWORD in .env.local to run authenticated tests');
     }
     await ensureLoggedIn(page);
-    await page.goto('app/cars/edit.php', { waitUntil: 'networkidle' });
+    await page.goto('app/owner/cars/edit.php', { waitUntil: 'networkidle' });
   });
 
   test('Year, Model, and Chassis icons are neutral (no thumbs-down) on load', async ({ page }) => {

--- a/tests/playwright/length-validation.spec.js
+++ b/tests/playwright/length-validation.spec.js
@@ -3,7 +3,7 @@
 // Regression tests for issue #1107: length-validation boundary coverage for
 // chassis-availability.php and transfer-request.php (hardened in #1081).
 //
-// Strategy: navigate to app/cars/edit.php to get a real CSRF token from the
+// Strategy: navigate to app/owner/cars/edit.php to get a real CSRF token from the
 // session, then POST directly to each endpoint via page.request with boundary
 // values (at-limit and over-limit). The auth session from ensureLoggedIn()
 // is shared with page.request, so the CSRF token extracted from the DOM is
@@ -33,7 +33,7 @@ const { ensureLoggedIn } = require('./auth-helper.js');
  * Returns null if the page redirects to login (unauthenticated).
  */
 async function getCsrfFromEditPage(page) {
-    await page.goto('app/cars/edit.php', { waitUntil: 'domcontentloaded' });
+    await page.goto('app/owner/cars/edit.php', { waitUntil: 'domcontentloaded' });
     const url = page.url();
     if (url.includes('login') || url.includes('Please Log In')) {
         return null;

--- a/tests/playwright/login-functionality.spec.js
+++ b/tests/playwright/login-functionality.spec.js
@@ -160,8 +160,8 @@ test.describe('Login Functionality', () => {
     
     // Navigate to various pages and verify still logged in
     const protectedPages = [
-      'app/cars/index.php',
-      'app/reports/statistics.php',
+      'app/owner/cars/index.php',
+      'app/owner/reports/statistics.php',
       'users/account.php'
     ];
     

--- a/tests/playwright/maps-charts.spec.js
+++ b/tests/playwright/maps-charts.spec.js
@@ -4,7 +4,7 @@ const { test, expect } = require('@playwright/test');
 test.describe('Maps and Charts', () => {
 
   test('statistics page world map renders with MapLibre GL JS', async ({ page }) => {
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
 
     // MapLibre GL JS injects .maplibregl-map onto the container
@@ -17,7 +17,7 @@ test.describe('Maps and Charts', () => {
   });
 
   test('statistics page marker data is inlined as JSON', async ({ page }) => {
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
 
     const markerCount = await page.evaluate(() => {
@@ -27,14 +27,14 @@ test.describe('Maps and Charts', () => {
   });
 
   test('Chart.js timeline chart renders on statistics page', async ({ page }) => {
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
     const chart = page.locator('#timelineChart');
     await expect(chart).toBeVisible({ timeout: 10000 });
   });
 
   test('Chart.js recent activity chart renders on statistics page', async ({ page }) => {
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
     const chart = page.locator('#recentActivityChart');
     await expect(chart).toBeVisible({ timeout: 10000 });
@@ -56,7 +56,7 @@ test.describe('Maps and Charts', () => {
   });
 
   test('car details page map renders with MapLibre GL JS', async ({ page }) => {
-    await page.goto('app/cars/details.php?car_id=1091');
+    await page.goto('app/owner/cars/details.php?car_id=1091');
     await page.waitForLoadState('networkidle');
 
     // Map renders only when the car has GPS coordinates; otherwise the location
@@ -71,7 +71,7 @@ test.describe('Maps and Charts', () => {
   });
 
   test('statistics page chart data loads', async ({ page }) => {
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
 
     const hasData = await page.evaluate(() => {
@@ -83,7 +83,7 @@ test.describe('Maps and Charts', () => {
 
   test('charts are responsive on mobile viewport', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
 
     const chart = page.locator('#timelineChart');
@@ -91,7 +91,7 @@ test.describe('Maps and Charts', () => {
   });
 
   test('statistics page 26R filter classifies Race cars by variant', async ({ page }) => {
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
 
     await expect(async () => {
@@ -186,7 +186,7 @@ test.describe('Maps and Charts', () => {
       } catch (_) { /* ignore non-URL strings */ }
     });
 
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(2000);
 

--- a/tests/playwright/mobile-responsive.spec.js
+++ b/tests/playwright/mobile-responsive.spec.js
@@ -18,14 +18,14 @@ const MOBILE_VIEWPORT = { width: 375, height: 667 };
 
 const PUBLIC_PAGES = [
   '',
-  'app/cars/index.php',
-  'app/cars/details.php?car_id=1091',
-  'app/cars/factory.php',
+  'app/owner/cars/index.php',
+  'app/owner/cars/details.php?car_id=1091',
+  'app/owner/cars/factory.php',
   'app/cars/identify.php',
-  'app/contact/index.php',
-  'app/contact/owner.php',
-  'app/reports/statistics.php',
-  'app/privacy.php',
+  'app/owner/contact/index.php',
+  'app/owner/contact/owner.php',
+  'app/owner/reports/statistics.php',
+  'app/owner/privacy.php',
   'docs/guides/car-transfer-faq.php',
 ];
 
@@ -51,7 +51,7 @@ test.describe('Mobile Responsive (iPhone SE / 375px)', () => {
   }
 
   test('DataTables responsive collapse indicator present on car listing', async ({ page }) => {
-    await page.goto('app/cars/index.php', { waitUntil: 'networkidle' });
+    await page.goto('app/owner/cars/index.php', { waitUntil: 'networkidle' });
 
     // DataTables 1.x uses .dataTables_wrapper; 2.x uses .dt-container
     await page.waitForSelector('table.dataTable, div.dt-container, div.dataTables_wrapper', { timeout: 15000 });
@@ -61,7 +61,7 @@ test.describe('Mobile Responsive (iPhone SE / 375px)', () => {
   });
 
   test('edit car form progress bar does not cause horizontal overflow', async ({ page }) => {
-    await navigateAndWait(page, 'app/cars/edit.php');
+    await navigateAndWait(page, 'app/owner/cars/edit.php');
     await page.waitForLoadState('networkidle');
 
     // Check overflow regardless of auth state — both paths render a full page at 375px.

--- a/tests/playwright/navigation.spec.js
+++ b/tests/playwright/navigation.spec.js
@@ -10,7 +10,7 @@ test.describe('Navigation and File Reorganization', () => {
   });
 
   test('car listing page loads (reorganized)', async ({ page }) => {
-    await navigateAndWait(page, 'app/cars/index.php');
+    await navigateAndWait(page, 'app/owner/cars/index.php');
 
     // Wait for network to be idle (all resources loaded)
     await page.waitForLoadState('networkidle');
@@ -19,13 +19,13 @@ test.describe('Navigation and File Reorganization', () => {
     await expect(page.locator('h2')).toContainText(/Registry Cars/, { timeout: 10000 });
 
     // Test backward compatibility redirect
-    await testRedirect(page, 'app/list_cars.php', 'app/cars/index.php');
+    await testRedirect(page, 'app/list_cars.php', 'app/owner/cars/index.php');
   });
 
   test('car details page loads (reorganized)', async ({ page }) => {
     // Navigate to car details page
-    await navigateAndWait(page, 'app/cars/details.php?car_id=1');
-    
+    await navigateAndWait(page, 'app/owner/cars/details.php?car_id=1');
+
     // Handle authentication requirement or verify content
     await handleAuthRequired(
       page,
@@ -34,32 +34,32 @@ test.describe('Navigation and File Reorganization', () => {
         await expect(page.locator('h1, h2, .card-header').first()).toContainText(/Car|Details|Information/);
       }
     );
-    
+
     // Test backward compatibility redirect
-    await testRedirect(page, 'app/car_details.php?car_id=1', 'app/cars/details.php');
+    await testRedirect(page, 'app/car_details.php?car_id=1', 'app/owner/cars/details.php');
   });
 
   test('car form page loads (reorganized)', async ({ page }) => {
     // Navigate to car form page — verify it loads at the new URL (not 404/500)
-    await navigateAndWait(page, 'app/cars/edit.php');
+    await navigateAndWait(page, 'app/owner/cars/edit.php');
     await expect(page).not.toHaveTitle(/404|Not Found|Server Error/i);
   });
 
   test('statistics page loads (reorganized)', async ({ page }) => {
     // Navigate to statistics page
-    await navigateAndWait(page, 'app/reports/statistics.php');
-    
+    await navigateAndWait(page, 'app/owner/reports/statistics.php');
+
     // Look for statistics page heading (page loads successfully)
     await expect(page.getByRole('heading', { name: /Registry Analytics|Statistics/i })).toBeVisible();
-    
+
     // Test backward compatibility redirect
-    await testRedirect(page, 'app/statistics.php', 'app/reports/statistics.php');
+    await testRedirect(page, 'app/statistics.php', 'app/owner/reports/statistics.php');
   });
 
   test('contact page loads (reorganized)', async ({ page }) => {
     // Navigate to contact page
-    await navigateAndWait(page, 'app/contact/index.php');
-    
+    await navigateAndWait(page, 'app/owner/contact/index.php');
+
     // Handle authentication requirement or verify contact form
     await handleAuthRequired(
       page,
@@ -68,9 +68,9 @@ test.describe('Navigation and File Reorganization', () => {
         await expect(page.locator('h2')).toContainText(/Contact/);
       }
     );
-    
+
     // Test backward compatibility redirect
-    await testRedirect(page, 'app/contact.php', 'app/contact/index.php');
+    await testRedirect(page, 'app/contact.php', 'app/owner/contact/index.php');
   });
 
   test('identification guide loads (reorganized)', async ({ page }) => {
@@ -81,6 +81,24 @@ test.describe('Navigation and File Reorganization', () => {
     // Test backward compatibility redirect chains
     await testRedirect(page, 'app/cars/identify.php', 'docs/reference/identification-guide.php');
     await testRedirect(page, 'app/identification.php', 'docs/reference/identification-guide.php');
+  });
+
+  // Issue #1040 — app/owner/ Phase 2 Migration
+  test('app/cars/ paths redirect to app/owner/cars/ equivalents', async ({ page }) => {
+    await testRedirect(page, 'app/cars/index.php', 'app/owner/cars/index.php');
+    await testRedirect(page, 'app/cars/details.php', 'app/owner/cars/details.php');
+    await testRedirect(page, 'app/cars/edit.php', 'app/owner/cars/edit.php');
+    await testRedirect(page, 'app/cars/factory.php', 'app/owner/cars/factory.php');
+  });
+
+  test('app/contact/ paths redirect to app/owner/contact/ equivalents', async ({ page }) => {
+    await testRedirect(page, 'app/contact/index.php', 'app/owner/contact/index.php');
+    await testRedirect(page, 'app/contact/owner.php', 'app/owner/contact/owner.php');
+  });
+
+  test('app/reports/statistics.php and app/privacy.php redirect to app/owner/ equivalents', async ({ page }) => {
+    await testRedirect(page, 'app/reports/statistics.php', 'app/owner/reports/statistics.php');
+    await testRedirect(page, 'app/privacy.php', 'app/owner/privacy.php');
   });
 
   // Issue #559 — Documentation Reorganization

--- a/tests/playwright/security/car-image-ownership.spec.js
+++ b/tests/playwright/security/car-image-ownership.spec.js
@@ -25,7 +25,7 @@ const { ensureLoggedIn } = require('../auth-helper.js');
  */
 
 const ACTIONS_ENDPOINT = 'app/api/cars/save.php';
-const FORM_PAGE = 'app/cars/edit.php';
+const FORM_PAGE = 'app/owner/cars/edit.php';
 const NONEXISTENT_CAR_ID = 999999;
 
 async function getCsrfFromForm(page) {

--- a/tests/playwright/security/car-update-ownership.spec.js
+++ b/tests/playwright/security/car-update-ownership.spec.js
@@ -14,7 +14,7 @@ const { ensureLoggedIn } = require('../auth-helper.js');
  */
 
 const ACTIONS_ENDPOINT = 'app/api/cars/save.php';
-const FORM_PAGE = 'app/cars/edit.php';
+const FORM_PAGE = 'app/owner/cars/edit.php';
 const NONEXISTENT_CAR_ID = 999999;
 
 async function getCsrfFromForm(page) {

--- a/tests/playwright/security/clickjacking.spec.js
+++ b/tests/playwright/security/clickjacking.spec.js
@@ -68,7 +68,7 @@ test.describe('Anti-clickjacking Security Headers', () => {
   });
 
   test('car listing page should have X-Frame-Options header', async ({ page }) => {
-    const response = await page.goto('app/cars/');
+    const response = await page.goto('app/owner/cars/index.php');
 
     if (response?.status() === 200) {
       const headers = response?.headers();

--- a/tests/playwright/security/contact-owner-idor.spec.js
+++ b/tests/playwright/security/contact-owner-idor.spec.js
@@ -16,7 +16,7 @@ const { ensureLoggedIn } = require('../auth-helper.js');
 const ENDPOINT = 'app/api/contact/send-owner-email.php';
 // Any authenticated page works — Token::check() validates against the session
 // token, not an endpoint-scoped one, so the feedback form's CSRF is valid here.
-const CSRF_FORM_PAGE = 'app/contact/index.php';
+const CSRF_FORM_PAGE = 'app/owner/contact/index.php';
 const NONEXISTENT_CAR_ID = 999999;
 const WRONG_USER_ID = 999999;
 

--- a/tests/playwright/ui-consistency.spec.js
+++ b/tests/playwright/ui-consistency.spec.js
@@ -5,10 +5,10 @@ const { navigateAndWait, validateCardStructure } = require('./auth-helper.js');
 test.describe('UI Consistency After Style Refactoring', () => {
   test('consistent card layouts across pages', async ({ page }) => {
     const pages = [
-      'app/cars/index.php',
-      'app/cars/details.php?car_id=1',
-      'app/reports/statistics.php',
-      'app/contact/index.php'
+      'app/owner/cars/index.php',
+      'app/owner/cars/details.php?car_id=1',
+      'app/owner/reports/statistics.php',
+      'app/owner/contact/index.php'
     ];
     
     for (const pagePath of pages) {
@@ -30,9 +30,9 @@ test.describe('UI Consistency After Style Refactoring', () => {
 
   test('consistent header structure', async ({ page }) => {
     const pages = [
-      'app/cars/index.php',
-      'app/cars/edit.php',
-      'app/reports/statistics.php'
+      'app/owner/cars/index.php',
+      'app/owner/cars/edit.php',
+      'app/owner/reports/statistics.php'
     ];
     
     for (const pagePath of pages) {
@@ -60,7 +60,7 @@ test.describe('UI Consistency After Style Refactoring', () => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
     
-    await navigateAndWait(page, 'app/cars/index.php');
+    await navigateAndWait(page, 'app/owner/cars/index.php');
     
     // Check that content is still accessible
     const mainContent = page.locator('.page-wrapper, .container, .card');
@@ -74,7 +74,7 @@ test.describe('UI Consistency After Style Refactoring', () => {
   });
 
   test('consistent button styling', async ({ page }) => {
-    await page.goto('app/cars/edit.php');
+    await page.goto('app/owner/cars/edit.php');
 
     // Check for Bootstrap button classes
     const buttons = page.locator('button, input[type="button"], input[type="submit"], .btn');
@@ -90,7 +90,7 @@ test.describe('UI Consistency After Style Refactoring', () => {
   });
 
   test('color scheme consistency', async ({ page }) => {
-    await page.goto('app/cars/index.php');
+    await page.goto('app/owner/cars/index.php');
 
     // Check for consistent color usage
     const cards = page.locator('.card-header');
@@ -110,7 +110,7 @@ test.describe('UI Consistency After Style Refactoring', () => {
       }
     });
     
-    await page.goto('app/reports/statistics.php');
+    await page.goto('app/owner/reports/statistics.php');
     await page.waitForTimeout(3000); // Wait for all scripts to load
     
     // Filter out known acceptable errors for unauthenticated local visits
@@ -150,8 +150,8 @@ test.describe('UI Consistency After Style Refactoring', () => {
 
   test('forms maintain consistent styling', async ({ page }) => {
     const formPages = [
-      'app/cars/edit.php',
-      'app/contact/index.php'
+      'app/owner/cars/edit.php',
+      'app/owner/contact/index.php'
     ];
     
     for (const pagePath of formPages) {

--- a/tests/regression/Issue317RegressionTest.php
+++ b/tests/regression/Issue317RegressionTest.php
@@ -51,9 +51,17 @@ final class Issue317RegressionTest extends TestCase
     {
         $testDir = dirname(__DIR__);
 
-        // Check that unit tests directory has test files
-        $unitTests = glob($testDir . '/unit/*.php');
-        $this->assertGreaterThan(0, count($unitTests), 'Unit tests directory should contain test files');
+        // Check that unit tests directory has test files (recursive — tests live in subdirectories)
+        $unitFiles = [];
+        $iter = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($testDir . '/unit', RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+        foreach ($iter as $file) {
+            if ($file->getExtension() === 'php') {
+                $unitFiles[] = $file->getPathname();
+            }
+        }
+        $this->assertGreaterThan(0, count($unitFiles), 'Unit tests directory should contain test files');
 
         // Check that integration tests directory has test files
         $integrationTests = glob($testDir . '/integration/*.php');

--- a/tests/unit/admin/PagePermissionClassifierTest.php
+++ b/tests/unit/admin/PagePermissionClassifierTest.php
@@ -33,7 +33,7 @@ final class PagePermissionClassifierTest extends TestCase
             'user_settings is not special'     => ['usersc/user_settings.php', false],
             'other usersc page'                => ['usersc/profile.php',       false],
             'admin page'                       => ['app/admin/manage.php',     false],
-            'public car listing'               => ['app/cars/index.php',       false],
+            'public car listing'               => ['app/owner/cars/index.php',       false],
         ];
     }
 
@@ -59,10 +59,10 @@ final class PagePermissionClassifierTest extends TestCase
             'admin design-system page'          => ['app/admin/design-system.php',                               true],
             'docs admin'                        => ['docs/admin/guide.php',                                     true],
             'user settings (owner page)'        => ['usersc/user_settings.php',                                 false],
-            'car listing (public)'              => ['app/cars/index.php',                                       false],
+            'car listing (public)'              => ['app/owner/cars/index.php',                                       false],
             'car actions (owner)'               => ['app/api/cars/save.php',                                   false],
             'api send-feedback (not admin)'     => ['app/api/contact/send-feedback.php',                       false],
-            'contact form (owner)'              => ['app/contact/form.php',                                     false],
+            'contact form (owner)'              => ['app/owner/contact/index.php',                              false],
             'error page'                        => ['404.php',                                                  false],
         ];
     }
@@ -95,7 +95,7 @@ final class PagePermissionClassifierTest extends TestCase
             'admin index (dashboard)'           => ['app/admin/index.php',                                      false],
             'tab-cars'                          => ['app/admin/includes/tab-cars.php',                          false],
             'docs admin'                        => ['docs/admin/guide.php',                                     false],
-            'non-admin page'                    => ['app/cars/index.php',                                       false],
+            'non-admin page'                    => ['app/owner/cars/index.php',                                       false],
         ];
     }
 
@@ -123,16 +123,18 @@ final class PagePermissionClassifierTest extends TestCase
             'car action'                        => ['app/api/cars/save.php',              true],
             'api send-feedback (owner)'         => ['app/api/contact/send-feedback.php',    true],
             'api send-owner-email (owner)'      => ['app/api/contact/send-owner-email.php', true],
-            'contact page'                      => ['app/contact/form.php',               true],
-            'edit page'                         => ['app/cars/edit-car.php',              true],
+            'contact page'                      => ['app/owner/contact/index.php',        true],
+            'contact owner page'                => ['app/owner/contact/owner.php',        true],
+            'privacy page (public)'             => ['app/owner/privacy.php',              false],
+            'edit page'                         => ['app/owner/cars/edit.php',             true],
             'usersc page'                       => ['usersc/user_settings.php',           true],
             // login/join are PUBLIC (PUBLIC_USERSC_PAGES), mirroring users/login.php and users/join.php
             'login page'                        => ['usersc/login.php',                   false],
             'join page'                         => ['usersc/join.php',                    false],
             // Public pages
-            'car listing'                       => ['app/cars/index.php',                 false],
-            'car details'                       => ['app/cars/details.php',               false],
-            'statistics'                        => ['app/reports/statistics.php',         false],
+            'car listing'                       => ['app/owner/cars/index.php',                 false],
+            'car details'                       => ['app/owner/cars/details.php',               false],
+            'statistics'                        => ['app/owner/reports/statistics.php',         false],
             'docs guide'                        => ['docs/guides/how-to.php',             false],
             'error 404'                         => ['404.php',                            false],
             'error 403'                         => ['403.php',                            false],

--- a/tests/unit/admin/ProcessAdminSettingsTest.php
+++ b/tests/unit/admin/ProcessAdminSettingsTest.php
@@ -121,6 +121,9 @@ final class ProcessAdminSettingsTest extends TestCase
             $matches,
             'FIELD_TYPES constant must be present in process-settings.php'
         );
+        if (empty($matches)) {
+            return; // Assertion above already recorded a failure; avoid cascading undefined-key errors.
+        }
 
         preg_match_all("/'([^']+)'\s*=>/", $matches[1], $keyMatches);
         $actualKeys = $keyMatches[1];

--- a/tests/unit/security/SerializedDataRemovalTest.php
+++ b/tests/unit/security/SerializedDataRemovalTest.php
@@ -69,7 +69,7 @@ class SerializedDataRemovalTest extends TestCase
      */
     public function testContactOwnerUsesSecureFields(): void
     {
-        $contactOwnerFile = $this->projectRoot . '/app/contact/owner.php';
+        $contactOwnerFile = $this->projectRoot . '/app/owner/contact/owner.php';
         $this->assertFileExists($contactOwnerFile);
 
         $content = file_get_contents($contactOwnerFile);
@@ -119,7 +119,7 @@ class SerializedDataRemovalTest extends TestCase
      */
     public function testUserIdFieldsAreHTMLEncoded(): void
     {
-        $contactOwnerFile = $this->projectRoot . '/app/contact/owner.php';
+        $contactOwnerFile = $this->projectRoot . '/app/owner/contact/owner.php';
         $content = file_get_contents($contactOwnerFile);
 
         $this->assertStringContainsString('htmlspecialchars($to[\'id\'], ENT_QUOTES, \'UTF-8\')', $content,
@@ -131,9 +131,9 @@ class SerializedDataRemovalTest extends TestCase
      */
     public function testCSRFProtectionMaintained(): void
     {
-        $contactOwnerFile = $this->projectRoot . '/app/contact/owner.php';
+        $contactOwnerFile = $this->projectRoot . '/app/owner/contact/owner.php';
         $content = file_get_contents($contactOwnerFile);
-        
+
         // Should maintain CSRF token
         $this->assertStringContainsString('Token::generate()', $content, 'CSRF token should be generated');
         $this->assertStringContainsString('name=\'csrf\'', $content, 'CSRF field should be present');

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -184,7 +184,7 @@ class LogCategoriesUsageTest extends TestCase
      */
     public function testFormPhpJsUsesElanRegistryAPI(): void
     {
-        $filePath = $this->rootDir . '/app/cars/edit.php';
+        $filePath = $this->rootDir . '/app/owner/cars/edit.php';
         if (!file_exists($filePath)) {
             $this->markTestSkipped('form.php not found');
         }

--- a/usersc/account.php
+++ b/usersc/account.php
@@ -171,7 +171,7 @@ $_baseUrl = htmlspecialchars($us_url_root, ENT_QUOTES, 'UTF-8');
                     <i class="fas fa-car me-2" aria-hidden="true"></i>My Cars
                     <span class="badge badge-er-account rounded-pill ms-1" style="font-size:0.7em; vertical-align:middle;"><?= $carCount ?></span>
                 </h2>
-                <a href="<?= $_baseUrl ?>app/cars/edit.php" class="btn btn-primary btn-sm">
+                <a href="<?= $_baseUrl ?>app/owner/cars/edit.php" class="btn btn-primary btn-sm">
                     <i class="fas fa-plus me-1" aria-hidden="true"></i>Add a Car
                 </a>
             </div>
@@ -183,7 +183,7 @@ $_baseUrl = htmlspecialchars($us_url_root, ENT_QUOTES, 'UTF-8');
             <div class="text-center py-5">
                 <i class="fas fa-car fa-3x text-muted mb-3 d-block" aria-hidden="true"></i>
                 <p class="text-muted mb-3">You haven't registered any cars yet. Add your first Lotus Elan to get started!</p>
-                <a class="btn btn-primary btn-lg" href="<?= $_baseUrl ?>app/cars/edit.php">
+                <a class="btn btn-primary btn-lg" href="<?= $_baseUrl ?>app/owner/cars/edit.php">
                     <i class="fas fa-plus me-2" aria-hidden="true"></i>Add Your First Car
                 </a>
             </div>

--- a/usersc/classes/DocumentPortalTemplate.php
+++ b/usersc/classes/DocumentPortalTemplate.php
@@ -38,8 +38,8 @@ class DocumentPortalTemplate
      * @var array<string, array{label: string, icon: string, url: string, parents: list<array{icon: string, text: string, url: string}>}>
      */
     private const BREADCRUMB_SECTIONS = [
-        'list_cars'  => ['label' => 'Cars',         'icon' => 'fa-car',            'url' => 'app/cars/index.php',   'parents' => []],
-        'add_car'    => ['label' => 'Add Car',       'icon' => 'fa-plus',           'url' => '',                     'parents' => [['icon' => 'fa-car', 'text' => 'Cars', 'url' => 'app/cars/index.php']]],
+        'list_cars'  => ['label' => 'Cars',         'icon' => 'fa-car',            'url' => 'app/owner/cars/index.php',   'parents' => []],
+        'add_car'    => ['label' => 'Add Car',       'icon' => 'fa-plus',           'url' => '',                     'parents' => [['icon' => 'fa-car', 'text' => 'Cars', 'url' => 'app/owner/cars/index.php']]],
         'statistics' => ['label' => 'Statistics',    'icon' => 'fa-pie-chart',      'url' => '',                     'parents' => []],
         'reference'  => ['label' => 'Reference',     'icon' => 'fa-book',           'url' => 'docs/reference/',      'parents' => []],
         'stories'    => ['label' => 'Car Stories',   'icon' => 'fa-book-open',      'url' => 'docs/car-stories.php', 'parents' => []],

--- a/usersc/classes/Transfer/TransferEmailService.php
+++ b/usersc/classes/Transfer/TransferEmailService.php
@@ -246,7 +246,7 @@ class TransferEmailService
                 'completed_date' => $transferData->completed_date ?: date('Y-m-d H:i:s'),
             ];
 
-            $carUrl = getBaseUrl() . '/app/cars/details.php?car_id=' . $carData->id;
+            $carUrl = getBaseUrl() . '/app/owner/cars/details.php?car_id=' . $carData->id;
 
             ob_start();
             include $this->basePath . 'app/views/email/_transfer_response.php';

--- a/usersc/classes/admin/PagePermissionClassifier.php
+++ b/usersc/classes/admin/PagePermissionClassifier.php
@@ -163,7 +163,7 @@ class PagePermissionClassifier
                                              //   without securePage() (e.g. app/api/cars/*) and purely public endpoints
                                              //   (e.g. app/api/shared/statistics.php) must NOT call securePage() —
                                              //   they are never registered and never reach here.
-            '#^app/contact/#',                   // app/contact/* pages
+            '#^app/owner/contact/#',             // app/owner/contact/* pages
             '#edit#',                            // Any path containing "edit"
             '#^usersc/#'                         // usersc/* pages
         ];

--- a/usersc/includes/footer.php
+++ b/usersc/includes/footer.php
@@ -31,14 +31,14 @@ $er_footer_version_tag = ApplicationVersion::tagOnly();
         var p = document.createElement('p');
         p.className = 'text-center small';
         var aPrivacy = document.createElement('a');
-        aPrivacy.href = '<?=$us_url_root?>app/privacy.php';
+        aPrivacy.href = '<?=$us_url_root?>app/owner/privacy.php';
         aPrivacy.className = 'text-muted';
         aPrivacy.textContent = 'Privacy Policy';
         p.appendChild(aPrivacy);
         <?php if (isset($user) && $user->isLoggedIn()) { ?>
         p.appendChild(document.createTextNode(' | '));
         var aContact = document.createElement('a');
-        aContact.href = '<?=$us_url_root?>app/contact/index.php';
+        aContact.href = '<?=$us_url_root?>app/owner/contact/index.php';
         aContact.className = 'text-muted';
         aContact.textContent = 'Contact Us';
         p.appendChild(aContact);

--- a/usersc/includes/server_globals.php
+++ b/usersc/includes/server_globals.php
@@ -61,14 +61,14 @@ $current_origin = $is_https ? "https://{$host}" : "http://{$host}";
 // Request Details
 // REQUEST_METHOD is normalized to uppercase (GET, POST, PUT, DELETE, etc.)
 // REQUEST_URI includes path and query string (/path?query=value)
-// PHP_SELF is the script path (/index.php or /app/cars/details.php)
+// PHP_SELF is the script path (/index.php or /app/owner/cars/details.php)
 $method = Server::get('REQUEST_METHOD', 'GET');
 $request_uri = Server::get('REQUEST_URI', '/');
 $php_self = Server::get('PHP_SELF', '/');
 
 // Full URL Construction
 // Combines scheme, host, and path for complete URL reference
-// Example: https://elanregistry.org/app/cars/details.php?id=123
+// Example: https://elanregistry.org/app/owner/cars/details.php?id=123
 $current_url = $current_origin . $request_uri;
 
 // Optional/Tracking Variables

--- a/usersc/plugins/ai_prompts/custom_prompts/elanregistry_directories.md.php
+++ b/usersc/plugins/ai_prompts/custom_prompts/elanregistry_directories.md.php
@@ -32,8 +32,11 @@ projectroot/
 │   │   ├── contact/  # Contact form API endpoints (send-feedback, send-owner-email)
 │   │   └── shared/   # Shared API endpoints (statistics, location-search, location-reverse)
 │   ├── assets/       # First-party JS/CSS source files (built → minified in place)
-│   ├── cars/         # Car pages (index, details, edit, factory, etc.)
-│   ├── contact/      # Contact form pages
+│   ├── owner/        # Owner-facing pages (moved from top-level app/ subdirectories)
+│   │   ├── cars/     # Car pages (index, details, edit, factory, etc.)
+│   │   ├── contact/  # Contact form pages
+│   │   ├── reports/  # Statistics and reporting pages
+│   │   └── privacy.php
 │   └── views/        # Reusable view partials
 ├── docs/             # User-facing docs (guides/, reference/, stories/, admin/)
 ├── error/            # Branded HTTP error pages (403, 404, 500)
@@ -59,7 +62,10 @@ $path = [
     'app/admin/',
     'app/admin/scripts/fix/',
     'app/admin/scripts/maintenance/',
-    'app/cars/',
+    'app/owner/',
+    'app/owner/cars/',
+    'app/owner/contact/',
+    'app/owner/reports/',
     'app/api/contact/',      // contact endpoints call securePage()
     // ... add 'your/new/directory/' here
 ];

--- a/usersc/templates/customizer/file_nav_custom.php
+++ b/usersc/templates/customizer/file_nav_custom.php
@@ -17,18 +17,18 @@ if ($navActive === '') {
         $current = '/' . ltrim(substr($current, strlen($root)), '/');
     }
     // Order matters: exact paths and more-specific entries first so they win
-    // over broader prefixes (e.g. factory.php beats the /app/cars/ prefix).
+    // over broader prefixes (e.g. factory.php beats the /app/owner/cars/ prefix).
     $sections = [
-        'add_car'    => ['/app/cars/edit.php'],
-        'reference'  => ['/app/cars/factory.php', '/docs/reference/'],
-        'list_cars'  => ['/app/cars/'],
-        'statistics' => ['/app/reports/statistics.php'],
+        'add_car'    => ['/app/owner/cars/edit.php'],
+        'reference'  => ['/app/owner/cars/factory.php', '/docs/reference/'],
+        'list_cars'  => ['/app/owner/cars/'],
+        'statistics' => ['/app/owner/reports/statistics.php'],
         'stories'    => ['/docs/car-stories.php', '/docs/stories/'],
         'guides'     => ['/docs/guides/'],
         'register'   => ['/users/join.php', '/usersc/join.php'],
         'login'      => ['/users/login.php', '/usersc/login.php'],
         'admin'      => ['/app/admin/', '/docs/admin/', '/users/admin.php'],
-        'account'    => ['/users/account.php', '/usersc/account.php', '/app/contact/', '/users/logout.php'],
+        'account'    => ['/users/account.php', '/usersc/account.php', '/app/owner/contact/', '/users/logout.php'],
     ];
     foreach ($sections as $key => $patterns) {
         foreach ($patterns as $p) {
@@ -67,7 +67,7 @@ if ($navActive === '') {
   </div>
 
   <li class='<?= $navActive === 'list_cars' ? 'active' : '' ?>'>
-    <a class='' href='<?= $us_url_root ?>app/cars/index.php'>
+    <a class='' href='<?= $us_url_root ?>app/owner/cars/index.php'>
       <i class='fa fa-car'></i>
       <span class='labelText'>List Cars</span>
     </a>
@@ -75,7 +75,7 @@ if ($navActive === '') {
 
   <?php if (isset($user) && $user->isLoggedIn()): ?>
     <li class='<?= $navActive === 'add_car' ? 'active' : '' ?>'>
-      <a class='btn btn-primary btn-sm ms-1' href='<?= $us_url_root ?>app/cars/edit.php'>
+      <a class='btn btn-primary btn-sm ms-1' href='<?= $us_url_root ?>app/owner/cars/edit.php'>
         <i class='fa fa-plus'></i>
         <span class='labelText'>Add Car</span>
       </a>
@@ -83,7 +83,7 @@ if ($navActive === '') {
   <?php endif; ?>
 
   <li class='<?= $navActive === 'statistics' ? 'active' : '' ?>'>
-    <a class='' href='<?= $us_url_root ?>app/reports/statistics.php'>
+    <a class='' href='<?= $us_url_root ?>app/owner/reports/statistics.php'>
       <i class='fa fa-pie-chart'></i>
       <span class='labelText'>Statistics</span>
     </a>
@@ -115,7 +115,7 @@ if ($navActive === '') {
         </a>
       </li>
       <li class=''>
-        <a class='' href='<?= $us_url_root ?>app/cars/factory.php'>
+        <a class='' href='<?= $us_url_root ?>app/owner/cars/factory.php'>
           <i class='fa fa-list-alt'></i>
           <span class='labelText'>Production Records</span>
         </a>
@@ -207,7 +207,7 @@ if ($navActive === '') {
           </a>
         </li>
         <li class=''>
-          <a class='' href='<?= $us_url_root ?>app/contact/index.php'>
+          <a class='' href='<?= $us_url_root ?>app/owner/contact/index.php'>
             <i class='fa fa-comments'></i>
             <span class='labelText'>Feedback</span>
           </a>

--- a/z_us_root.php
+++ b/z_us_root.php
@@ -6,7 +6,7 @@
  * Determines the root URL for Userspice and redirects to it.
  * Used for path resolution and navigation consistency.
  */
-$path = ['', 'users/', 'usersc/', 'app/', 'app/cars/', 'app/contact/', 'app/reports/', 'app/api/contact/', 'app/admin/', 'app/admin/includes/', 'app/admin/includes/system/', 'app/admin/scripts/fix/', 'app/admin/scripts/maintenance/', 'app/admin/verify/', 'docs/', 'docs/guides/', 'docs/reference/', 'docs/stories/', 'docs/stories/brian_walton/', 'docs/stories/SGO_2F/'];
+$path = ['', 'users/', 'usersc/', 'app/', 'app/owner/', 'app/owner/cars/', 'app/owner/contact/', 'app/owner/reports/', 'app/api/contact/', 'app/admin/', 'app/admin/includes/', 'app/admin/includes/system/', 'app/admin/scripts/fix/', 'app/admin/scripts/maintenance/', 'app/admin/verify/', 'docs/', 'docs/guides/', 'docs/reference/', 'docs/stories/', 'docs/stories/brian_walton/', 'docs/stories/SGO_2F/'];
 // Only add or remove values in the $path variable separated by commas above
 
 $abs_us_root = Server::get('DOCUMENT_ROOT');


### PR DESCRIPTION
## Summary

- Moves 8 owner-facing pages from flat `app/` structure to `app/owner/` namespace: `cars/`, `contact/`, `reports/`, and `privacy.php`
- Updates all internal references atomically: nav, footer, email templates, admin views, API endpoints, homepage CTA — no redirect stubs for internal links
- Adds 8 `.htaccess` 301 redirects to preserve external bookmarks and search engine links
- Adds `app/owner/`, `app/owner/cars/`, `app/owner/contact/`, `app/owner/reports/` to `z_us_root.php` `$path` (UserSpice Manage Pages scanner uses non-recursive glob — all four dirs required)
- Updates `PagePermissionClassifier` contact pattern: `#^app/contact/#` → `#^app/owner/contact/#`
- Fixes pre-existing double-slash redirect bug in `details.php` (was silently sending users to homepage)
- Fixes `Issue317RegressionTest` glob to recurse into unit test subdirectories
- Updates 20 Playwright specs, 5 PHPUnit files, 9 docs/ADR files

## Post-deploy steps

See Required Actions in the release notes. In brief:
1. Visit each new URL to trigger UserSpice auto-registration (private pages must be visited as admin)
2. Run Fix Page Permissions maintenance script
3. Optionally delete old `app/cars/*` / `app/contact/*` / `app/reports/*` slugs from `pages` table

## Test plan

- [ ] `composer test:quick` — 1008 unit tests, all pass
- [ ] Playwright: `npm run playwright:test` against MAMP at localhost:9999
- [ ] Spot-check each of the 8 new URLs in browser (confirm no 404s, nav active states correct)
- [ ] Verify each old URL redirects 301 → new location
- [ ] Post-deploy: visit new URLs as admin, run Fix Page Permissions, confirm permission tiers

## Pre-existing issues found during review (filed separately)

- `app/owner/contact/owner.php` — `Redirect::to('/')` bypasses `$us_url_root` (harmless at domain root)
- `app/owner/cars/details.php` — silent `catch` blocks with no logging for bad date fields
- `app/owner/reports/statistics.php` — Chart.js and map failure states have no user-visible fallback
- Wiki (`wiki/Elan-Registry-Architecture-and-Database-Design.md`) needs updating — handled in `/finish-milestone`

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM