### PR TITLE
refactor: remove dead code in CarVerificationManager/Car; route direct DB writes through CarRepository

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.25.6.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.6.md
@@ -27,7 +27,7 @@
 
 - **requireAdminAjax() helper** ([#959](https://github.com/unibrain1/elanregistry/issues/959)): Extracted duplicated 16-line admin auth+CSRF guard from 9 files into a single reusable helper in `custom_functions.php`. Normalizes log categories: auth failures log to `LOG_CATEGORY_ACCESS_DENIED`, CSRF failures to `LOG_CATEGORY_SECURITY`.
 
-- **CarVerificationManager / Car cleanup** ([#939](https://github.com/unibrain1/elanregistry/issues/939)): Removed no-op catch blocks in CarVerificationManager and dead owner-cache block in Car::__construct(); routed remaining direct DB writes in CarVerificationManager, CarImageProcessor, and syncLocationToCars through CarRepository. WIP.
+- **CarVerificationManager / Car cleanup** ([#939](https://github.com/unibrain1/elanregistry/issues/939)): Removed no-op catch blocks in CarVerificationManager and CarImageProcessor; removed dead owner-cache block from Car::__construct(); added four named update methods to CarRepository and routed all direct `cars` writes in CarVerificationManager, CarImageProcessor, and ElanRegistryOwner::syncLocationToCars() through them.
 
 - **CarTransferRepository** ([#1062](https://github.com/unibrain1/elanregistry/issues/1062)): New repository class consolidating car_transfer_requests data access from scattered files. WIP.
 

--- a/tests/unit/cars/services/CarRepositoryTest.php
+++ b/tests/unit/cars/services/CarRepositoryTest.php
@@ -81,4 +81,28 @@ final class CarRepositoryTest extends TestCase
         $result = $this->repo->insertCarUser(1, 100);
         $this->assertTrue($result);
     }
+
+    public function testUpdateVerificationCodeReturnsTrue(): void
+    {
+        $result = $this->repo->updateVerificationCode(1, 'TESTCODE12345678');
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateLastVerifiedReturnsTrue(): void
+    {
+        $result = $this->repo->updateLastVerified(1, '2026-07-05 12:00:00');
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateSoldDateReturnsTrue(): void
+    {
+        $result = $this->repo->updateSoldDate(1, '2026-07-05');
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateImageReturnsTrue(): void
+    {
+        $result = $this->repo->updateImage(1, '["test.jpg"]');
+        $this->assertTrue($result);
+    }
 }

--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -61,8 +61,6 @@ class Car
      */
     public function __construct(?int $id = null)
     {
-        global $user;
-
         $this->_db = DB::getInstance();
 
         if (function_exists('getSettings')) {
@@ -70,17 +68,6 @@ class Car
         } else {
             $settingsQuery = $this->_db->query('SELECT * FROM settings WHERE id = ?', [1]);
             $settings = $settingsQuery->count() > 0 ? $settingsQuery->first() : null;
-        }
-
-        if (isset($user) && $user->isLoggedIn()) {
-            static $cachedOwner = null;
-            static $cachedOwnerId = null;
-            $currentUserId = (int) $user->data()->id;
-            if ($cachedOwnerId !== $currentUserId) {
-                $cachedOwner = getUserWithProfile($currentUserId);
-                $cachedOwnerId = $currentUserId;
-            }
-            $this->_owner = $cachedOwner;
         }
 
         if ($id && $settings) {
@@ -360,7 +347,7 @@ class Car
      */
     public function exists(): bool
     {
-        return (!empty($this->_data)) ? true : false;
+        return !empty($this->_data);
     }
 
     /**
@@ -644,9 +631,8 @@ class Car
             if ($carData !== null) {
                 $car = new Car((int) $carData->id);
                 return $car->exists() ? $car : null;
-            } else {
-                return null;
             }
+            return null;
         } catch (Exception $e) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('unexpected_error', ['error' => $e->getMessage()]);
             logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);

--- a/usersc/classes/Car/CarImageProcessor.php
+++ b/usersc/classes/Car/CarImageProcessor.php
@@ -59,7 +59,7 @@ class CarImageProcessor
     ): array {
         $carImages = null;
 
-        if (!is_null($imageData) && !empty($imageData)) {
+        if (!empty($imageData)) {
             $carImages = json_decode($imageData);
 
             if (is_null($carImages)) {
@@ -126,7 +126,7 @@ class CarImageProcessor
         }
 
         $currentImages = [];
-        if (!is_null($carData->image) && !empty($carData->image)) {
+        if (!empty($carData->image)) {
             $decoded = json_decode($carData->image);
             if ($decoded !== null) {
                 $currentImages = is_array($decoded) ? $decoded : [$decoded];
@@ -149,20 +149,20 @@ class CarImageProcessor
         }
 
         try {
-            $updateSuccess = $db->update('cars', $carData->id, ['image' => $imageJson]);
-
-            if ($updateSuccess) {
-                $carData->image = $imageJson;
-                return true;
-            } else {
-                throw new CarDatabaseException(CarErrorMessages::getAdminMessage('database_update_failed'));
-            }
-        } catch (CarDatabaseException $e) {
-            throw $e;
+            $updateSuccess = (new CarRepository($db))->updateImage((int) $carData->id, $imageJson);
         } catch (\Exception $e) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('image_remove_failed', ['error' => $e->getMessage()]);
             logger(0, LogCategories::LOG_CATEGORY_CAR_ACTIONS, $technicalMsg);
             throw new CarDatabaseException(CarErrorMessages::getMessage('image_remove_failed'));
         }
+
+        if ($updateSuccess) {
+            $carData->image = $imageJson;
+            return true;
+        }
+
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false: ' . $db->errorString()]);
+        logger(0, LogCategories::LOG_CATEGORY_CAR_ACTIONS, $technicalMsg);
+        throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }
 }

--- a/usersc/classes/Car/CarRepository.php
+++ b/usersc/classes/Car/CarRepository.php
@@ -142,6 +142,54 @@ class CarRepository
     }
 
     /**
+     * Update the verification code for a car
+     *
+     * @param int $carId Car ID
+     * @param string $verificationCode Verification code to set
+     * @return bool True on success
+     */
+    public function updateVerificationCode(int $carId, string $verificationCode): bool
+    {
+        return $this->update('cars', $carId, ['vericode' => $verificationCode]);
+    }
+
+    /**
+     * Update the last-verified timestamp for a car
+     *
+     * @param int $carId Car ID
+     * @param string $dateTime Datetime string in AppConstants::DATETIME_FORMAT
+     * @return bool True on success
+     */
+    public function updateLastVerified(int $carId, string $dateTime): bool
+    {
+        return $this->update('cars', $carId, ['last_verified' => $dateTime]);
+    }
+
+    /**
+     * Update the sold date for a car
+     *
+     * @param int $carId Car ID
+     * @param string $soldDate Date string in Y-m-d format
+     * @return bool True on success
+     */
+    public function updateSoldDate(int $carId, string $soldDate): bool
+    {
+        return $this->update('cars', $carId, ['solddate' => $soldDate]);
+    }
+
+    /**
+     * Update the image JSON for a car
+     *
+     * @param int $carId Car ID
+     * @param string $imageJson JSON-encoded image list (empty string clears all images)
+     * @return bool True on success
+     */
+    public function updateImage(int $carId, string $imageJson): bool
+    {
+        return $this->update('cars', $carId, ['image' => $imageJson]);
+    }
+
+    /**
      * Find a car by verification code
      *
      * @param string $code Verification code

--- a/usersc/classes/Car/CarVerificationManager.php
+++ b/usersc/classes/Car/CarVerificationManager.php
@@ -43,23 +43,21 @@ class CarVerificationManager
         }
 
         try {
-            $updateSuccess = $db->update('cars', $carData->id, ['vericode' => $verificationCode]);
-
-            if ($updateSuccess) {
-                $carData->vericode = $verificationCode;
-                return true;
-            } else {
-                $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false']);
-                logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
-                throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
-            }
-        } catch (CarDatabaseException $e) {
-            throw $e;
+            $updateSuccess = (new CarRepository($db))->updateVerificationCode((int) $carData->id, $verificationCode);
         } catch (\Exception $e) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('verification_code_failed', ['error' => $e->getMessage()]);
             logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
             throw new CarDatabaseException(CarErrorMessages::getMessage('verification_code_failed'));
         }
+
+        if ($updateSuccess) {
+            $carData->vericode = $verificationCode;
+            return true;
+        }
+
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false: ' . $db->errorString()]);
+        logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
+        throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }
 
     /**
@@ -72,25 +70,24 @@ class CarVerificationManager
      */
     public function markVerified(object $carData, DB $db): bool
     {
-        try {
-            $currentDateTime = date(AppConstants::DATETIME_FORMAT);
-            $updateSuccess = $db->update('cars', $carData->id, ['last_verified' => $currentDateTime]);
+        $currentDateTime = date(AppConstants::DATETIME_FORMAT);
 
-            if ($updateSuccess) {
-                $carData->last_verified = $currentDateTime;
-                return true;
-            } else {
-                $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false']);
-                logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
-                throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
-            }
-        } catch (CarDatabaseException $e) {
-            throw $e;
+        try {
+            $updateSuccess = (new CarRepository($db))->updateLastVerified((int) $carData->id, $currentDateTime);
         } catch (\Exception $e) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('verification_mark_failed', ['error' => $e->getMessage()]);
             logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
             throw new CarDatabaseException(CarErrorMessages::getMessage('verification_mark_failed'));
         }
+
+        if ($updateSuccess) {
+            $carData->last_verified = $currentDateTime;
+            return true;
+        }
+
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false: ' . $db->errorString()]);
+        logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
+        throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }
 
     /**
@@ -105,9 +102,7 @@ class CarVerificationManager
      */
     public function markSold(object $carData, ?string $soldDate, DB $db): bool
     {
-        if ($soldDate === null) {
-            $soldDate = date('Y-m-d');
-        }
+        $soldDate ??= date('Y-m-d');
 
         $parsedDate = DateTime::createFromFormat('Y-m-d', $soldDate);
         if (!$parsedDate || $parsedDate->format('Y-m-d') !== $soldDate) {
@@ -115,22 +110,20 @@ class CarVerificationManager
         }
 
         try {
-            $updateSuccess = $db->update('cars', $carData->id, ['solddate' => $soldDate]);
-
-            if ($updateSuccess) {
-                $carData->solddate = $soldDate;
-                return true;
-            } else {
-                $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false']);
-                logger(0, LogCategories::LOG_CATEGORY_CAR_SOLD, $technicalMsg);
-                throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
-            }
-        } catch (CarDatabaseException $e) {
-            throw $e;
+            $updateSuccess = (new CarRepository($db))->updateSoldDate((int) $carData->id, $soldDate);
         } catch (\Exception $e) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('sold_mark_failed', ['error' => $e->getMessage()]);
             logger(0, LogCategories::LOG_CATEGORY_CAR_SOLD, $technicalMsg);
             throw new CarDatabaseException(CarErrorMessages::getMessage('sold_mark_failed'));
         }
+
+        if ($updateSuccess) {
+            $carData->solddate = $soldDate;
+            return true;
+        }
+
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false: ' . $db->errorString()]);
+        logger(0, LogCategories::LOG_CATEGORY_CAR_SOLD, $technicalMsg);
+        throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }
 }

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -565,10 +565,10 @@ class ElanRegistryOwner
                 $historyFields['comments'] = "Car location synchronized with owner profile update. City: {$this->_data->city}, State: {$this->_data->state}, Country: {$this->_data->country}";
                 $historyFields['ctime'] = $locationFields['mtime'];
                 if (!$repo->insertHistory($historyFields)) {
-                    logger((int) $this->_data->id, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "syncLocationToCars: failed to insert history record for car ID {$car->id}: " . $this->_db->errorString());
+                    logger((int) $this->_data->id, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "syncLocationToCars: failed to insert history record for car ID {$car->id}: " . $repo->errorString());
                 }
             } else {
-                logger((int) $this->_data->id, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "syncLocationToCars: DB update returned false for car ID {$car->id}: " . $this->_db->errorString());
+                logger((int) $this->_data->id, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "syncLocationToCars: DB update returned false for car ID {$car->id}: " . $repo->errorString());
             }
         }
 

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\OwnerCreationException;
 use ElanRegistry\Exceptions\OwnerUpdateException;
 use ElanRegistry\Exceptions\OwnerValidationException;
@@ -551,8 +552,10 @@ class ElanRegistryOwner
             'mtime' => date(AppConstants::DATETIME_FORMAT)
         ];
 
+        $repo = new CarRepository($this->_db);
+
         foreach ($ownedCars as $car) {
-            if ($this->_db->update('cars', $car->id, $locationFields)) {
+            if ($repo->update('cars', (int) $car->id, $locationFields)) {
                 $carsUpdated++;
 
                 // Add history record for location sync
@@ -561,7 +564,11 @@ class ElanRegistryOwner
                 $historyFields['operation'] = 'LOCATION_SYNC';
                 $historyFields['comments'] = "Car location synchronized with owner profile update. City: {$this->_data->city}, State: {$this->_data->state}, Country: {$this->_data->country}";
                 $historyFields['ctime'] = $locationFields['mtime'];
-                $this->_db->insert('cars_hist', $historyFields);
+                if (!$repo->insertHistory($historyFields)) {
+                    logger((int) $this->_data->id, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "syncLocationToCars: failed to insert history record for car ID {$car->id}: " . $this->_db->errorString());
+                }
+            } else {
+                logger((int) $this->_data->id, LogCategories::LOG_CATEGORY_OWNER_ACTIONS, "syncLocationToCars: DB update returned false for car ID {$car->id}: " . $this->_db->errorString());
             }
         }
 


### PR DESCRIPTION
## Summary

- Removes no-op catch-rethrow blocks in `CarVerificationManager` (3 methods) and `CarImageProcessor::removeImage()`; restructures try/catch so only the repository call is wrapped
- Removes dead owner-cache block and orphaned `global $user` from `Car::__construct()`
- Adds four named update methods to `CarRepository`: `updateVerificationCode`, `updateLastVerified`, `updateSoldDate`, `updateImage`
- Routes all direct `$db->update('cars', ...)` calls in `CarVerificationManager`, `CarImageProcessor`, and `ElanRegistryOwner::syncLocationToCars()` through `CarRepository`
- Adds logging for false-return paths in the `syncLocationToCars()` loop and for failed `insertHistory()` calls; all false-return log messages now include `$db->errorString()` for diagnostics

## Test plan

- [ ] All 1008 unit tests pass (verified locally via pre-commit hook)
- [ ] PHPStan level 5 passes with no errors on all changed files
- [ ] Manual: mark a car as verified via verification email link → `last_verified` populated, `cars_hist` shows `UPDATE` + `VERIFIED` rows
- [ ] Manual: mark a car as sold via verification link → `solddate` populated, `cars_hist` shows `UPDATE` + `VERIFIED SOLD` rows
- [ ] Manual: remove a car image on the owner edit page → image absent from `cars.image` JSON, remaining images unaffected
- [ ] Manual: admin sync owner location to cars → `cars.lat`/`lon` updated, `cars_hist` shows `UPDATE` + `LOCATION_SYNC` rows per car
- [ ] Smoke test: car listing, details, and edit pages load without errors after `Car::__construct()` dead code removal

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM