### PR TITLE
refactor: extract car_models filter queries into CarRepository (#1064)

### DIFF
--- a/app/owner/cars/index.php
+++ b/app/owner/cars/index.php
@@ -10,17 +10,17 @@ declare(strict_types=1);
 require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
-use ElanRegistry\Documentation\DocumentPortalTemplate;
+use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Car\CarShowcaseService;
+use ElanRegistry\Documentation\DocumentPortalTemplate;
 
 // Security: Only allow access to authorized users
 if (!securePage($php_self)) {
   die();
 }
 
-$filterSeries   = $db->query("SELECT DISTINCT series_normalized AS series  FROM car_models WHERE series_normalized  IS NOT NULL AND series_normalized  != '' ORDER BY series_normalized")->results();
-$filterTypes    = $db->query("SELECT DISTINCT type_code         AS type   FROM car_models WHERE type_code          IS NOT NULL AND type_code          != '' ORDER BY type_code")->results();
-$filterVariants = $db->query("SELECT DISTINCT variant                      FROM car_models WHERE variant            IS NOT NULL AND variant            != '' ORDER BY variant")->results();
+['series' => $filterSeries, 'types' => $filterTypes, 'variants' => $filterVariants]
+    = (new CarRepository($db))->getFilterOptions();
 
 /**
  * Render a row of filter pills for a single DataTables column.

--- a/docs/releases/RELEASE_NOTES_v2.25.6.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.6.md
@@ -33,7 +33,7 @@
 
 - **manage-consolidated.php cleanup** ([#969](https://github.com/unibrain1/elanregistry/issues/969)): Duplicate stat queries consolidated into `getAdminSystemStatus()` helper; car merge path routed through CarRepository. WIP.
 
-- **car_models filter query extraction** ([#1064](https://github.com/unibrain1/elanregistry/issues/1064)): SELECT DISTINCT queries for car listing filter pills moved to CarRepository. WIP.
+- **car_models filter query extraction** ([#1064](https://github.com/unibrain1/elanregistry/issues/1064)): Three inline `SELECT DISTINCT` queries for car listing filter pills extracted from `cars/index.php` into `CarRepository::getFilterOptions()`. Page now calls one repository method instead of three raw queries.
 
 - **Admin AJAX rate limiting** ([#1141](https://github.com/unibrain1/elanregistry/issues/1141)): Rate limiting added to admin AJAX endpoints. WIP.
 

--- a/tests/unit/cars/services/CarRepositoryTest.php
+++ b/tests/unit/cars/services/CarRepositoryTest.php
@@ -105,4 +105,16 @@ final class CarRepositoryTest extends TestCase
         $result = $this->repo->updateImage(1, '["test.jpg"]');
         $this->assertTrue($result);
     }
+
+    public function testGetFilterOptionsReturnsCorrectShape(): void
+    {
+        $result = $this->repo->getFilterOptions();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('series', $result);
+        $this->assertArrayHasKey('types', $result);
+        $this->assertArrayHasKey('variants', $result);
+        $this->assertIsArray($result['series']);
+        $this->assertIsArray($result['types']);
+        $this->assertIsArray($result['variants']);
+    }
 }

--- a/usersc/classes/Car/CarRepository.php
+++ b/usersc/classes/Car/CarRepository.php
@@ -275,6 +275,45 @@ class CarRepository
     }
 
     /**
+     * Get distinct filter options from car_models for the car listing filter pills.
+     *
+     * Each sub-array contains objects whose property matches the SQL alias:
+     * 'series' elements expose ->series, 'types' elements expose ->type,
+     * and 'variants' elements expose ->variant.
+     *
+     * @return array{series: array<object>, types: array<object>, variants: array<object>}
+     */
+    public function getFilterOptions(): array
+    {
+        return [
+            'series'   => $this->distinctCarModelValues('series_normalized', 'series'),
+            'types'    => $this->distinctCarModelValues('type_code', 'type'),
+            'variants' => $this->distinctCarModelValues('variant'),
+        ];
+    }
+
+    /**
+     * Return distinct non-empty values for a single car_models column, ordered alphabetically.
+     *
+     * IMPORTANT: $column and $alias are interpolated directly into SQL without parameterisation.
+     * This is safe only because the method is private and every call site uses a string literal.
+     * Never pass values derived from request input or runtime configuration.
+     *
+     * @param string $column Database column name
+     * @param string $alias  Result property name; defaults to $column when omitted
+     * @return array<object>
+     */
+    private function distinctCarModelValues(string $column, string $alias = ''): array
+    {
+        $alias = $alias ?: $column;
+        return $this->db->query(
+            "SELECT DISTINCT {$column} AS {$alias} FROM car_models"
+            . " WHERE {$column} IS NOT NULL AND {$column} != ''"
+            . " ORDER BY {$column}"
+        )->results();
+    }
+
+    /**
      * Begin a database transaction
      *
      * @return void

--- a/usersc/classes/Car/CarRepository.php
+++ b/usersc/classes/Car/CarRepository.php
@@ -305,12 +305,16 @@ class CarRepository
      */
     private function distinctCarModelValues(string $column, string $alias = ''): array
     {
-        $alias = $alias ?: $column;
-        return $this->db->query(
+        $alias  = $alias ?: $column;
+        $result = $this->db->query(
             "SELECT DISTINCT {$column} AS {$alias} FROM car_models"
             . " WHERE {$column} IS NOT NULL AND {$column} != ''"
             . " ORDER BY {$column}"
-        )->results();
+        );
+        if ($this->db->error()) {
+            return [];
+        }
+        return $result->results();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds `CarRepository::getFilterOptions()` backed by a private `distinctCarModelValues()` helper
- Replaces three inline `SELECT DISTINCT` queries on `car_models` in `cars/index.php` with a single repository call
- Reduces raw SQL in page controllers; SQL is now co-located with the rest of the `car_models` access layer

## Test plan

- [x] 1020 unit tests pass (`composer test:quick`)
- [x] PHPStan clean on changed files
- [x] phpcs clean on changed files
- [x] Pre-commit hooks pass
- [x] Behavior preserved: all three SQL aliases (`series`, `type`, `variant`) match the property names consumed by `renderFilterRow()`

Closes #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM