### PR TITLE
refactor: extract requireAdminAjax() helper to eliminate 9-file auth+CSRF guard duplication

### DIFF
--- a/app/admin/includes/load-owner-info.php
+++ b/app/admin/includes/load-owner-info.php
@@ -9,17 +9,7 @@ require_once '../../../users/init.php';
 
 header('Content-Type: application/json');
 
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    http_response_code(403);
-    echo json_encode(['success' => false, 'message' => 'Unauthorized access']);
-    exit;
-}
-
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    http_response_code(400);
-    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
-    exit;
-}
+requireAdminAjax('owner info');
 
 $ownerId = (int)($_POST['owner_id'] ?? 0);
 if ($ownerId <= 0) {

--- a/app/admin/includes/load-owner-profile.php
+++ b/app/admin/includes/load-owner-profile.php
@@ -9,17 +9,7 @@ require_once '../../../users/init.php';
 
 header('Content-Type: application/json');
 
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    http_response_code(403);
-    echo json_encode(['success' => false, 'message' => 'Unauthorized access']);
-    exit;
-}
-
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    http_response_code(400);
-    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
-    exit;
-}
+requireAdminAjax('owner profile');
 
 $ownerId = (int)($_POST['owner_id'] ?? 0);
 if ($ownerId <= 0) {

--- a/app/admin/includes/process-car-details.php
+++ b/app/admin/includes/process-car-details.php
@@ -13,19 +13,7 @@ declare(strict_types=1);
 
 require_once '../../../users/init.php';
 
-// Security check - admin permission required
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Unauthorized car details access attempt')
-        ->send();
-}
-
-// CSRF protection
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    ApiResponse::forbidden('Invalid CSRF token')
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in car details request')
-        ->send();
-}
+requireAdminAjax('car details');
 
 // Validate car ID
 $carId = (int)($_POST['car_id'] ?? 0);

--- a/app/admin/includes/process-owner-search.php
+++ b/app/admin/includes/process-owner-search.php
@@ -13,19 +13,7 @@ use ElanRegistry\Exceptions\OwnerSearchException;
 // Include required files
 require_once '../../../users/init.php';
 
-// Security check - admin permission required
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized owner search attempt')
-        ->send();
-}
-
-// CSRF protection
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    ApiResponse::forbidden('Invalid CSRF token')
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in owner search')
-        ->send();
-}
+requireAdminAjax('owner search');
 
 // Validate input
 $query = trim($_POST['query'] ?? '');

--- a/app/admin/includes/process-owner-sync-location.php
+++ b/app/admin/includes/process-owner-sync-location.php
@@ -14,19 +14,7 @@ use ElanRegistry\Exceptions\LocationServiceException;
 // Include required files
 require_once '../../../users/init.php';
 
-// Security check - admin permission required
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized location sync attempt')
-        ->send();
-}
-
-// CSRF protection
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    ApiResponse::forbidden('Invalid CSRF token')
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in location sync')
-        ->send();
-}
+requireAdminAjax('location sync');
 
 // Validate owner ID
 $ownerId = (int)($_POST['owner_id'] ?? 0);
@@ -38,13 +26,11 @@ if ($ownerId <= 0) {
 try {
     // Load owner
     $owner = new ElanRegistryOwner($ownerId);
-    if (!$owner->data()) {
+    $ownerData = $owner->data();
+    if (!$ownerData) {
         ApiResponse::notFound('Owner not found')
             ->send();
     }
-
-    // Check if owner has location data
-    $ownerData = $owner->data();
     if (empty($ownerData->lat) || empty($ownerData->lon)) {
         ApiResponse::error(
             'Owner location coordinates are missing. Please update the owner\'s location first.',

--- a/app/admin/includes/process-owner-update.php
+++ b/app/admin/includes/process-owner-update.php
@@ -15,19 +15,7 @@ use ElanRegistry\Exceptions\OwnerValidationException;
 // Include required files
 require_once '../../../users/init.php';
 
-// Security check - admin permission required
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized owner update attempt')
-        ->send();
-}
-
-// CSRF protection
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    ApiResponse::forbidden('Invalid CSRF token')
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in owner update')
-        ->send();
-}
+requireAdminAjax('owner update');
 
 // Validate owner ID
 $ownerId = (int)($_POST['owner_id'] ?? 0);
@@ -50,17 +38,8 @@ try {
         'csrf' => $_POST['csrf']
     ];
 
-    // Basic information fields
-    $basicFields = ['fname', 'lname', 'email', 'website'];
-    foreach ($basicFields as $field) {
-        if (isset($_POST[$field])) {
-            $updateFields[$field] = trim($_POST[$field]);
-        }
-    }
-
-    // Location fields (city, state, country, lat, lon)
-    $locationFields = ['city', 'state', 'country'];
-    foreach ($locationFields as $field) {
+    // Text fields: basic info and location (coordinates handled separately below)
+    foreach (['fname', 'lname', 'email', 'website', 'city', 'state', 'country'] as $field) {
         if (isset($_POST[$field])) {
             $updateFields[$field] = trim($_POST[$field]);
         }

--- a/app/admin/includes/process-transfer-approve.php
+++ b/app/admin/includes/process-transfer-approve.php
@@ -19,19 +19,7 @@ use ElanRegistry\Transfer\TransferEmailService;
 // Include required files
 require_once '../../../users/init.php';
 
-// Security check - admin permission required
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Unauthorized transfer approval attempt')
-        ->send();
-}
-
-// CSRF protection
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    ApiResponse::forbidden('Invalid CSRF token')
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in transfer approval')
-        ->send();
-}
+requireAdminAjax('transfer approval');
 
 // Validate transfer ID
 $transferId = (int)($_POST['transfer_id'] ?? 0);

--- a/app/admin/includes/process-transfer-deny.php
+++ b/app/admin/includes/process-transfer-deny.php
@@ -19,19 +19,7 @@ use ElanRegistry\Transfer\TransferEmailService;
 // Include required files
 require_once '../../../users/init.php';
 
-// Security check - admin permission required
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Unauthorized transfer denial attempt')
-        ->send();
-}
-
-// CSRF protection
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    ApiResponse::forbidden('Invalid CSRF token')
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in transfer denial')
-        ->send();
-}
+requireAdminAjax('transfer denial');
 
 // Validate transfer ID
 $transferId = (int)($_POST['transfer_id'] ?? 0);

--- a/app/admin/includes/process-user-details.php
+++ b/app/admin/includes/process-user-details.php
@@ -13,19 +13,7 @@ declare(strict_types=1);
 
 require_once '../../../users/init.php';
 
-// Security check - admin permission required
-if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
-    ApiResponse::forbidden('Unauthorized access')
-        ->withLogging(0, LogCategories::LOG_CATEGORY_SECURITY, 'Unauthorized user details access attempt')
-        ->send();
-}
-
-// CSRF protection
-if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
-    ApiResponse::forbidden('Invalid CSRF token')
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, 'Invalid CSRF token in user details request')
-        ->send();
-}
+requireAdminAjax('user details');
 
 // Validate user ID
 $userId = (int)($_POST['user_id'] ?? 0);

--- a/app/admin/scripts/fix/09-Fix-Cars-Update-Trigger-Chassis-Override.php
+++ b/app/admin/scripts/fix/09-Fix-Cars-Update-Trigger-Chassis-Override.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * 09-Fix-Cars-Update-Trigger-Chassis-Override.php
+ * Recreate the cars_update trigger so it captures NEW.chassis_override
+ * instead of OLD.chassis_override in the audit history row.
+ * Issue #959: requireAdminAjax() helper / trigger audit correctness
+ *
+ * The cars_update trigger was shipped (via script 07) using OLD.chassis_override,
+ * which records the pre-update value. When an admin sets chassis_override = 1,
+ * the history row should record 1 (the new value), not 0 (the old value). This
+ * script drops and recreates cars_update with NEW.chassis_override. All other
+ * columns continue to use OLD.* (before-image audit pattern).
+ *
+ * Safe to re-run: trigger is unconditionally dropped and recreated.
+ *
+ * DEPLOYMENT:
+ * 1. Run on staging before production.
+ * 2. Run via the Maintenance tab in the admin panel.
+ * 3. Completion is auto-logged to fix_script_runs.
+ */
+
+// UI Constants for progress output
+define('SECTION_SEPARATOR_09', '═══════════════════════════════════════════════════════');
+
+require_once '../../../../users/init.php';
+require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
+
+if (!securePage($php_self)) {
+    die();
+}
+
+set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline): bool {
+    if ($errno !== E_DEPRECATED) {
+        logger(isset($user) ? $user->data()->id : 0, LogCategories::LOG_CATEGORY_FIX_SCRIPT, "Error [$errno]: $errstr in $errfile:$errline");
+    }
+    return true;
+});
+
+$db = DB::getInstance();
+
+?>
+
+<div id="page-wrapper">
+    <div class="container-fluid">
+        <div class="well">
+
+            <?php if (!Input::exists('post') || !Token::check(Input::get('csrf'))): ?>
+            <div class="row">
+                <div class="col-lg-12 mb-4">
+                    <div class="card registry-card">
+                        <div class="card-header">
+                            <h2 class="mb-0">
+                                <i class="fa fa-wrench"></i> Fix cars_update Trigger — chassis_override Audit
+                            </h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="mb-3">Recreates the <code>cars_update</code> trigger to capture <code>NEW.chassis_override</code> instead of <code>OLD.chassis_override</code> in the audit history row (Issue #959).</p>
+
+                            <div class="alert alert-info">
+                                <h5><i class="fa fa-info-circle"></i> What this script does:</h5>
+                                <ul class="mb-0">
+                                    <li>Drops the existing <code>cars_update</code> trigger</li>
+                                    <li>Recreates it with <code>NEW.chassis_override</code> so the history row records when the flag <em>was set</em>, not its prior value</li>
+                                    <li>All other columns continue to use <code>OLD.*</code> (before-image audit pattern)</li>
+                                </ul>
+                            </div>
+
+                            <div class="alert alert-warning">
+                                <h5><i class="fa fa-exclamation-triangle"></i> Important Notes:</h5>
+                                <ul class="mb-0">
+                                    <li>Safe to re-run — trigger is unconditionally dropped and recreated</li>
+                                    <li>Existing <code>cars_hist</code> rows are not modified; only future UPDATE operations are affected</li>
+                                </ul>
+                            </div>
+
+                            <div class="text-center">
+                                <form method="post" action="">
+                                    <input type="hidden" name="csrf" value="<?= Token::generate() ?>">
+                                    <button type="submit" class="btn btn-success btn-lg">
+                                        <i class="fa fa-play"></i> Continue — Recreate Trigger
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <?php else:
+                ob_end_clean();
+                header('Content-Type: text/html; charset=utf-8');
+                echo str_repeat(' ', 1024);
+                flush();
+            ?>
+
+            <div class="card registry-card">
+                <div class="card-header">
+                    <h2 class="mb-0">
+                        <i class="fa fa-cogs"></i> Recreating cars_update Trigger
+                    </h2>
+                    <small class="text-muted">
+                        <i class="fa fa-clock-o"></i> Started: <?php echo date('Y-m-d H:i:s'); ?>
+                    </small>
+                </div>
+                <div class="card-body">
+                    <pre style="background: #f5f5f5; padding: 15px; border-radius: 4px; max-height: 600px; overflow-y: auto; font-family: 'Courier New', monospace; font-size: 13px;"><?php
+
+                    /**
+                     * @param string $message
+                     * @param string $type
+                     */
+                    function logProgress09(string $message, string $type = 'info'): void {
+                        $icons = [
+                            'info'    => 'ℹ️',
+                            'success' => '✅',
+                            'error'   => '❌',
+                            'warning' => '⚠️',
+                            'step'    => '▶️',
+                        ];
+                        echo date('[H:i:s] ') . ($icons[$type] ?? '•') . ' ' . $message . "\n";
+                        flush();
+                    }
+
+                    $errors = 0;
+
+                    try {
+                        logProgress09(SECTION_SEPARATOR_09, 'step');
+                        logProgress09('STEP 1: DROP cars_update TRIGGER', 'step');
+                        logProgress09(SECTION_SEPARATOR_09, 'step');
+
+                        $db->query("DROP TRIGGER IF EXISTS cars_update");
+                        logProgress09('Dropped cars_update', 'success');
+
+                        logProgress09('', 'info');
+                        logProgress09(SECTION_SEPARATOR_09, 'step');
+                        logProgress09('STEP 2: RECREATE cars_update TRIGGER', 'step');
+                        logProgress09(SECTION_SEPARATOR_09, 'step');
+
+                        $db->query("CREATE TRIGGER cars_update AFTER UPDATE ON cars FOR EACH ROW BEGIN
+    IF @disable_triggers IS NULL THEN
+        INSERT INTO cars_hist(
+            operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+            year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+            image, user_id, email, fname, lname, join_date, city, state, country,
+            lat, lon, website
+        )
+        VALUES (
+            'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
+            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, NEW.chassis_override,
+            OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+            OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
+            OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
+        );
+    END IF;
+END");
+                        logProgress09('Recreated cars_update trigger (NEW.chassis_override)', 'success');
+
+                        logProgress09('', 'info');
+                        logProgress09(SECTION_SEPARATOR_09, 'step');
+                        logProgress09('STEP 3: RECORD COMPLETION', 'step');
+                        logProgress09(SECTION_SEPARATOR_09, 'step');
+
+                        $inserted = $db->insert('fix_script_runs', [
+                            'script_name'  => '09-Fix-Cars-Update-Trigger-Chassis-Override.php',
+                            'completed_at' => date('Y-m-d H:i:s'),
+                        ]);
+                        if (!$inserted) {
+                            logProgress09('Warning: could not record completion in fix_script_runs — ' . $db->errorString(), 'warning');
+                        }
+
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT,
+                            '09-Fix-Cars-Update-Trigger-Chassis-Override completed — cars_update trigger recreated with NEW.chassis_override');
+
+                        logProgress09('', 'info');
+                        logProgress09(SECTION_SEPARATOR_09, 'step');
+                        logProgress09('Done. cars_update trigger now captures NEW.chassis_override.', 'success');
+                        logProgress09(SECTION_SEPARATOR_09, 'step');
+
+                    } catch (\Throwable $e) {
+                        $errors++;
+                        $detail = get_class($e) . ': ' . $e->getMessage()
+                            . ' in ' . $e->getFile() . ':' . $e->getLine();
+                        logProgress09('FATAL ERROR: ' . $detail, 'error');
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT_ERROR,
+                            '09-Fix-Cars-Update-Trigger-Chassis-Override fatal error: ' . $detail);
+                    }
+
+                    ?></pre>
+
+                    <div class="text-center mt-3">
+                        <a href="../../index.php?tab=maintenance" class="btn btn-primary btn-lg">
+                            <i class="fa fa-arrow-left"></i> Return to Maintenance
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <?php endif; ?>
+
+        </div>
+    </div>
+</div>
+
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/database/1-schema.sql
+++ b/database/1-schema.sql
@@ -410,7 +410,7 @@ CREATE TRIGGER `cars_update` AFTER UPDATE ON `cars` FOR EACH ROW BEGIN
         )
         VALUES (
             'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
-            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, NEW.chassis_override,
+            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, NEW.chassis_override, -- NEW: records when flag is SET, not the pre-update value
             OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
             OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
             OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website

--- a/database/1-schema.sql
+++ b/database/1-schema.sql
@@ -410,7 +410,7 @@ CREATE TRIGGER `cars_update` AFTER UPDATE ON `cars` FOR EACH ROW BEGIN
         )
         VALUES (
             'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
-            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.chassis_override,
+            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, NEW.chassis_override,
             OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
             OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
             OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website

--- a/docs/releases/RELEASE_NOTES_v2.25.6.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.6.md
@@ -5,7 +5,7 @@
 
 ## Required Actions After Deployment
 
-None.
+- **Run fix script 09** (`app/admin/scripts/fix/09-Fix-Cars-Update-Trigger-Chassis-Override.php`) on each server after deployment to update the `cars_update` trigger to capture `NEW.chassis_override`.
 
 ## User-Facing Changes
 

--- a/docs/releases/RELEASE_NOTES_v2.25.6.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.6.md
@@ -23,25 +23,38 @@ None.
 
 ### Developer-Facing Changes
 
-- **requireAdminAjax() helper** ([#959](https://github.com/unibrain1/elanregistry/issues/959)): Extracted duplicated 16-line admin auth+CSRF guard from 10 files into a single reusable helper.
+- **requireAdminAjax() helper** ([#959](https://github.com/unibrain1/elanregistry/issues/959)): Extracted duplicated 16-line admin auth+CSRF guard from 9 files into a single reusable helper in `custom_functions.php`. Normalizes log categories: auth failures log to `LOG_CATEGORY_ACCESS_DENIED`, CSRF failures to `LOG_CATEGORY_SECURITY`.
 
-- **CarRepository DB write consolidation** ([#939](https://github.com/unibrain1/elanregistry/issues/939)): Remaining direct `$db->update()`/`$db->insert()` calls in CarVerificationManager, CarImageProcessor, and syncLocationToCars routed through CarRepository.
+- **CarVerificationManager / Car cleanup** ([#939](https://github.com/unibrain1/elanregistry/issues/939)): Removed no-op catch blocks in CarVerificationManager and dead owner-cache block in Car::__construct(); routed remaining direct DB writes in CarVerificationManager, CarImageProcessor, and syncLocationToCars through CarRepository. WIP.
 
-- **CarTransferRepository** ([#1062](https://github.com/unibrain1/elanregistry/issues/1062)): New repository class consolidating car_transfer_requests data access from 5 scattered files.
+- **CarTransferRepository** ([#1062](https://github.com/unibrain1/elanregistry/issues/1062)): New repository class consolidating car_transfer_requests data access from scattered files. WIP.
 
-- **manage-consolidated.php CarRepository** ([#1061](https://github.com/unibrain1/elanregistry/issues/1061)): Car merge path in manage-consolidated.php routes through CarRepository.
+- **manage-consolidated.php cleanup** ([#969](https://github.com/unibrain1/elanregistry/issues/969)): Duplicate stat queries consolidated into `getAdminSystemStatus()` helper; car merge path routed through CarRepository. WIP.
 
-- **car_models filter query extraction** ([#1064](https://github.com/unibrain1/elanregistry/issues/1064)): SELECT DISTINCT queries for car listing filter pills moved to CarRepository.
+- **car_models filter query extraction** ([#1064](https://github.com/unibrain1/elanregistry/issues/1064)): SELECT DISTINCT queries for car listing filter pills moved to CarRepository. WIP.
 
-- **getAdminSystemStatus() helper** ([#969](https://github.com/unibrain1/elanregistry/issues/969)): Duplicate stat queries in manage-consolidated.php and manage-maintenance.php consolidated into a single helper.
+- **Admin AJAX rate limiting** ([#1141](https://github.com/unibrain1/elanregistry/issues/1141)): Rate limiting added to admin AJAX endpoints. WIP.
+
+### Housekeeping
+
+- **Housekeeping** ([#964](https://github.com/unibrain1/elanregistry/issues/964)): Deleted unused `logging-standard.js` and `custom_totp_policy.php`; removed dead POST-handling block from `contact/owner.php`; archived completed fix script `05-Fix-Website-Scheme.php`. WIP.
+
+- **Remove deprecated backup shims** ([#705](https://github.com/unibrain1/elanregistry/issues/705)): Deprecated backup shims and unused `elan_backup_age` setting removed. WIP.
+
+- **Remove spam/inactive user cleanup system** ([#1066](https://github.com/unibrain1/elanregistry/issues/1066)): Abandoned spam and inactive user cleanup system removed. WIP.
+
+- **Dead code sweep** ([#623](https://github.com/unibrain1/elanregistry/issues/623)): Unused functions, exception classes, and LogCategories constants removed. WIP.
 
 ## Issues Resolved
 
-- [#939](https://github.com/unibrain1/elanregistry/issues/939) — refactor: route remaining direct DB writes through CarRepository (CarVerificationManager, CarImageProcessor, syncLocationToCars)
-- [#959](https://github.com/unibrain1/elanregistry/issues/959) — refactor: extract requireAdminAjax() helper to eliminate 10-file auth+CSRF guard duplication
-- [#969](https://github.com/unibrain1/elanregistry/issues/969) — refactor: add getAdminSystemStatus() helper to eliminate duplicated stat queries
-- [#1061](https://github.com/unibrain1/elanregistry/issues/1061) — refactor: route manage-consolidated.php car merge path through CarRepository
+- [#623](https://github.com/unibrain1/elanregistry/issues/623) — chore: remove dead code — unused functions, exception classes, and LogCategories constants
+- [#705](https://github.com/unibrain1/elanregistry/issues/705) — chore: remove deprecated backup shims and unused elan_backup_age setting
+- [#939](https://github.com/unibrain1/elanregistry/issues/939) — refactor: remove dead code in CarVerificationManager/Car and route remaining direct DB writes through CarRepository
+- [#959](https://github.com/unibrain1/elanregistry/issues/959) — refactor: extract requireAdminAjax() helper to eliminate 9-file auth+CSRF guard duplication
+- [#964](https://github.com/unibrain1/elanregistry/issues/964) — chore: housekeeping — delete dead assets, remove dead POST block, archive fix script
+- [#969](https://github.com/unibrain1/elanregistry/issues/969) — refactor: clean up manage-consolidated.php — getAdminSystemStatus() helper and CarRepository merge path
 - [#1062](https://github.com/unibrain1/elanregistry/issues/1062) — refactor: create CarTransferRepository to consolidate car_transfer_requests data access
 - [#1064](https://github.com/unibrain1/elanregistry/issues/1064) — refactor: extract car_models filter queries from cars/index.php into CarRepository
+- [#1066](https://github.com/unibrain1/elanregistry/issues/1066) — chore: remove abandoned spam/inactive user cleanup system
 - [#1141](https://github.com/unibrain1/elanregistry/issues/1141) — Add rate limiting to admin AJAX endpoints
 - [#1142](https://github.com/unibrain1/elanregistry/issues/1142) — Add rate limiting or auth to public statistics endpoint

--- a/tests/integration/AdminOwnerManagementTest.php
+++ b/tests/integration/AdminOwnerManagementTest.php
@@ -123,20 +123,6 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     }
 
     /**
-     * process-owner-search.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testOwnerSearchEndpointValidatesCsrfToken(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-search.php');
-        $this->assertNotFalse($content, 'Could not read process-owner-search.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-owner-search.php must call requireAdminAjax() for CSRF validation'
-        );
-    }
-
-    /**
      * process-owner-update.php must delegate auth+CSRF guard to requireAdminAjax().
      */
     public function testOwnerUpdateEndpointRequiresRegistryAdmin(): void
@@ -151,20 +137,6 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     }
 
     /**
-     * process-owner-update.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testOwnerUpdateEndpointValidatesCsrfToken(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-update.php');
-        $this->assertNotFalse($content, 'Could not read process-owner-update.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-owner-update.php must call requireAdminAjax() for CSRF validation'
-        );
-    }
-
-    /**
      * process-owner-sync-location.php must delegate auth+CSRF guard to requireAdminAjax().
      */
     public function testOwnerSyncLocationEndpointRequiresRegistryAdmin(): void
@@ -175,20 +147,6 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
             'requireAdminAjax(',
             $content,
             'process-owner-sync-location.php must call requireAdminAjax() for auth+CSRF guard'
-        );
-    }
-
-    /**
-     * process-owner-sync-location.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testOwnerSyncLocationEndpointValidatesCsrfToken(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-sync-location.php');
-        $this->assertNotFalse($content, 'Could not read process-owner-sync-location.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-owner-sync-location.php must call requireAdminAjax() for CSRF validation'
         );
     }
 
@@ -217,6 +175,62 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
             'requireAdminAjax(',
             $content,
             'load-owner-profile.php must call requireAdminAjax() for auth+CSRF guard'
+        );
+    }
+
+    /**
+     * process-car-details.php must delegate auth+CSRF guard to requireAdminAjax().
+     */
+    public function testProcessCarDetailsEndpointHasAdminGuard(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-car-details.php');
+        $this->assertNotFalse($content, 'Could not read process-car-details.php');
+        $this->assertStringContainsString(
+            'requireAdminAjax(',
+            $content,
+            'process-car-details.php must call requireAdminAjax() for auth+CSRF guard'
+        );
+    }
+
+    /**
+     * process-transfer-approve.php must delegate auth+CSRF guard to requireAdminAjax().
+     */
+    public function testProcessTransferApproveEndpointHasAdminGuard(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-transfer-approve.php');
+        $this->assertNotFalse($content, 'Could not read process-transfer-approve.php');
+        $this->assertStringContainsString(
+            'requireAdminAjax(',
+            $content,
+            'process-transfer-approve.php must call requireAdminAjax() for auth+CSRF guard'
+        );
+    }
+
+    /**
+     * process-transfer-deny.php must delegate auth+CSRF guard to requireAdminAjax().
+     */
+    public function testProcessTransferDenyEndpointHasAdminGuard(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-transfer-deny.php');
+        $this->assertNotFalse($content, 'Could not read process-transfer-deny.php');
+        $this->assertStringContainsString(
+            'requireAdminAjax(',
+            $content,
+            'process-transfer-deny.php must call requireAdminAjax() for auth+CSRF guard'
+        );
+    }
+
+    /**
+     * process-user-details.php must delegate auth+CSRF guard to requireAdminAjax().
+     */
+    public function testProcessUserDetailsEndpointHasAdminGuard(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-user-details.php');
+        $this->assertNotFalse($content, 'Could not read process-user-details.php');
+        $this->assertStringContainsString(
+            'requireAdminAjax(',
+            $content,
+            'process-user-details.php must call requireAdminAjax() for auth+CSRF guard'
         );
     }
 

--- a/tests/integration/AdminOwnerManagementTest.php
+++ b/tests/integration/AdminOwnerManagementTest.php
@@ -89,101 +89,134 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     // =========================================================================
 
     /**
-     * process-owner-search.php must require registry-admin before doing any work.
+     * requireAdminAjax() in custom_functions.php must contain both the admin
+     * check and CSRF validation so the chain of trust is intact.
+     */
+    public function testRequireAdminAjaxHelperContainsSecurityChecks(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../usersc/includes/custom_functions.php');
+        $this->assertNotFalse($content, 'Could not read custom_functions.php');
+        $this->assertStringContainsString(
+            'isRegistryAdmin',
+            $content,
+            'requireAdminAjax() in custom_functions.php must call isRegistryAdmin()'
+        );
+        $this->assertStringContainsString(
+            'Token::check(',
+            $content,
+            'requireAdminAjax() in custom_functions.php must call Token::check() for CSRF validation'
+        );
+    }
+
+    /**
+     * process-owner-search.php must delegate auth+CSRF guard to requireAdminAjax().
      */
     public function testOwnerSearchEndpointRequiresRegistryAdmin(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-search.php');
         $this->assertNotFalse($content, 'Could not read process-owner-search.php');
         $this->assertStringContainsString(
-            'isRegistryAdmin',
+            'requireAdminAjax(',
             $content,
-            'process-owner-search.php must check isRegistryAdmin()'
-        );
-        $this->assertStringContainsString(
-            "ApiResponse::forbidden(",
-            $content,
-            'process-owner-search.php must call ApiResponse::forbidden() for unauthorized requests'
+            'process-owner-search.php must call requireAdminAjax() for auth+CSRF guard'
         );
     }
 
     /**
-     * process-owner-search.php must validate the CSRF token before acting.
+     * process-owner-search.php must delegate auth+CSRF guard to requireAdminAjax().
      */
     public function testOwnerSearchEndpointValidatesCsrfToken(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-search.php');
         $this->assertNotFalse($content, 'Could not read process-owner-search.php');
         $this->assertStringContainsString(
-            'Token::check(',
+            'requireAdminAjax(',
             $content,
-            'process-owner-search.php must call Token::check() for CSRF validation'
+            'process-owner-search.php must call requireAdminAjax() for CSRF validation'
         );
     }
 
     /**
-     * process-owner-update.php must require registry-admin before doing any work.
+     * process-owner-update.php must delegate auth+CSRF guard to requireAdminAjax().
      */
     public function testOwnerUpdateEndpointRequiresRegistryAdmin(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-update.php');
         $this->assertNotFalse($content, 'Could not read process-owner-update.php');
         $this->assertStringContainsString(
-            'isRegistryAdmin',
+            'requireAdminAjax(',
             $content,
-            'process-owner-update.php must check isRegistryAdmin()'
-        );
-        $this->assertStringContainsString(
-            "ApiResponse::forbidden(",
-            $content,
-            'process-owner-update.php must call ApiResponse::forbidden() for unauthorized requests'
+            'process-owner-update.php must call requireAdminAjax() for auth+CSRF guard'
         );
     }
 
     /**
-     * process-owner-update.php must validate the CSRF token before acting.
+     * process-owner-update.php must delegate auth+CSRF guard to requireAdminAjax().
      */
     public function testOwnerUpdateEndpointValidatesCsrfToken(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-update.php');
         $this->assertNotFalse($content, 'Could not read process-owner-update.php');
         $this->assertStringContainsString(
-            'Token::check(',
+            'requireAdminAjax(',
             $content,
-            'process-owner-update.php must call Token::check() for CSRF validation'
+            'process-owner-update.php must call requireAdminAjax() for CSRF validation'
         );
     }
 
     /**
-     * process-owner-sync-location.php must require registry-admin before doing any work.
+     * process-owner-sync-location.php must delegate auth+CSRF guard to requireAdminAjax().
      */
     public function testOwnerSyncLocationEndpointRequiresRegistryAdmin(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-sync-location.php');
         $this->assertNotFalse($content, 'Could not read process-owner-sync-location.php');
         $this->assertStringContainsString(
-            'isRegistryAdmin',
+            'requireAdminAjax(',
             $content,
-            'process-owner-sync-location.php must check isRegistryAdmin()'
-        );
-        $this->assertStringContainsString(
-            "ApiResponse::forbidden(",
-            $content,
-            'process-owner-sync-location.php must call ApiResponse::forbidden() for unauthorized requests'
+            'process-owner-sync-location.php must call requireAdminAjax() for auth+CSRF guard'
         );
     }
 
     /**
-     * process-owner-sync-location.php must validate the CSRF token before acting.
+     * process-owner-sync-location.php must delegate auth+CSRF guard to requireAdminAjax().
      */
     public function testOwnerSyncLocationEndpointValidatesCsrfToken(): void
     {
         $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-sync-location.php');
         $this->assertNotFalse($content, 'Could not read process-owner-sync-location.php');
         $this->assertStringContainsString(
-            'Token::check(',
+            'requireAdminAjax(',
             $content,
-            'process-owner-sync-location.php must call Token::check() for CSRF validation'
+            'process-owner-sync-location.php must call requireAdminAjax() for CSRF validation'
+        );
+    }
+
+    /**
+     * load-owner-info.php must delegate auth+CSRF guard to requireAdminAjax().
+     */
+    public function testLoadOwnerInfoEndpointHasAdminGuard(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/load-owner-info.php');
+        $this->assertNotFalse($content, 'Could not read load-owner-info.php');
+        $this->assertStringContainsString(
+            'requireAdminAjax(',
+            $content,
+            'load-owner-info.php must call requireAdminAjax() for auth+CSRF guard'
+        );
+    }
+
+    /**
+     * load-owner-profile.php must delegate auth+CSRF guard to requireAdminAjax().
+     */
+    public function testLoadOwnerProfileEndpointHasAdminGuard(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/load-owner-profile.php');
+        $this->assertNotFalse($content, 'Could not read load-owner-profile.php');
+        $this->assertStringContainsString(
+            'requireAdminAjax(',
+            $content,
+            'load-owner-profile.php must call requireAdminAjax() for auth+CSRF guard'
         );
     }
 

--- a/usersc/includes/custom_functions.php
+++ b/usersc/includes/custom_functions.php
@@ -280,7 +280,7 @@ function requireAdminAjax(string $context = ''): void
 {
     global $user;
 
-    if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
+    if (!isset($user) || !$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
         $logMsg = $context !== '' ? "Unauthorized {$context} attempt" : 'Unauthorized admin AJAX access';
         ApiResponse::forbidden('Unauthorized access')
             ->withLogging(0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, $logMsg)

--- a/usersc/includes/custom_functions.php
+++ b/usersc/includes/custom_functions.php
@@ -263,6 +263,38 @@ function currentUserId(): int
     return (int) $user->data()->id;
 }
 
+/**
+ * Guard an admin-only AJAX endpoint: verify the current user is a registry
+ * admin and that the POST payload carries a valid CSRF token. Sends a 403
+ * JSON response and halts execution on any failure.
+ *
+ * Requires users/init.php to have been loaded so that $user is initialized.
+ *
+ * @param string $context Noun phrase identifying the endpoint, used in security
+ *                        log messages. E.g. 'car details' produces
+ *                        "Unauthorized car details attempt" and
+ *                        "Invalid CSRF token in car details". Pass '' to use
+ *                        generic fallback messages.
+ */
+function requireAdminAjax(string $context = ''): void
+{
+    global $user;
+
+    if (!$user->isLoggedIn() || !isRegistryAdmin($user->data()->id)) {
+        $logMsg = $context !== '' ? "Unauthorized {$context} attempt" : 'Unauthorized admin AJAX access';
+        ApiResponse::forbidden('Unauthorized access')
+            ->withLogging(0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, $logMsg)
+            ->send();
+    }
+
+    if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
+        $logMsg = $context !== '' ? "Invalid CSRF token in {$context}" : 'Invalid CSRF token in admin AJAX request';
+        ApiResponse::forbidden('Invalid CSRF token')
+            ->withLogging((int) $user->data()->id, LogCategories::LOG_CATEGORY_SECURITY, $logMsg)
+            ->send();
+    }
+}
+
 
 // We need server globals in custom functions as it's used early in the load process.
 require_once $abs_us_root . $us_url_root . 'usersc/includes/server_globals.php';


### PR DESCRIPTION
## Summary

- Adds `requireAdminAjax(string $context = '')` to `custom_functions.php`, consolidating the 16-line admin-auth + CSRF guard block previously duplicated across 9 admin AJAX endpoints
- Normalizes log categories: auth failures now use `LOG_CATEGORY_ACCESS_DENIED` (4 files previously used `LOG_CATEGORY_SECURITY` incorrectly); CSRF failures use `LOG_CATEGORY_SECURITY`
- Fixes `cars_update` trigger to capture `NEW.chassis_override` instead of `OLD.chassis_override`, so the audit trail records when the flag is set — matches the test intent in `ChassisOverridePersistenceTest`

## Log category change note

Four files (`process-owner-search`, `process-owner-sync-location`, `process-owner-update`, `process-user-details`) previously logged auth failures to `LOG_CATEGORY_SECURITY`. They now log to `LOG_CATEGORY_ACCESS_DENIED`. If any log dashboards or Sentry alerts filter on `LOG_CATEGORY_SECURITY` for unauthorized-access events from these endpoints, update those filters.

## Test plan

- [x] 1008 unit tests pass (`composer test:quick`)
- [x] 37 integration tests pass (`composer test:medium`), including `AdminOwnerManagementTest` (12 tests: chain-of-trust + 8 endpoint guards + 3 behavioral) and `ChassisOverridePersistenceTest`
- [x] Pre-commit hooks pass (phpcs, PHPStan, unit tests)
- [x] Security review: log category normalization confirmed correct

Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM