### PR TITLE
refactor: deduplicate exception constructors and ElanRegistryOwner profile field list (#960)

### DIFF
--- a/tests/unit/classes/ElanRegistryOwnerProfileTest.php
+++ b/tests/unit/classes/ElanRegistryOwnerProfileTest.php
@@ -84,6 +84,16 @@ final class ElanRegistryOwnerProfileTest extends TestCase
     }
 
     // -----------------------------------------------------------------------
+    // getProfileQualityScore() — instance method, delegates to qualityScoreFromRow()
+    // -----------------------------------------------------------------------
+
+    public function testNullDataQualityScoreReturnsZero(): void
+    {
+        $this->injectData(null);
+        $this->assertSame(0.0, $this->owner->getProfileQualityScore());
+    }
+
+    // -----------------------------------------------------------------------
     // qualityScoreFromRow() — public static, accepts plain stdClass
     // -----------------------------------------------------------------------
 

--- a/tests/unit/classes/ElanRegistryOwnerProfileTest.php
+++ b/tests/unit/classes/ElanRegistryOwnerProfileTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Unit tests for ElanRegistryOwner::qualityScoreFromRow() and
+ * ElanRegistryOwner::validateProfileCompleteness()
+ *
+ * Regression guard for issue #960: both methods iterate the shared private
+ * constant PROFILE_SIMPLE_FIELD_LABELS. A typo in any key (e.g. 'fname' →
+ * 'firstname') would silently break scoring and completeness checks. The
+ * per-field tests below catch that class of regression without touching the
+ * constant directly.
+ *
+ * Scoring formula: round(($completed / 7) * 100, 1)
+ *   - 6 simple fields: fname, lname, email, city, state, country (1 pt each)
+ *   - lat AND lon together (1 pt combined)
+ *
+ * @see https://github.com/unibrain1/elanregistry/issues/960
+ */
+#[Group('fast')]
+#[Group('unit')]
+final class ElanRegistryOwnerProfileTest extends TestCase
+{
+    private \ElanRegistryOwner $owner;
+    private \ReflectionProperty $dataProp;
+
+    protected function setUp(): void
+    {
+        $this->owner    = new \ElanRegistryOwner();
+        $ref            = new \ReflectionClass(\ElanRegistryOwner::class);
+        $this->dataProp = $ref->getProperty('_data');
+        // PHP 8.1+: setAccessible() is a no-op; ReflectionProperty accesses
+        // private members directly via setValue()/getValue().
+    }
+
+    // -----------------------------------------------------------------------
+    // Shared helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * A row with every scoring field populated (score = 7/7 = 100.0).
+     */
+    private function fullRow(): object
+    {
+        return (object) [
+            'fname'   => 'Jim',
+            'lname'   => 'Boone',
+            'email'   => 'jim@example.com',
+            'city'    => 'Portland',
+            'state'   => 'OR',
+            'country' => 'USA',
+            'lat'     => '45.5231',
+            'lon'     => '-122.6765',
+        ];
+    }
+
+    /**
+     * A row with every scoring field blank (score = 0/7 = 0.0).
+     */
+    private function emptyRow(): object
+    {
+        return (object) [
+            'fname'   => '',
+            'lname'   => '',
+            'email'   => '',
+            'city'    => '',
+            'state'   => '',
+            'country' => '',
+            'lat'     => '',
+            'lon'     => '',
+        ];
+    }
+
+    /**
+     * Inject a value into the private $_data property of $this->owner.
+     */
+    private function injectData(?object $data): void
+    {
+        $this->dataProp->setValue($this->owner, $data);
+    }
+
+    // -----------------------------------------------------------------------
+    // qualityScoreFromRow() — public static, accepts plain stdClass
+    // -----------------------------------------------------------------------
+
+    public function testAllFieldsPopulatedScores100(): void
+    {
+        $this->assertSame(100.0, \ElanRegistryOwner::qualityScoreFromRow($this->fullRow()));
+    }
+
+    public function testNoFieldsPopulatedScores0(): void
+    {
+        $this->assertSame(0.0, \ElanRegistryOwner::qualityScoreFromRow($this->emptyRow()));
+    }
+
+    /**
+     * Only lat + lon set → 1 point → round(1/7 * 100, 1) = 14.3
+     */
+    public function testOnlyLatLonScores14point3(): void
+    {
+        $row      = $this->emptyRow();
+        $row->lat = '45.5231';
+        $row->lon = '-122.6765';
+
+        $this->assertSame(14.3, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    /**
+     * All 6 simple fields set, no coordinates → 6 points → round(6/7 * 100, 1) = 85.7
+     */
+    public function testAllSimpleFieldsButNoCoordinatesScores85point7(): void
+    {
+        $row      = $this->fullRow();
+        $row->lat = '';
+        $row->lon = '';
+
+        $this->assertSame(85.7, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    // Per-field regression tests — catch PROFILE_SIMPLE_FIELD_LABELS key typos.
+    // Each test sets exactly one simple field and leaves everything else blank.
+    // Expected: 1/7 * 100 rounded to 1 decimal = 14.3.
+
+    public function testOnlyFnameScores14point3(): void
+    {
+        $row        = $this->emptyRow();
+        $row->fname = 'Jim';
+
+        $this->assertSame(14.3, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    public function testOnlyLnameScores14point3(): void
+    {
+        $row        = $this->emptyRow();
+        $row->lname = 'Boone';
+
+        $this->assertSame(14.3, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    public function testOnlyEmailScores14point3(): void
+    {
+        $row        = $this->emptyRow();
+        $row->email = 'jim@example.com';
+
+        $this->assertSame(14.3, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    public function testOnlyCityScores14point3(): void
+    {
+        $row       = $this->emptyRow();
+        $row->city = 'Portland';
+
+        $this->assertSame(14.3, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    public function testOnlyStateScores14point3(): void
+    {
+        $row        = $this->emptyRow();
+        $row->state = 'OR';
+
+        $this->assertSame(14.3, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    public function testOnlyCountryScores14point3(): void
+    {
+        $row          = $this->emptyRow();
+        $row->country = 'USA';
+
+        $this->assertSame(14.3, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    /**
+     * lat set but lon empty → AND condition fails → 0 points → 0.0
+     * Confirms that a partial coordinate pair does not score.
+     */
+    public function testLatWithoutLonDoesNotScore(): void
+    {
+        $row      = $this->emptyRow();
+        $row->lat = '45.5231';
+
+        $this->assertSame(0.0, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    /**
+     * lon set but lat empty → AND condition fails → 0 points → 0.0
+     */
+    public function testLonWithoutLatDoesNotScore(): void
+    {
+        $row      = $this->emptyRow();
+        $row->lon = '-122.6765';
+
+        $this->assertSame(0.0, \ElanRegistryOwner::qualityScoreFromRow($row));
+    }
+
+    // -----------------------------------------------------------------------
+    // validateProfileCompleteness() — instance method, $_data injected via Reflection
+    // -----------------------------------------------------------------------
+
+    public function testNullDataReturnsLoadedMessage(): void
+    {
+        $this->injectData(null);
+
+        $this->assertSame(['Owner data not loaded'], $this->owner->validateProfileCompleteness());
+    }
+
+    public function testAllFieldsPopulatedReturnsEmpty(): void
+    {
+        $this->injectData($this->fullRow());
+
+        $this->assertSame([], $this->owner->validateProfileCompleteness());
+    }
+
+    public function testMissingFnameReturnsFirstName(): void
+    {
+        $data        = $this->fullRow();
+        $data->fname = '';
+        $this->injectData($data);
+
+        $this->assertContains('First Name', $this->owner->validateProfileCompleteness());
+    }
+
+    public function testMissingLnameReturnsLastName(): void
+    {
+        $data        = $this->fullRow();
+        $data->lname = '';
+        $this->injectData($data);
+
+        $this->assertContains('Last Name', $this->owner->validateProfileCompleteness());
+    }
+
+    public function testMissingEmailReturnsEmail(): void
+    {
+        $data        = $this->fullRow();
+        $data->email = '';
+        $this->injectData($data);
+
+        $this->assertContains('Email', $this->owner->validateProfileCompleteness());
+    }
+
+    public function testMissingCityReturnsCity(): void
+    {
+        $data       = $this->fullRow();
+        $data->city = '';
+        $this->injectData($data);
+
+        $this->assertContains('City', $this->owner->validateProfileCompleteness());
+    }
+
+    public function testMissingStateReturnsState(): void
+    {
+        $data        = $this->fullRow();
+        $data->state = '';
+        $this->injectData($data);
+
+        $this->assertContains('State', $this->owner->validateProfileCompleteness());
+    }
+
+    public function testMissingCountryReturnsCountry(): void
+    {
+        $data          = $this->fullRow();
+        $data->country = '';
+        $this->injectData($data);
+
+        $this->assertContains('Country', $this->owner->validateProfileCompleteness());
+    }
+
+    /**
+     * lat missing, lon present → OR condition true → 'Location Coordinates' added.
+     */
+    public function testMissingLatReturnsLocationCoordinates(): void
+    {
+        $data      = $this->fullRow();
+        $data->lat = '';
+        $this->injectData($data);
+
+        $this->assertContains('Location Coordinates', $this->owner->validateProfileCompleteness());
+    }
+
+    /**
+     * lon missing, lat present → OR condition true → 'Location Coordinates' added.
+     */
+    public function testMissingLonReturnsLocationCoordinates(): void
+    {
+        $data      = $this->fullRow();
+        $data->lon = '';
+        $this->injectData($data);
+
+        $this->assertContains('Location Coordinates', $this->owner->validateProfileCompleteness());
+    }
+
+    /**
+     * Multiple fields missing → all corresponding labels returned.
+     */
+    public function testMultipleMissingFieldsReturnsAllLabels(): void
+    {
+        $data        = $this->fullRow();
+        $data->fname = '';
+        $data->email = '';
+        $data->lat   = '';
+        $this->injectData($data);
+
+        $missing = $this->owner->validateProfileCompleteness();
+
+        $this->assertContains('First Name', $missing);
+        $this->assertContains('Email', $missing);
+        $this->assertContains('Location Coordinates', $missing);
+    }
+
+    /**
+     * All fields missing → result order must match PROFILE_SIMPLE_FIELD_LABELS
+     * declaration order (fname → lname → email → city → state → country) with
+     * 'Location Coordinates' appended last.
+     */
+    public function testReturnOrderMatchesFieldOrder(): void
+    {
+        $this->injectData($this->emptyRow());
+
+        $this->assertSame(
+            ['First Name', 'Last Name', 'Email', 'City', 'State', 'Country', 'Location Coordinates'],
+            $this->owner->validateProfileCompleteness()
+        );
+    }
+}

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -341,8 +341,10 @@ class ElanRegistryOwner
      * Accepts a raw DB row object so batch loops can score many owners without
      * constructing a full ElanRegistryOwner for each one.
      *
-     * @param object $row DB row with owner fields: fname, lname, email, city, state, country
-     *                    (1 point each) and lat+lon (1 point combined, 7 points total)
+     * @param object $row DB row — must include all PROFILE_SIMPLE_FIELD_LABELS columns
+     *                    (fname, lname, email, city, state, country) plus lat and lon.
+     *                    Missing properties are treated as empty (score 0 for that field).
+     *                    (1 point each for simple fields; lat+lon together count as 1 combined point, 7 points total)
      * @return float Score 0–100
      */
     public static function qualityScoreFromRow(object $row): float

--- a/usersc/classes/ElanRegistryOwner.php
+++ b/usersc/classes/ElanRegistryOwner.php
@@ -20,6 +20,16 @@ use ElanRegistry\Exceptions\OwnerValidationException;
 
 class ElanRegistryOwner
 {
+    /** Maps DB column → display label for simple profile completeness fields (lat/lon handled separately). */
+    private const PROFILE_SIMPLE_FIELD_LABELS = [
+        'fname'   => 'First Name',
+        'lname'   => 'Last Name',
+        'email'   => 'Email',
+        'city'    => 'City',
+        'state'   => 'State',
+        'country' => 'Country',
+    ];
+
     private $_db;
     private $_data;
     private $userTableName = 'users';
@@ -331,19 +341,21 @@ class ElanRegistryOwner
      * Accepts a raw DB row object so batch loops can score many owners without
      * constructing a full ElanRegistryOwner for each one.
      *
-     * @param object $row DB row with owner fields (fname, lname, email, city, state, country, lat, lon)
+     * @param object $row DB row with owner fields: fname, lname, email, city, state, country
+     *                    (1 point each) and lat+lon (1 point combined, 7 points total)
      * @return float Score 0–100
      */
     public static function qualityScoreFromRow(object $row): float
     {
         $completed = 0;
-        if (!empty($row->fname)) $completed++;
-        if (!empty($row->lname)) $completed++;
-        if (!empty($row->email)) $completed++;
-        if (!empty($row->city)) $completed++;
-        if (!empty($row->state)) $completed++;
-        if (!empty($row->country)) $completed++;
-        if (!empty($row->lat) && !empty($row->lon)) $completed++;
+        foreach (array_keys(self::PROFILE_SIMPLE_FIELD_LABELS) as $field) {
+            if (!empty($row->$field)) {
+                $completed++;
+            }
+        }
+        if (!empty($row->lat) && !empty($row->lon)) {
+            $completed++;
+        }
         return round(($completed / 7) * 100, 1);
     }
 
@@ -367,7 +379,7 @@ class ElanRegistryOwner
     /**
      * Validate profile completeness and return missing fields
      *
-     * @return array Array of missing or incomplete field names
+     * @return array<string> Human-readable labels for missing profile fields (e.g. 'First Name', 'Location Coordinates')
      */
     public function validateProfileCompleteness(): array
     {
@@ -377,13 +389,14 @@ class ElanRegistryOwner
             return ['Owner data not loaded'];
         }
 
-        if (empty($this->_data->fname)) $missingFields[] = 'First Name';
-        if (empty($this->_data->lname)) $missingFields[] = 'Last Name';
-        if (empty($this->_data->email)) $missingFields[] = 'Email';
-        if (empty($this->_data->city)) $missingFields[] = 'City';
-        if (empty($this->_data->state)) $missingFields[] = 'State';
-        if (empty($this->_data->country)) $missingFields[] = 'Country';
-        if (empty($this->_data->lat) || empty($this->_data->lon)) $missingFields[] = 'Location Coordinates';
+        foreach (self::PROFILE_SIMPLE_FIELD_LABELS as $field => $label) {
+            if (empty($this->_data->$field)) {
+                $missingFields[] = $label;
+            }
+        }
+        if (empty($this->_data->lat) || empty($this->_data->lon)) {
+            $missingFields[] = 'Location Coordinates';
+        }
 
         return $missingFields;
     }

--- a/usersc/classes/Exceptions/AdminContactException.php
+++ b/usersc/classes/Exceptions/AdminContactException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * AdminContactException
@@ -21,23 +20,6 @@ use Throwable;
 class AdminContactException extends ElanRegistryException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class AdminContactException extends ElanRegistryException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_CAR_ACTIONS;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/AdminOperationException.php
+++ b/usersc/classes/Exceptions/AdminOperationException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * AdminOperationException
@@ -21,23 +20,6 @@ use Throwable;
 class AdminOperationException extends ElanRegistryException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class AdminOperationException extends ElanRegistryException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_SYSTEM_ERROR;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/BackupException.php
+++ b/usersc/classes/Exceptions/BackupException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * BackupException
@@ -20,23 +19,6 @@ use Throwable;
 class BackupException extends ElanRegistryException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -50,13 +32,5 @@ class BackupException extends ElanRegistryException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_BACKUP_ERROR;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/CarCreationException.php
+++ b/usersc/classes/Exceptions/CarCreationException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * CarCreationException
@@ -21,23 +20,6 @@ use Throwable;
 class CarCreationException extends CarException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class CarCreationException extends CarException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_CAR_CREATION;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/CarDatabaseException.php
+++ b/usersc/classes/Exceptions/CarDatabaseException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * CarDatabaseException
@@ -21,23 +20,6 @@ use Throwable;
 class CarDatabaseException extends CarException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class CarDatabaseException extends CarException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_DATABASE_ERROR;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/CarDeletionException.php
+++ b/usersc/classes/Exceptions/CarDeletionException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * CarDeletionException
@@ -21,23 +20,6 @@ use Throwable;
 class CarDeletionException extends CarException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class CarDeletionException extends CarException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_CAR_DELETION;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/CarException.php
+++ b/usersc/classes/Exceptions/CarException.php
@@ -35,12 +35,4 @@ abstract class CarException extends ElanRegistryException
     {
         return LogCategories::LOG_CATEGORY_CAR_ERRORS;
     }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
-    }
 }

--- a/usersc/classes/Exceptions/CarMergeException.php
+++ b/usersc/classes/Exceptions/CarMergeException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * CarMergeException
@@ -21,23 +20,6 @@ use Throwable;
 class CarMergeException extends CarException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class CarMergeException extends CarException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_CAR_MERGE;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/CarNotFoundException.php
+++ b/usersc/classes/Exceptions/CarNotFoundException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * CarNotFoundException
@@ -20,23 +19,6 @@ use Throwable;
  */
 class CarNotFoundException extends CarException
 {
-    /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
     /**
      * @inheritDoc
      */

--- a/usersc/classes/Exceptions/CarPermissionException.php
+++ b/usersc/classes/Exceptions/CarPermissionException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * CarPermissionException
@@ -19,23 +18,6 @@ use Throwable;
  */
 class CarPermissionException extends CarException
 {
-    /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
     /**
      * @inheritDoc
      */

--- a/usersc/classes/Exceptions/CarTransferException.php
+++ b/usersc/classes/Exceptions/CarTransferException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * CarTransferException
@@ -21,23 +20,6 @@ use Throwable;
  */
 class CarTransferException extends CarException
 {
-    /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
     /**
      * @inheritDoc
      */

--- a/usersc/classes/Exceptions/ImageProcessingException.php
+++ b/usersc/classes/Exceptions/ImageProcessingException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * ImageProcessingException
@@ -21,23 +20,6 @@ use Throwable;
 class ImageProcessingException extends ElanRegistryException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class ImageProcessingException extends ElanRegistryException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_FILE_ERROR;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/LocationServiceException.php
+++ b/usersc/classes/Exceptions/LocationServiceException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ElanRegistry\Exceptions;
 
-use Throwable;
-
 /**
  * LocationServiceException
  *
@@ -18,23 +16,6 @@ use Throwable;
  */
 class LocationServiceException extends ElanRegistryException
 {
-    /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
     /**
      * @inheritDoc
      */
@@ -49,13 +30,5 @@ class LocationServiceException extends ElanRegistryException
     protected static function getDefaultLogCategory(): string
     {
         return 'SystemError';
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/OwnerCreationException.php
+++ b/usersc/classes/Exceptions/OwnerCreationException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * OwnerCreationException
@@ -21,23 +20,6 @@ use Throwable;
 class OwnerCreationException extends ElanRegistryException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class OwnerCreationException extends ElanRegistryException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_OWNER_ACTIONS;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/OwnerNotFoundException.php
+++ b/usersc/classes/Exceptions/OwnerNotFoundException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * OwnerNotFoundException
@@ -20,23 +19,6 @@ use Throwable;
  */
 class OwnerNotFoundException extends ElanRegistryException
 {
-    /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
     /**
      * @inheritDoc
      */

--- a/usersc/classes/Exceptions/OwnerSearchException.php
+++ b/usersc/classes/Exceptions/OwnerSearchException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * OwnerSearchException
@@ -21,23 +20,6 @@ use Throwable;
 class OwnerSearchException extends ElanRegistryException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class OwnerSearchException extends ElanRegistryException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_OWNER_ACTIONS;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/OwnerUpdateException.php
+++ b/usersc/classes/Exceptions/OwnerUpdateException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * OwnerUpdateException
@@ -21,23 +20,6 @@ use Throwable;
 class OwnerUpdateException extends ElanRegistryException
 {
     /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
-    /**
      * @inheritDoc
      */
     protected static function getDefaultUserMessage(): string
@@ -51,13 +33,5 @@ class OwnerUpdateException extends ElanRegistryException
     protected static function getDefaultLogCategory(): string
     {
         return LogCategories::LOG_CATEGORY_OWNER_ACTIONS;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected static function getDefaultHttpStatusCode(): int
-    {
-        return 500;
     }
 }

--- a/usersc/classes/Exceptions/OwnerValidationException.php
+++ b/usersc/classes/Exceptions/OwnerValidationException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Exceptions;
 
 use LogCategories;
-use Throwable;
 
 /**
  * OwnerValidationException
@@ -20,23 +19,6 @@ use Throwable;
  */
 class OwnerValidationException extends ElanRegistryException
 {
-    /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
     /**
      * @inheritDoc
      */

--- a/usersc/classes/Exceptions/ValidationException.php
+++ b/usersc/classes/Exceptions/ValidationException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ElanRegistry\Exceptions;
 
-use Throwable;
-
 /**
  * ValidationException
  *
@@ -19,23 +17,6 @@ use Throwable;
  */
 class ValidationException extends ElanRegistryException
 {
-    /**
-     * Constructor
-     *
-     * @param string $message Exception message
-     * @param int $code Exception code (optional)
-     * @param Throwable|null $previous Previous exception for chaining (optional)
-     * @param string|null $userMessage User-friendly message (uses default if null)
-     */
-    public function __construct(
-        string $message = "",
-        int $code = 0,
-        ?Throwable $previous = null,
-        ?string $userMessage = null
-    ) {
-        parent::__construct($message, $code, $previous, $userMessage);
-    }
-
     /**
      * @inheritDoc
      */


### PR DESCRIPTION
## Summary

- **Exception hierarchy cleanup**: Removes 18 pass-through constructors (and their now-unused `use Throwable;` imports) from leaf exception classes. Also removes 13 redundant `getDefaultHttpStatusCode(): int { return 500; }` overrides (12 leaf + `CarException` abstract) since `ElanRegistryException` already defaults to 500. Non-500 overrides (403, 404, 409, 422) are preserved in 7 classes.
- **ElanRegistryOwner field deduplication**: Extracts a `PROFILE_SIMPLE_FIELD_LABELS` private constant (`field => 'Display Label'`) shared by `qualityScoreFromRow()` and `validateProfileCompleteness()`, eliminating duplicated field lists and creating a single point of maintenance.
- **Tests**: Adds 20 unit tests for the two refactored `ElanRegistryOwner` methods, including per-field key-typo regression guards.

## Test plan

- [x] Pre-commit hooks pass: coding standards, PHPStan, 1008 unit tests — all green
- [x] `ExceptionHierarchyTest` verifies constructor compatibility, HTTP status codes, and exception chaining after removals
- [x] `ElanRegistryOwnerProfileTest` (new, 20 tests): covers all scoring combinations, per-field guards, AND vs OR lat/lon semantics, and label order for `validateProfileCompleteness()`

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM