### PR TITLE
fix: wrap car merge steps in a DB transaction (#1170)

### DIFF
--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarDeletionException;
+use ElanRegistry\Exceptions\CarMergeException;
 use ElanRegistry\Exceptions\CarNotFoundException;
 use ElanRegistry\Exceptions\CarPermissionException;
 use ElanRegistry\Input as ElanInput;
@@ -206,20 +207,32 @@ if (Input::exists('post')) {
                         $errors[] = 'Select 2 cars to merge';
                         break;
                     }
+
+                    $car1 = (int) $cars[0];
+                    $car2 = (int) $cars[1];
+                    if ($car1 <= 0 || $car2 <= 0) {
+                        $errors[] = 'Car IDs must be positive integers';
+                        break;
+                    }
+                    if ($car1 === $car2) {
+                        $errors[] = 'Cannot merge a car with itself';
+                        break;
+                    }
+
                     if (count($reason) <> 1) {
                         $errors[] = 'Select 1 reason code';
                         break;
                     } else {
-                        // Build the reason string
+                        // Assign old_car_id / new_car_id and build the audit comment based on reason code
                         switch ($reason[0]) {
                             case "duplicate":
                                 // Determine the newest car
-                                if ($cars[0] > $cars[1]) {
-                                    $new_car_id = $cars[0];
-                                    $old_car_id = $cars[1];
+                                if ($car1 > $car2) {
+                                    $new_car_id = $car1;
+                                    $old_car_id = $car2;
                                 } else {
-                                    $new_car_id = $cars[1];
-                                    $old_car_id = $cars[0];
+                                    $new_car_id = $car2;
+                                    $old_car_id = $car1;
                                 }
                                 $fields['comments'] = "Car $old_car_id is a duplicate of $new_car_id.  The history of $old_car_id has been merged with $new_car_id and $old_car_id deleted.";
                                 $fields['operation'] = "DUPLICATE";
@@ -227,60 +240,96 @@ if (Input::exists('post')) {
 
                             case "newownerNewToOld":
                                 // Determine the newest car
-                                if ($cars[0] > $cars[1]) {
-                                    $new_car_id = $cars[0];
-                                    $old_car_id = $cars[1];
+                                if ($car1 > $car2) {
+                                    $new_car_id = $car1;
+                                    $old_car_id = $car2;
                                 } else {
-                                    $new_car_id = $cars[1];
-                                    $old_car_id = $cars[0];
+                                    $new_car_id = $car2;
+                                    $old_car_id = $car1;
                                 }
                                 $fields['comments'] = "Car $old_car_id was sold to a new owner and the new owner created a record for the same car as $new_car_id. The history of $old_car_id has been merged with $new_car_id and $old_car_id deleted.";
                                 $fields['operation'] = "NEWOWNER";
                                 break;
 
                             case "newownerOldToNew":
-                                if ($cars[0] > $cars[1]) {
-                                    $new_car_id = $cars[1];
-                                    $old_car_id = $cars[0];
+                                // newownerOldToNew: the older (lower-ID) car record is kept as canonical
+                                if ($car1 > $car2) {
+                                    $new_car_id = $car2;
+                                    $old_car_id = $car1;
                                 } else {
-                                    $new_car_id = $cars[0];
-                                    $old_car_id = $cars[1];
+                                    $new_car_id = $car1;
+                                    $old_car_id = $car2;
                                 }
                                 $fields['comments'] = "Car $old_car_id was sold to a new owner and the new owner created a record for the same car as $new_car_id. The history of $old_car_id has been merged with $new_car_id and $old_car_id deleted.";
                                 $fields['operation'] = "NEWOWNER";
                                 break;
 
                             default:
-                                // This should never happen
-                                $fields['comments'] = "Car $old_car_id was merged with $new_car_id.  Car $old_car_id has been deleted.";
-                                $fields['operation'] = "DEFAULT";
+                                $errors[] = 'Invalid merge reason code.';
                                 break;
                         }
                     }
 
-                    // Merge the history
-                    $carRepo = new CarRepository($db);
-                    if (!$carRepo->transferHistory((int) $old_car_id, (int) $new_car_id)) {
-                        $errors[] = $db->errorString();
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_MERGE, "FAILED: Could not transfer history from CAR $old_car_id to CAR $new_car_id. DB: " . $db->errorString());
-                    } elseif (!$carRepo->deleteCarUser((int) $old_car_id)) {
-                        $errors[] = $db->errorString();
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_MERGE, "FAILED: Could not unassign owner from CAR $old_car_id during merge. DB: " . $db->errorString());
-                    } elseif (!$carRepo->deleteCar((int) $old_car_id)) {
-                        $errors[] = $db->errorString();
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_MERGE, "FAILED: Could not delete CAR $old_car_id after owner unassign. DB: " . $db->errorString());
-                    } else {
-                        // Add a record to the history with some information on the assignment
-                        $fields['car_id'] = $new_car_id;
-                        $fields['ctime'] = date(AppConstants::DATETIME_FORMAT);
-                        $fields['mtime'] = $fields['ctime'];
+                    if (!empty($errors)) {
+                        break;
+                    }
 
-                        if (!$carRepo->insertHistory($fields)) {
-                            logger($currentUserId, LogCategories::LOG_CATEGORY_DATABASE_ERROR, "WARNING: History insert failed after merging CAR $old_car_id to CAR $new_car_id — merge completed but audit record missing.");
+                    // Execute the merge transaction: transfer history, unlink owner, delete old car, write audit record
+                    $carRepo = new CarRepository($db);
+                    try {
+                        $carRepo->beginTransaction();
+                        if (!$carRepo->transferHistory((int) $old_car_id, (int) $new_car_id)) {
+                            throw new CarMergeException('transferHistory failed: ' . $carRepo->errorString());
+                        }
+                        if (!$carRepo->deleteCarUser((int) $old_car_id)) {
+                            throw new CarMergeException('deleteCarUser failed: ' . $carRepo->errorString());
+                        }
+                        if (!$carRepo->deleteCar((int) $old_car_id)) {
+                            throw new CarMergeException('deleteCar failed: ' . $carRepo->errorString());
                         }
 
+                        // Set up the audit record fields now that all structural steps succeeded
+                        $fields['car_id'] = $new_car_id;
+                        $fields['ctime']  = date(AppConstants::DATETIME_FORMAT);
+                        $fields['mtime']  = $fields['ctime'];
+
+                        // insertHistory is best-effort: an audit failure must not roll back the structural merge.
+                        // The inner try/catch prevents both false-returns and thrown Throwables from reaching
+                        // the outer catch, so commit() proceeds regardless. A successful insert is committed
+                        // atomically with the structural changes; a failed insert is logged and merge still succeeds.
+                        try {
+                            if (!$carRepo->insertHistory($fields)) {
+                                logger($currentUserId, LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                                    "WARNING: History insert failed after merging CAR $old_car_id to CAR $new_car_id — merge completed but audit record missing.");
+                            }
+                        } catch (\Throwable $insertEx) {
+                            logger($currentUserId, LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                                "WARNING: History insert threw after merging CAR $old_car_id to CAR $new_car_id — merge completed but audit record missing: " . $insertEx->getMessage());
+                        }
+
+                        $carRepo->commit();
                         $successes[] = $fields['comments'];
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_MERGE, $fields['comments']);
+                    } catch (CarMergeException $e) {
+                        try {
+                            $carRepo->rollback();
+                        } catch (\PDOException $rollbackEx) {
+                            logger($currentUserId, LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                                "CRITICAL: Rollback failed after car merge failure — DB may be inconsistent. " . $rollbackEx->getMessage());
+                        }
+                        $errors[] = 'Car merge failed and was rolled back. Check the admin log for details.';
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_MERGE,
+                            "FAILED: Car merge rolled back. " . $e->getMessage());
+                    } catch (\PDOException $e) {
+                        try {
+                            $carRepo->rollback();
+                        } catch (\PDOException $rollbackEx) {
+                            logger($currentUserId, LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                                "CRITICAL: Rollback failed after car merge database error — DB may be inconsistent. " . $rollbackEx->getMessage());
+                        }
+                        $errors[] = 'Car merge failed due to a database error and was rolled back. Check the admin log for details.';
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_MERGE,
+                            "FAILED: Car merge rolled back due to database error. " . $e->getMessage());
                     }
                     break;
 

--- a/docs/releases/RELEASE_NOTES_v2.25.6.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.6.md
@@ -35,6 +35,8 @@
 
 - **Admin dashboard cleanup** ([#969](https://github.com/unibrain1/elanregistry/issues/969)): Extracted duplicate `SELECT COUNT(*)` header queries from `admin/index.php` and `admin/maintenance.php` into a shared `getAdminSystemStatus()` helper in `custom_functions.php`. Routed the `action=merge` car-merge path in `admin/index.php` through the existing `CarRepository::transferHistory()`, `deleteCarUser()`, `deleteCar()`, and `insertHistory()` methods instead of four raw `$db` calls. Removed the defensive `$systemStatus` fallback from `tab-owner_mgmt.php` — the tab is only included from pages that populate `$systemStatus` upstream.
 
+- **Car merge atomicity** ([#1170](https://github.com/unibrain1/elanregistry/issues/1170)): The four-step car merge sequence in the admin panel is now wrapped in a database transaction. A failure at any structural step (transfer history, unassign owner, delete car) rolls back the entire operation, leaving the database unchanged. Previously, a failure midway would leave orphaned history rows pointing at the surviving car. Also added positive-integer and same-car guards on submitted car IDs.
+
 - **car_models filter query extraction** ([#1064](https://github.com/unibrain1/elanregistry/issues/1064)): Three inline `SELECT DISTINCT` queries for car listing filter pills extracted from `cars/index.php` into `CarRepository::getFilterOptions()`. Page now calls one repository method instead of three raw queries.
 
 ### Housekeeping
@@ -61,3 +63,4 @@
 - [#1066](https://github.com/unibrain1/elanregistry/issues/1066) — chore: remove abandoned spam/inactive user cleanup system
 - [#1141](https://github.com/unibrain1/elanregistry/issues/1141) — security: add per-user rate limiting to admin AJAX endpoints via requireAdminAjax()
 - [#1142](https://github.com/unibrain1/elanregistry/issues/1142) — security: require CSRF + add IP rate limiting to public statistics endpoint
+- [#1170](https://github.com/unibrain1/elanregistry/issues/1170) — fix: wrap car merge steps in a DB transaction to prevent partial-failure inconsistency

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\CarPermissionException;
 
 use PHPUnit\Framework\Attributes\Group;
@@ -236,5 +237,125 @@ final class CarMergeTest extends IntegrationTestCase
                 $GLOBALS['user'] = $originalUser;
             }
         }
+    }
+
+    /**
+     * Test that CarRepository::rollback() reverts all three merge steps when the
+     * admin page aborts a car merge midway through.
+     *
+     * WHY THIS TEST EXISTS: The admin car-merge page performs three DB steps inside a
+     * transaction — (1) transferHistory, (2) deleteCarUser, (3) deleteCar.  If a
+     * failure occurs after steps 1 and 2 but before step 3, rollback() must undo all
+     * completed steps so the database is left in a consistent state.  This test
+     * simulates that scenario by executing steps 1 and 2, then calling rollback()
+     * instead of proceeding to step 3, and asserting full state recovery.
+     */
+    #[Group('fast')]
+    public function testCarRepositoryTransactionRollbackPreservesCarAndOwnerAssignment(): void
+    {
+        if ($this->testCarId === null) {
+            $this->markTestSkipped('No test cars available');
+        }
+
+        // Seed a cars_hist row so transferHistory() has a real UPDATE to roll back.
+        // createTestCar() purges any stale hist rows, so the table starts empty.
+        $carRow = $this->db->query(
+            'SELECT * FROM cars WHERE id = ?',
+            [$this->testCarId]
+        )->first();
+
+        $histSeeded = $this->db->insert('cars_hist', [
+            'car_id'    => $this->testCarId,
+            'operation' => 'TEST',
+            'model'     => $carRow->model,
+            'series'    => $carRow->series,
+            'variant'   => $carRow->variant,
+            'year'      => $carRow->year,
+            'type'      => $carRow->type,
+            'chassis'   => $carRow->chassis,
+        ]);
+        $this->assertTrue($histSeeded, 'Precondition: should be able to seed a cars_hist row');
+
+        // Snapshot counts before the transaction
+        $carExistsBefore = $this->db->query(
+            'SELECT id FROM cars WHERE id = ?',
+            [$this->testCarId]
+        )->count();
+
+        $carUserCountBefore = $this->db->query(
+            'SELECT * FROM car_user WHERE car_id = ?',
+            [$this->testCarId]
+        )->count();
+
+        $histCountBefore = $this->db->query(
+            'SELECT * FROM cars_hist WHERE car_id = ?',
+            [$this->testCarId]
+        )->count();
+
+        $this->assertGreaterThan(0, $carExistsBefore, 'Precondition: test car must exist');
+        $this->assertGreaterThan(0, $carUserCountBefore, 'Precondition: car_user row must exist');
+        $this->assertGreaterThan(0, $histCountBefore, 'Precondition: cars_hist row must exist');
+
+        // Simulate a mid-merge abort: steps 1 and 2 run, but step 3 (deleteCar) never fires
+        $repo = new CarRepository($this->db);
+        $repo->beginTransaction();
+        $this->assertTrue(
+            $repo->transferHistory($this->testCarId, $this->testMergeCarId),
+            'Precondition: transferHistory must succeed within transaction'
+        );
+        // Mid-transaction: hist rows must now point to the merge target (visible within same connection)
+        $histMid = $this->db->query(
+            'SELECT * FROM cars_hist WHERE car_id = ?',
+            [$this->testMergeCarId]
+        )->count();
+        $this->assertGreaterThan(0, $histMid, 'mid-transaction: transferHistory must have moved hist rows to merge target');
+
+        $this->assertTrue(
+            $repo->deleteCarUser($this->testCarId),
+            'Precondition: deleteCarUser must succeed within transaction'
+        );
+        // Mid-transaction: car_user rows must be gone (visible within same connection)
+        $carUserMid = $this->db->query(
+            'SELECT * FROM car_user WHERE car_id = ?',
+            [$this->testCarId]
+        )->count();
+        $this->assertEquals(0, $carUserMid, 'mid-transaction: deleteCarUser must have removed car_user rows');
+
+        $repo->rollback();
+
+        // Assertions: every in-transaction change must be fully reverted
+
+        // 1. The cars row must still exist (was never touched, but confirms no side-effects)
+        $carExistsAfter = $this->db->query(
+            'SELECT id FROM cars WHERE id = ?',
+            [$this->testCarId]
+        )->count();
+        $this->assertEquals(
+            $carExistsBefore,
+            $carExistsAfter,
+            'cars row must survive rollback'
+        );
+
+        // 2. The car_user assignment must be restored (deleteCarUser was rolled back)
+        $carUserCountAfter = $this->db->query(
+            'SELECT * FROM car_user WHERE car_id = ?',
+            [$this->testCarId]
+        )->count();
+        $this->assertEquals(
+            $carUserCountBefore,
+            $carUserCountAfter,
+            'car_user rows must be restored after rollback'
+        );
+
+        // 3. The cars_hist rows must still belong to testCarId (transferHistory UPDATE was rolled back)
+        $histCountAfter = $this->db->query(
+            'SELECT * FROM cars_hist WHERE car_id = ?',
+            [$this->testCarId]
+        )->count();
+        $this->assertEquals(
+            $histCountBefore,
+            $histCountAfter,
+            'cars_hist rows must remain on testCarId after rollback'
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Wraps the four-step admin car-merge sequence (transfer history → unlink owner → delete car → insert audit record) in a DB transaction so any structural failure rolls back the entire operation
- Adds `PDOException` catch alongside `CarMergeException` so connection drops and deadlocks at `beginTransaction()`/`commit()` are handled gracefully
- Guards `rollback()` in both catch blocks against a thrown `PDOException` (failed rollback now logs CRITICAL instead of swallowing the upstream error)
- Changes inner best-effort catch from `\Exception` to `\Throwable` so PHP `Error` subclasses from `insertHistory` can't crash the request after a successful commit
- Adds `if (!empty($errors)) { break; }` guard before the transaction — the `default:` reason-code branch now sets an error instead of falling through with undefined car IDs
- Adds positive-integer and same-car guards on submitted car IDs
- Expands rollback integration test with mid-transaction assertions

## Test plan

- [x] `composer test:quick` — 983/983 unit tests pass
- [x] Pre-commit hooks pass (PHPStan no errors, phpcs no blocking issues)
- [ ] `composer test:medium` — integration tests including `testCarRepositoryTransactionRollbackPreservesCarAndOwnerAssignment` (requires MAMP)

## Bug escape analysis

The pre-existing `default:` branch referenced `$old_car_id`/`$new_car_id` before they were assigned (only set inside the three named reason-code branches). This was masked by the `// This should never happen` comment and the fact that the merge form only exposes the three named reasons — but POST input is not trusted. Now the `default:` branch sets `$errors[]` and the transaction is gated on `empty($errors)`.

Closes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM