### PR TITLE
chore: remove deprecated X-XSS-Protection header and ineffective cleanString() defense (#976)

### DIFF
--- a/app/admin/includes/process-car-details.php
+++ b/app/admin/includes/process-car-details.php
@@ -27,7 +27,7 @@ try {
     $carQ = $db->query("SELECT * FROM cars WHERE id = ?", [$carId]);
 
     if ($carQ->count() === 0) {
-        ApiResponse::error('Car not found', 200)
+        ApiResponse::notFound('Car not found')
             ->withLogging(
                 $user->data()->id,
                 LogCategories::LOG_CATEGORY_CAR_ERRORS,

--- a/app/api/contact/send-feedback.php
+++ b/app/api/contact/send-feedback.php
@@ -25,24 +25,6 @@ if (!securePage($php_self)) {
     die();
 }
 
-/**
- * Remove suspicious email-header keywords and link-injection substrings.
- *
- * Legacy defense-in-depth: email is sent via Brevo API (not raw SMTP), so
- * header injection is not a real risk. str_replace is bypassable by wrapping
- * the target (e.g. "ccontent-typeontent-type"), and silently mutates user text
- * that contains filtered substrings (e.g. "to:" in a sentence). Retained for
- * consistency with the original handler; do not expand its use.
- *
- * @param string $string Raw input
- * @return string String with email-header keywords and link-injection substrings removed
- */
-function cleanString(string $string): string
-{
-    $bad = array("content-type", "bcc:", "to:", "cc:", "href");
-    return str_replace($bad, "", $string);
-}
-
 $logUserId = ($user->isLoggedIn() && $user->data()) ? (int)$user->data()->id : 0;
 
 if (!Token::check(Input::get('csrf'))) {
@@ -77,14 +59,6 @@ if (strlen($comments) > 1000) {
 
 $emailTo = getFeedbackEmail();
 $emailSubject = '[ELANREGISTRY] Feedback';
-
-// Strip link-injection keywords from all values going into the email template.
-// Name, email, and id come from the session but are passed through as a
-// defense-in-depth measure consistent with the original form handler.
-$name = cleanString($name);
-$emailFrom = cleanString($emailFrom);
-$idFrom = cleanString($idFrom);
-$comments = cleanString($comments);
 
 $template = array(
     'name' => $name,

--- a/docs/releases/RELEASE_NOTES_v2.25.7.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.7.md
@@ -27,16 +27,21 @@
 - **Transfer approval is now atomic** ([#1175](https://github.com/unibrain1/elanregistry/issues/1175)): Car ownership transfer and request-status update are wrapped in a single transaction; if the status update fails (including TOCTOU "already processed"), the ownership change rolls back cleanly. As a side effect, the deny flow now also correctly returns an error when attempting to deny an already-processed request.
 - **Correct 404 for missing cars** ([#976](https://github.com/unibrain1/elanregistry/issues/976)): Admin car-details endpoint now returns HTTP 404 for missing cars instead of HTTP 200 with an error payload, improving error visibility.
 
+## Technical Changes
+
+- **Removed deprecated `X-XSS-Protection` header** ([#976](https://github.com/unibrain1/elanregistry/issues/976)): The header is ignored by all modern browsers (Chrome dropped it in v78, Firefox never implemented it) and implied XSS protection was being provided when it wasn't. The Content Security Policy header remains the correct mechanism and is unchanged.
+- **Removed ineffective `cleanString()` defense** ([#976](https://github.com/unibrain1/elanregistry/issues/976)): The feedback-form input filter (`str_replace` on `"content-type"`, `"bcc:"`, `"to:"`, `"cc:"`, `"href"`) was trivially bypassable (e.g. `"ccontent-typeontent-type"` passes through) and silently mutated legitimate user text. Email is sent via the Brevo API rather than raw SMTP header concatenation, so the header-injection vector it purported to block was never real.
+
 ## Issues Resolved
 
 - [#518](https://github.com/unibrain1/elanregistry/issues/518) — Migrate non-car endpoint logging to LogCategories constants
 - [#946](https://github.com/unibrain1/elanregistry/issues/946) — refactor: consolidate getSeriesCounts() into single conditional-aggregate query
 - [#960](https://github.com/unibrain1/elanregistry/issues/960) — refactor: eliminate boilerplate and duplicated field lists in exception classes and ElanRegistryOwner
-- [#976](https://github.com/unibrain1/elanregistry/issues/976) — chore: remove deprecated X-XSS-Protection header and ineffective cleanString() defense
+- [#976](https://github.com/unibrain1/elanregistry/issues/976) ✓ — chore: remove deprecated X-XSS-Protection header and ineffective cleanString() defense
 - [#1096](https://github.com/unibrain1/elanregistry/issues/1096) — fix: correct DataTable catch behavior in car_details.js and resolve npm vulnerability
 - [#1126](https://github.com/unibrain1/elanregistry/issues/1126) — enhancement: add cache-busting version parameter to static asset URLs
 - [#1127](https://github.com/unibrain1/elanregistry/issues/1127) — feat: maintenance script — report and delete unverified accounts with no car associations
 - [#1151](https://github.com/unibrain1/elanregistry/issues/1151) ✓ — chore: fix PHP 8.5 ReflectionProperty deprecations in test infrastructure and remove unreliable CarShowcaseService tests
-- [#1182](https://github.com/unibrain1/elanregistry/issues/1182) — test: migrate getNewCarIds() floor/tie-breaking tests to CarShowcaseServiceTest
+- [#1182](https://github.com/unibrain1/elanregistry/issues/1182) ✓ — test: migrate getNewCarIds() floor/tie-breaking tests to CarShowcaseServiceTest
 - [#1167](https://github.com/unibrain1/elanregistry/issues/1167) — fix: CarRepository::getHistory() returns null for empty history — should return []
 - [#1175](https://github.com/unibrain1/elanregistry/issues/1175) — fix: process-transfer-approve.php — wrap transfer + updateStatus in a shared transaction

--- a/tests/unit/security/SecurityHeadersTest.php
+++ b/tests/unit/security/SecurityHeadersTest.php
@@ -118,7 +118,6 @@ class SecurityHeadersTest extends TestCase
         $expectedHeaders = [
             'Content-Security-Policy',
             'X-Frame-Options',
-            'X-XSS-Protection',
             'X-Content-Type-Options',
             'Referrer-Policy',
         ];
@@ -130,6 +129,14 @@ class SecurityHeadersTest extends TestCase
                 "security_headers.php should set {$header} header"
             );
         }
+
+        // X-XSS-Protection was removed (#976): deprecated by all modern browsers,
+        // implies protection that isn't actually provided. CSP is the correct mechanism.
+        $this->assertStringNotContainsString(
+            'X-XSS-Protection',
+            $this->fileContent,
+            'security_headers.php must not set X-XSS-Protection (deprecated, removed in #976)'
+        );
     }
 
     /**

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -407,13 +407,6 @@ class LogCategoriesUsageTest extends TestCase
 
         $content = (string)file_get_contents($filePath);
 
-        // cleanString() must have a PHPDoc block
-        $this->assertMatchesRegularExpression(
-            '/\/\*\*.*?cleanString/s',
-            $content,
-            'send-feedback.php cleanString() must have a PHPDoc block (#600)'
-        );
-
         // logger() calls must not use hardcoded user ID 1
         $this->assertDoesNotMatchRegularExpression(
             '/\blogger\s*\(\s*1\s*,/',

--- a/usersc/includes/security_headers.php
+++ b/usersc/includes/security_headers.php
@@ -91,7 +91,7 @@ header("X-Content-Type-Options: nosniff");
 header("Referrer-Policy: no-referrer-when-downgrade");
 
 
-// 7. There is no direct security risk, but exposing an outdated (and possibly vulnerable) version of PHP may be an invitation for people to try and attack it.
+// 6. There is no direct security risk, but exposing an outdated (and possibly vulnerable) version of PHP may be an invitation for people to try and attack it.
 
 header_remove("X-Powered-By");
 

--- a/usersc/includes/security_headers.php
+++ b/usersc/includes/security_headers.php
@@ -69,22 +69,7 @@ header("X-Frame-Options: SAMEORIGIN");
 
 
 /*
-4. X-XSS-Protection
-
-The x-xss-protection header is designed to enable the cross-site scripting (XSS) filter built into modern web browsers. This is usually enabled by default, but using it will enforce it.
-
-The reflected-xss directive configures the built in heuristics a user agent has to filter or block reflected XSS attacks.
-
-    Allow - Allows reflected XSS attacks.
-    Block - Block reflected XSS attacks.
-    Filter - Filter the reflected XSS attack.
-*/
-
-header("X-XSS-Protection: 1; mode=block");
-
-
-/*
-5. X-Content-Type-Options
+4. X-Content-Type-Options
 
 The X-content-type header prevents Internet Explorer and Google Chrome from sniffing a response away from the declared content-type. This helps reduce the danger of drive-by downloads and helps treat the content the right way.
 X-Content-Type-Options header instructs IE not to sniff mime types, preventing attacks related to mime-sniffing.
@@ -94,7 +79,7 @@ header("X-Content-Type-Options: nosniff");
 
 
 /*
-6. The referrer directive specifies information for the referrer header in links away from the page.
+5. The referrer directive specifies information for the referrer header in links away from the page.
 
     No Referrer - Prevents the UA sending a referrer header.
     No Referrer When Downgrade - Prevents the UA sending a referrer header when navigating from https to http.


### PR DESCRIPTION
## Summary

- Removes the `X-XSS-Protection` header from `security_headers.php` — Chrome dropped it in v78 (2019), Firefox never implemented it. Its presence implied XSS protection that was not actually being provided. The Content-Security-Policy header remains in place and is the correct mechanism.
- Removes `cleanString()` from `send-feedback.php` — the `str_replace` filter was trivially bypassable (e.g. `"ccontent-typeontent-type"` passes through) and silently mutated legitimate user text. Email is sent via the Brevo REST API, not raw SMTP header concatenation, so the header-injection vector it purported to block was never real.
- Corrects `process-car-details.php` to return HTTP 404 (not HTTP 200 with `{success:false}`) when a car is not found. The frontend `ApiError` catch path handles non-2xx responses correctly.

## Test changes

- `SecurityHeadersTest`: removed `X-XSS-Protection` from the expected-headers list; added a negative assertion pinning its removal as intentional.
- `LogCategoriesUsageTest`: removed the `cleanString()` PHPDoc regex check (function no longer exists).

## Security review

Security review confirmed no vulnerabilities introduced (0 Critical, 0 High, 0 Medium, 0 Low). Key verification points:
- `cleanString()` callers: `$name`/`$emailFrom`/`$idFrom` come from the authenticated session (database-sourced), not POST. `$comments` goes into the email body only and is escaped by `EmailTemplate`. Brevo SDK serializes the `replyTo` field as structured JSON — no raw SMTP header string is ever constructed from user values.
- 404 on missing car: discloses nothing beyond the prior HTTP 200 error payload.

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM