### PR TITLE
fix: address all PR review findings before v2.25.7 → main merge

### DIFF
--- a/app/admin/includes/process-car-details.php
+++ b/app/admin/includes/process-car-details.php
@@ -60,7 +60,7 @@ try {
         ->withData('car', $carData)
         ->send();
 
-} catch (Exception $e) {
+} catch (\Throwable $e) {
     ApiResponse::serverError('Database error occurred')
         ->withLogging(
             $user->data()->id,

--- a/app/admin/includes/process-transfer-deny.php
+++ b/app/admin/includes/process-transfer-deny.php
@@ -87,7 +87,7 @@ try {
         ->send();
 
 } catch (CarTransferException $e) {
-    ApiResponse::error($e->getUserMessage(), 400)
+    ApiResponse::error($e->getUserMessage(), $e->getHttpStatusCode())
         ->withLogging(
             $user->data()->id,
             $e->getLogCategory(),

--- a/tests/integration/transfer/CarTransferWorkflowTest.php
+++ b/tests/integration/transfer/CarTransferWorkflowTest.php
@@ -509,7 +509,7 @@ class CarTransferWorkflowTest extends IntegrationTestCase
 
         // Step 2: simulate a failed car transfer by rolling back the outer transaction
         // (mirrors what the catch block in process-transfer-approve.php does when
-        // $car->transfer() throws or returns false).
+        // $car->transfer() throws).
         $this->db->rollBack();
 
         // The rollback must have reverted the status claim: the row is still 'pending'.

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -474,6 +474,31 @@ class LogCategoriesUsageTest extends TestCase
     }
 
     /**
+     * Regression test for Issue #976: process-car-details.php must return HTTP 404
+     * for missing cars, not HTTP 200 with an error payload.
+     */
+    public function testProcessCarDetailsUsesNotFoundForMissingCar(): void
+    {
+        $filePath = $this->rootDir . '/app/admin/includes/process-car-details.php';
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped('process-car-details.php not found');
+        }
+
+        $content = (string)file_get_contents($filePath);
+
+        $this->assertStringContainsString(
+            'ApiResponse::notFound(',
+            $content,
+            'process-car-details.php must use ApiResponse::notFound() for missing cars (#976)'
+        );
+        $this->assertStringNotContainsString(
+            "ApiResponse::error('Car not found', 200)",
+            $content,
+            'process-car-details.php must not return HTTP 200 for a missing car (#976)'
+        );
+    }
+
+    /**
      * Data provider for contact endpoint files
      */
     public static function contactEndpointFilesProvider(): array

--- a/usersc/classes/Car.php
+++ b/usersc/classes/Car.php
@@ -479,10 +479,12 @@ class Car
      * @param int $newUserId The user ID to transfer ownership to
      * @param string $reason Reason for transfer (for audit trail)
      * @param string $operationType Operation type for history
-     * @return bool True if transfer was successful
-     * @throws Exception If validation fails or database operation fails
+     * @return true Always returns true; throws on any failure.
+     * @throws CarNotFoundException If the car does not exist
+     * @throws CarPermissionException If the user is not authenticated
+     * @throws CarDatabaseException If a database operation fails
      */
-    public function transfer(int $newUserId, string $reason = 'Administrative transfer', string $operationType = 'NEWOWNER'): bool
+    public function transfer(int $newUserId, string $reason = 'Administrative transfer', string $operationType = 'NEWOWNER'): true
     {
         global $user;
 

--- a/usersc/classes/Car/CarAdministrationService.php
+++ b/usersc/classes/Car/CarAdministrationService.php
@@ -8,6 +8,7 @@ use AppConstants;
 use CarErrorMessages;
 use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarDeletionException;
+use ElanRegistry\Exceptions\CarException;
 use ElanRegistry\Exceptions\CarMergeException;
 use ElanRegistry\Exceptions\CarNotFoundException;
 use ElanRegistry\Exceptions\CarTransferException;
@@ -69,9 +70,9 @@ class CarAdministrationService
             logger($adminUserId, LogCategories::LOG_CATEGORY_CAR_DELETION, "Car ID $carId ($chassis) permanently deleted. Reason: $reason");
             return true;
 
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $repo->rollback();
-            if ($e instanceof CarDatabaseException || $e instanceof CarDeletionException) {
+            if ($e instanceof CarException) {
                 throw $e;
             }
             $technicalMsg = CarErrorMessages::getTechnicalMessage('operation_failed', ['operation' => 'Car deletion', 'error' => $e->getMessage()]);
@@ -91,7 +92,7 @@ class CarAdministrationService
      * @param CarRepository $repo Repository for database operations
      * @param callable $updateCallback Callback to perform car update (receives array of fields)
      * @param callable $refreshCallback Callback to refresh car data after update (receives car ID)
-     * @return bool True if transfer was successful
+     * @return true Always returns true; throws on any failure.
      * @throws CarValidationException If target user is invalid
      * @throws CarDatabaseException If database operation fails
      * @throws CarTransferException If transfer operation fails
@@ -105,7 +106,7 @@ class CarAdministrationService
         CarRepository $repo,
         callable $updateCallback,
         callable $refreshCallback
-    ): bool {
+    ): true {
         $targetUser = getUserWithProfile($newUserId);
         if (!$targetUser) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('user_not_found', ['user_id' => $newUserId]);
@@ -189,20 +190,20 @@ class CarAdministrationService
             $historyInserted = $repo->insertHistory($historyFields);
             if (!$historyInserted) {
                 $technicalMsg = CarErrorMessages::getTechnicalMessage('audit_trail_failed', ['operation' => $operationType]);
-                logger($adminUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER, $technicalMsg);
-                logger($adminUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER, 'Warning: Transfer completed but history record creation failed');
+                logger($adminUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, $technicalMsg);
+                throw new CarDatabaseException(CarErrorMessages::getAdminMessage('audit_trail_failed', ['operation' => $operationType]));
             }
 
             return true;
 
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $repo->rollback();
-            if ($e instanceof CarDatabaseException || $e instanceof CarValidationException || $e instanceof CarTransferException) {
+            if ($e instanceof CarException) {
                 throw $e;
             }
             $technicalMsg = CarErrorMessages::getTechnicalMessage('operation_failed', ['operation' => 'Car ownership transfer', 'error' => $e->getMessage()]);
             logger($adminUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER, $technicalMsg);
-            throw new CarTransferException(CarErrorMessages::getMessage('operation_failed', 'admin'));
+            throw new CarDatabaseException(CarErrorMessages::getMessage('operation_failed', 'admin'));
         }
     }
 
@@ -293,9 +294,9 @@ class CarAdministrationService
             $repo->commit();
             return true;
 
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $repo->rollback();
-            if ($e instanceof CarDatabaseException || $e instanceof CarNotFoundException || $e instanceof CarValidationException || $e instanceof CarMergeException) {
+            if ($e instanceof CarException) {
                 throw $e;
             }
             $technicalMsg = CarErrorMessages::getTechnicalMessage('operation_failed', ['operation' => 'Car merge', 'error' => $e->getMessage()]);

--- a/usersc/classes/Car/CarAdministrationService.php
+++ b/usersc/classes/Car/CarAdministrationService.php
@@ -95,7 +95,6 @@ class CarAdministrationService
      * @return true Always returns true; throws on any failure.
      * @throws CarValidationException If target user is invalid
      * @throws CarDatabaseException If database operation fails
-     * @throws CarTransferException If transfer operation fails
      */
     public function transfer(
         object $carData,
@@ -148,15 +147,13 @@ class CarAdministrationService
                 throw new CarDatabaseException(CarErrorMessages::getAdminMessage('car_relationship_failed'));
             }
 
-            $repo->commit();
-
-            // Refresh car data — in standalone mode this follows the commit above;
-            // when an outer transaction is active, $repo->commit() was a no-op and
-            // this reads uncommitted state within that outer transaction.
+            // Refresh car data within the transaction — InnoDB reads own uncommitted
+            // writes, so the refreshed fields reflect the update above in both
+            // standalone and outer-transaction mode.
             $refreshedData = $refreshCallback($carId);
 
-            // Create history record — committed atomically with the transfer when
-            // an outer transaction is active; otherwise runs in autocommit.
+            // Insert history before commit so a failure rolls back the entire
+            // ownership change atomically (standalone and outer-transaction alike).
             $historyFields = [
                 'operation' => $operationType,
                 'car_id' => $carId,
@@ -187,12 +184,13 @@ class CarAdministrationService
                 'website' => $targetUser->website ?? ''
             ];
 
-            $historyInserted = $repo->insertHistory($historyFields);
-            if (!$historyInserted) {
+            if (!$repo->insertHistory($historyFields)) {
                 $technicalMsg = CarErrorMessages::getTechnicalMessage('audit_trail_failed', ['operation' => $operationType]);
                 logger($adminUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, $technicalMsg);
                 throw new CarDatabaseException(CarErrorMessages::getAdminMessage('audit_trail_failed', ['operation' => $operationType]));
             }
+
+            $repo->commit();
 
             return true;
 

--- a/usersc/classes/Car/CarRepository.php
+++ b/usersc/classes/Car/CarRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ElanRegistry\Car;
 
 use DB;
+use LogCategories;
 
 /**
  * CarRepository - Database access layer for car operations
@@ -312,6 +313,7 @@ class CarRepository
             . " ORDER BY {$column}"
         );
         if ($this->db->error()) {
+            logger(0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, "CarRepository::distinctCarModelValues failed for column={$column}: " . $this->db->errorString());
             return [];
         }
         return $result->results();

--- a/usersc/classes/Exceptions/CarTransferException.php
+++ b/usersc/classes/Exceptions/CarTransferException.php
@@ -10,9 +10,10 @@ use Throwable;
 /**
  * CarTransferException
  *
- * Exception thrown when car ownership transfer operations fail.
- * Used during the car transfer workflow when database updates,
- * validation, or user permission checks fail.
+ * Exception thrown for car transfer conflicts — primarily concurrent-approval
+ * (TOCTOU) races where a second admin processes a request that another already
+ * claimed. Returns HTTP 409 Conflict. Validation failures use
+ * CarValidationException; database/infrastructure failures use CarDatabaseException.
  *
  * @package ElanRegistry
  * @subpackage Exceptions


### PR DESCRIPTION
## Summary

Addresses all 10 issues surfaced by the multi-agent `/review-pr` audit of `milestone/v2.25.7` before the final PR to `main`.

- **`process-transfer-deny.php`**: Use `$e->getHttpStatusCode()` instead of hardcoded `400` for the TOCTOU `CarTransferException` catch — same fix applied to approve handler in #1178
- **`CarAdministrationService`**: Audit trail failure now throws `CarDatabaseException` instead of silently returning `true`; all three `catch` blocks widened to `\Throwable` (catches PHP `\Error` subclasses in standalone transactions) and simplified to `instanceof CarException`
- **`CarAdministrationService`**: `operation_failed` catch-all now throws `CarDatabaseException` (was `CarTransferException`, incorrectly surfacing infrastructure failures as HTTP 409 Conflict)
- **`Car::transfer()` / `CarAdministrationService::transfer()`**: Return type narrowed to `true` (always returns true or throws); `@return` and `@throws` updated to reflect actual contract
- **`process-car-details.php`**: `catch (Exception)` → `catch (\Throwable)` to avoid PHP `\Error` bypassing the `ApiResponse` JSON format
- **`CarRepository::distinctCarModelValues()`**: Log DB errors before silent `return []` using `errorString()` for readable messages
- **`CarTransferException`**: PHPDoc updated to describe TOCTOU/409 Conflict role; removes incorrect "validation or permission failures" description
- **`CarTransferWorkflowTest`**: Remove stale "or returns false" comment — dead code path was removed in #1175
- **`LogCategoriesUsageTest`**: Regression guard added for #976 (prevents `process-car-details.php` from silently reverting to HTTP 200 for missing cars)

## Test plan

- [x] `composer test:quick` — 984/984 pass
- [x] Pre-commit hooks: PHPStan clean, phpcs no blocking issues
- [ ] CI: CodeQL, GitGuardian, Claude Code Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM