### PR TITLE
feat: add cache-busting version parameter to all first-party static assets (#1126)

### DIFF
--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -821,16 +821,16 @@ if (Input::exists('post')) {
 <?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>
 
 <!-- Location Picker Styles -->
-<link rel="stylesheet" href="<?=$us_url_root?>app/assets/css/location-picker.min.css">
+<link rel="stylesheet" href="<?=$us_url_root?>app/assets/css/location-picker.min.css?v=<?= ASSET_VERSION ?>">
 
 <!-- Location Picker Script -->
-<script src="<?=$us_url_root?>app/assets/js/location-picker.min.js"></script>
+<script src="<?=$us_url_root?>app/assets/js/location-picker.min.js?v=<?= ASSET_VERSION ?>"></script>
 
 <!-- Include custom CSS and JavaScript -->
-<link rel="stylesheet" href="assets/manage-consolidated.min.css">
+<link rel="stylesheet" href="assets/manage-consolidated.min.css?v=<?= ASSET_VERSION ?>">
 <script>
     window.elanUrlRoot = '<?= $us_url_root ?>';
     // Make CSRF token available to ElanRegistryAPI client
     document.documentElement.setAttribute('data-csrf-token', '<?= $csrfToken ?>');
 </script>
-<script src="assets/manage-consolidated.min.js"></script>
+<script src="assets/manage-consolidated.min.js?v=<?= ASSET_VERSION ?>"></script>

--- a/app/admin/maintenance.php
+++ b/app/admin/maintenance.php
@@ -188,12 +188,12 @@ try {
 
 <?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>
 
-<link rel="stylesheet" href="assets/manage-consolidated.min.css">
+<link rel="stylesheet" href="assets/manage-consolidated.min.css?v=<?= ASSET_VERSION ?>">
 <script>
     window.elanUrlRoot = '<?= $us_url_root ?>';
     // Make CSRF token available to ElanRegistryAPI client
     document.documentElement.setAttribute('data-csrf-token', '<?= $csrfToken ?>');
 </script>
-<script src="assets/manage-consolidated.min.js"></script>
-<script src="assets/backup-operations.min.js"></script>
+<script src="assets/manage-consolidated.min.js?v=<?= ASSET_VERSION ?>"></script>
+<script src="assets/backup-operations.min.js?v=<?= ASSET_VERSION ?>"></script>
 

--- a/app/owner/cars/details.php
+++ b/app/owner/cars/details.php
@@ -466,8 +466,8 @@ window.ELAN_CONFIG = {
     RESPONSIVE_SIZE: <?php echo $responsiveSize; ?>
 };
 </script>
-<script src='<?= $us_url_root ?>app/assets/js/imagedisplay.min.js'></script>
-<script src='<?= $us_url_root ?>app/assets/js/highlightDifferences.min.js'></script>
+<script src='<?= $us_url_root ?>app/assets/js/imagedisplay.min.js?v=<?= ASSET_VERSION ?>'></script>
+<script src='<?= $us_url_root ?>app/assets/js/highlightDifferences.min.js?v=<?= ASSET_VERSION ?>'></script>
 <script>
 const img_root = <?= json_encode($us_url_root . ($settings->elan_image_dir ?? '')) ?>;
 window.carDetailsConfig = {
@@ -476,7 +476,7 @@ window.carDetailsConfig = {
     urlRoot: '<?= $us_url_root ?>'
 };
 </script>
-<script src='<?= $us_url_root ?>app/assets/js/car_details.min.js'></script>
+<script src='<?= $us_url_root ?>app/assets/js/car_details.min.js?v=<?= ASSET_VERSION ?>'></script>
 
 
 

--- a/app/owner/cars/edit.php
+++ b/app/owner/cars/edit.php
@@ -131,7 +131,7 @@ function updateCarDetails(array &$car): void
     }
 }
 ?>
-<link rel="stylesheet" href="<?= $us_url_root ?>app/assets/css/edit_car.min.css">
+<link rel="stylesheet" href="<?= $us_url_root ?>app/assets/css/edit_car.min.css?v=<?= ASSET_VERSION ?>">
 
 <div class="page-wrapper">
     <div class="container-fluid">
@@ -655,7 +655,7 @@ require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //c
 <link rel="stylesheet" href="<?=$us_url_root?>usersc/css/filepond-plugin-image-preview.min.css">
 
 <!-- Dynamic model loading from database -->
-<script src='<?= $us_url_root ?>app/assets/js/model-loader.min.js'></script>
+<script src='<?= $us_url_root ?>app/assets/js/model-loader.min.js?v=<?= ASSET_VERSION ?>'></script>
 
 <script>
     const csrf = $('#csrf').val();

--- a/app/owner/cars/index.php
+++ b/app/owner/cars/index.php
@@ -134,7 +134,7 @@ window.ELAN_CONFIG = {
     RESPONSIVE_SIZE: <?php echo $responsiveSize; ?>
 };
 </script>
-<script src='<?= $us_url_root ?>app/assets/js/imagedisplay.min.js'></script>
+<script src='<?= $us_url_root ?>app/assets/js/imagedisplay.min.js?v=<?= ASSET_VERSION ?>'></script>
 
 <script>
   const table = $('#cartable').DataTable({

--- a/app/owner/reports/statistics.php
+++ b/app/owner/reports/statistics.php
@@ -362,7 +362,7 @@ window.elanMapMarkers = <?= $mapMarkersJson ?>;
 <script src="<?=$us_url_root?>usersc/js/chart.umd.min.js"></script>
 
 <!-- Load Statistics JavaScript first -->
-<script src="<?= $us_url_root ?>app/assets/js/statistics.min.js?v=<?= filemtime($abs_us_root . $us_url_root . 'app/assets/js/statistics.min.js') ?>"></script>
+<script src="<?= $us_url_root ?>app/assets/js/statistics.min.js?v=<?= ASSET_VERSION ?>"></script>
 
 <!-- Initialize MapLibre and Statistics -->
 <script>

--- a/docs/releases/RELEASE_NOTES_v2.25.7.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.7.md
@@ -30,6 +30,8 @@
 
 ## Technical Changes
 
+- **`ASSET_VERSION` constant for cache-busting** ([#1126](https://github.com/unibrain1/elanregistry/issues/1126)): Added `ASSET_VERSION` PHP constant to `usersc/includes/config.php` (loaded on every page via `loader.php`). Reads the `VERSION` file written by post-receive deploy hooks; allow-list validated against `[a-zA-Z0-9.\-]+` (git describe format); falls back to `'dev'` when absent or unreadable. Applied as `?v=<version>` to all 20 first-party `.min.js`/`.min.css` asset URLs across 11 files, replacing the previous one-off `filemtime()` on `statistics.min.js`.
+
 - **Removed deprecated `X-XSS-Protection` header** ([#976](https://github.com/unibrain1/elanregistry/issues/976)): The header is ignored by all modern browsers (Chrome dropped it in v78, Firefox never implemented it) and implied XSS protection was being provided when it wasn't. The Content Security Policy header remains the correct mechanism and is unchanged.
 - **Removed ineffective `cleanString()` defense** ([#976](https://github.com/unibrain1/elanregistry/issues/976)): The feedback-form input filter (`str_replace` on `"content-type"`, `"bcc:"`, `"to:"`, `"cc:"`, `"href"`) was trivially bypassable (e.g. `"ccontent-typeontent-type"` passes through) and silently mutated legitimate user text. Email is sent via the Brevo API rather than raw SMTP header concatenation, so the header-injection vector it purported to block was never real.
 

--- a/index.php
+++ b/index.php
@@ -305,5 +305,5 @@ var homepageTimelineData = <?= $timelineJson ?>;
 }());
 </script>
 <style>[data-showcase-slide]{transition:opacity .3s ease-in-out}</style>
-<script src="<?= htmlspecialchars($us_url_root, ENT_QUOTES, 'UTF-8') ?>app/assets/js/car-showcase.min.js"></script>
+<script src="<?= htmlspecialchars($us_url_root, ENT_QUOTES, 'UTF-8') ?>app/assets/js/car-showcase.min.js?v=<?= ASSET_VERSION ?>"></script>
 <?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/tests/unit/system/AssetVersionTest.php
+++ b/tests/unit/system/AssetVersionTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the ASSET_VERSION constant resolution logic (GitHub issue #1126).
+ *
+ * ASSET_VERSION is a PHP constant defined once at runtime via define() in
+ * usersc/includes/config.php. PHP constants cannot be redefined between tests
+ * in the same process, and config.php is not loaded by bootstrap-unit.php
+ * (it requires $abs_us_root and redefines backup constants already set by
+ * the bootstrap). Therefore these tests target the resolution logic directly
+ * via resolveAssetVersion(), a private helper that replicates the exact
+ * ternary expression from config.php.
+ *
+ * Four required scenarios are covered:
+ *   - VERSION file present with a clean version string
+ *   - VERSION file absent (fallback to 'dev')
+ *   - VERSION file with invalid content — allow-list rejects it (fallback to 'dev')
+ *   - VERSION file with surrounding whitespace (trim applied)
+ *
+ * Source code inspection tests verify that config.php implements the contract
+ * correctly so the tests serve as executable documentation of the requirement.
+ *
+ * MAINTENANCE NOTE: When the resolution expression in config.php is modified,
+ * update resolveAssetVersion() to match or the scenario tests will exercise
+ * stale logic. The source-inspection tests guard only token presence, not
+ * full expression equivalence.
+ *
+ * @issue 1126
+ */
+#[Group('system')]
+#[Group('asset-version')]
+class AssetVersionTest extends TestCase
+{
+    /**
+     * Replicates the exact resolution logic from usersc/includes/config.php:
+     *
+     *   if (file_exists($versionFilePath)) {
+     *       $contents = file_get_contents($versionFilePath);
+     *       $raw = ($contents !== false) ? trim($contents) : '';
+     *   } else { $raw = ''; }
+     *   return (preg_match('/^[a-zA-Z0-9.\-]+$/', $raw) === 1) ? $raw : 'dev';
+     *
+     * Testing this helper against all scenarios verifies the logic without
+     * loading config.php multiple times (which would cause a constant-
+     * redefinition fatal because backup constants are already defined by
+     * bootstrap-unit.php). error_log() side effects are intentionally omitted.
+     */
+    private static function resolveAssetVersion(string $versionFilePath): string
+    {
+        if (file_exists($versionFilePath)) {
+            $contents = file_get_contents($versionFilePath);
+            $raw = ($contents !== false) ? trim($contents) : '';
+        } else {
+            $raw = '';
+        }
+        return (preg_match('/^[a-zA-Z0-9.\-]+$/', $raw) === 1) ? $raw : 'dev';
+    }
+
+    /**
+     * Writes content to a unique temporary file and returns the path.
+     * Callers must unlink the file when done (use try/finally).
+     */
+    private function writeTempVersionFile(string $content): string
+    {
+        $path = sys_get_temp_dir() . '/AssetVersionTest_' . uniqid() . '_VERSION';
+        file_put_contents($path, $content);
+        return $path;
+    }
+
+    // -------------------------------------------------------------------
+    // Scenario 1: VERSION file present — version string returned as-is
+    // -------------------------------------------------------------------
+
+    public function test_resolveAssetVersion_versionFilePresent_returnsVersionString(): void
+    {
+        $path = $this->writeTempVersionFile('v2.25.7');
+
+        try {
+            $this->assertSame('v2.25.7', self::resolveAssetVersion($path));
+        } finally {
+            unlink($path);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Scenario 2: VERSION file absent — fallback to 'dev'
+    // -------------------------------------------------------------------
+
+    public function test_resolveAssetVersion_versionFileAbsent_returnsDev(): void
+    {
+        // Construct a path guaranteed not to exist.
+        $path = sys_get_temp_dir() . '/AssetVersionTest_absent_' . uniqid() . '_VERSION';
+        $this->assertFileDoesNotExist($path, 'Precondition: temp path must not exist');
+
+        $this->assertSame('dev', self::resolveAssetVersion($path));
+    }
+
+    // -------------------------------------------------------------------
+    // Scenario 3: VERSION file with invalid content — allow-list rejects it
+    // -------------------------------------------------------------------
+
+    public function test_resolveAssetVersion_versionFileWithInvalidContent_returnsDev(): void
+    {
+        $path = $this->writeTempVersionFile('<script>alert(1)</script>');
+
+        try {
+            $this->assertSame('dev', self::resolveAssetVersion($path));
+        } finally {
+            unlink($path);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Scenario 4: VERSION file with surrounding whitespace — trim applied
+    // -------------------------------------------------------------------
+
+    public function test_resolveAssetVersion_versionFileWithLeadingAndTrailingWhitespace_returnsTrimmedString(): void
+    {
+        $path = $this->writeTempVersionFile("  v2.25.7\n");
+
+        try {
+            $this->assertSame('v2.25.7', self::resolveAssetVersion($path));
+        } finally {
+            unlink($path);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Data provider: all common whitespace / line-ending patterns
+    // -------------------------------------------------------------------
+
+    /**
+     * Shell scripts and editors can produce various whitespace patterns in
+     * a VERSION file. trim() must handle all of them.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function whitespaceVariants(): array
+    {
+        return [
+            'trailing newline only'           => ["v2.25.7\n",      'v2.25.7'],
+            'leading spaces and trailing LF'  => ["  v2.25.7\n",   'v2.25.7'],
+            'tab-padded on both sides'        => ["\tv2.25.7\t",   'v2.25.7'],
+            'Windows CRLF line ending'        => ["v2.25.7\r\n",   'v2.25.7'],
+            'leading and trailing spaces'     => ["  v2.25.7  ",   'v2.25.7'],
+            'git-describe with build suffix'  => ["v2.25.6-13-g16246bf2\n", 'v2.25.6-13-g16246bf2'],
+        ];
+    }
+
+    /**
+     * trim() must strip all common whitespace and line-ending patterns,
+     * including the git-describe output format actually written by the
+     * deploy hook on this project.
+     */
+    #[DataProvider('whitespaceVariants')]
+    public function test_resolveAssetVersion_stripsVariousWhitespacePatterns(
+        string $fileContent,
+        string $expected
+    ): void {
+        $path = $this->writeTempVersionFile($fileContent);
+
+        try {
+            $this->assertSame($expected, self::resolveAssetVersion($path));
+        } finally {
+            unlink($path);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Source code inspection: verify config.php implements the contract
+    // -------------------------------------------------------------------
+
+    /**
+     * config.php must define ASSET_VERSION. Removing or renaming the constant
+     * would silently break all asset URL cache-busting.
+     */
+    public function test_configPhp_definesAssetVersionConstant(): void
+    {
+        $configFile = dirname(__DIR__, 3) . '/usersc/includes/config.php';
+
+        $this->assertFileExists($configFile, 'config.php must exist at usersc/includes/config.php');
+
+        $content = (string) file_get_contents($configFile);
+
+        $this->assertStringContainsString(
+            "define('ASSET_VERSION'",
+            $content,
+            "config.php must define the ASSET_VERSION constant"
+        );
+    }
+
+    /**
+     * The resolution expression must use file_exists(), file_get_contents(),
+     * trim(), an allow-list regex, and the 'dev' fallback — all parts are
+     * required for the feature to work correctly and safely.
+     */
+    public function test_configPhp_resolutionExpressionUsesFileExistsTrimAllowListAndDevFallback(): void
+    {
+        $configFile = dirname(__DIR__, 3) . '/usersc/includes/config.php';
+        $content = (string) file_get_contents($configFile);
+
+        $this->assertStringContainsString(
+            'file_exists',
+            $content,
+            "config.php must use file_exists() to check for the VERSION file"
+        );
+        $this->assertStringContainsString(
+            'file_get_contents',
+            $content,
+            "config.php must use file_get_contents() to read the VERSION file"
+        );
+        $this->assertStringContainsString(
+            'trim(',
+            $content,
+            "config.php must apply trim() to strip whitespace from the VERSION file contents"
+        );
+        $this->assertStringContainsString(
+            'preg_match',
+            $content,
+            "config.php must validate VERSION content against an allow-list regex"
+        );
+        $this->assertStringContainsString(
+            "'dev'",
+            $content,
+            "config.php must fall back to 'dev' when the VERSION file is absent, empty, or invalid"
+        );
+    }
+
+    /**
+     * The VERSION file path must be built from $abs_us_root . $us_url_root so
+     * it resolves to the project root on every environment. $abs_us_root alone
+     * has no trailing slash, so omitting $us_url_root produces a broken path
+     * (e.g. /var/www/htmlVERSION) and the constant always falls back to 'dev'.
+     */
+    public function test_configPhp_buildsVersionFilePathFromAbsUsRootAndUsUrlRoot(): void
+    {
+        $configFile = dirname(__DIR__, 3) . '/usersc/includes/config.php';
+        $content = (string) file_get_contents($configFile);
+
+        $this->assertStringContainsString(
+            '$abs_us_root',
+            $content,
+            "ASSET_VERSION path must use \$abs_us_root"
+        );
+        $this->assertStringContainsString(
+            '$us_url_root',
+            $content,
+            "ASSET_VERSION path must include \$us_url_root as the directory separator between document root and 'VERSION'"
+        );
+        $this->assertStringContainsString(
+            "'VERSION'",
+            $content,
+            "config.php must reference the 'VERSION' filename"
+        );
+    }
+
+    /**
+     * All helper variables ($_versionFile, $_rawVersion) must be unset after use
+     * to avoid leaking intermediate variables into the global scope.
+     */
+    public function test_configPhp_unsetsHelperVariablesAfterUse(): void
+    {
+        $configFile = dirname(__DIR__, 3) . '/usersc/includes/config.php';
+        $content = (string) file_get_contents($configFile);
+
+        $this->assertStringContainsString(
+            '$_versionFile',
+            $content,
+            "config.php must reference \$_versionFile for VERSION path construction"
+        );
+        $this->assertStringContainsString(
+            'unset(',
+            $content,
+            "config.php must unset helper variables after use to prevent global-scope leakage"
+        );
+        $this->assertStringContainsString(
+            '$_rawVersion',
+            $content,
+            "config.php must unset \$_rawVersion to prevent global-scope leakage"
+        );
+    }
+
+    /**
+     * An empty VERSION file (created but not written by a failed deploy hook)
+     * must fall back to 'dev'. The '+' quantifier in the allow-list regex
+     * requires at least one character, so an empty trimmed string is rejected.
+     */
+    public function test_resolveAssetVersion_emptyVersionFile_returnsDev(): void
+    {
+        $path = $this->writeTempVersionFile('');
+
+        try {
+            $this->assertSame('dev', self::resolveAssetVersion($path));
+        } finally {
+            unlink($path);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Template regression: every call site must include ?v=ASSET_VERSION
+    // -------------------------------------------------------------------
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function templateFilesWithAssetVersionTag(): array
+    {
+        $root = dirname(__DIR__, 3);
+        return [
+            'index.php (root)'         => [$root . '/index.php'],
+            'footer.php'               => [$root . '/usersc/includes/footer.php'],
+            'join.php'                 => [$root . '/usersc/join.php'],
+            'user_settings.php'        => [$root . '/usersc/user_settings.php'],
+            'cars/index.php'           => [$root . '/app/owner/cars/index.php'],
+            'cars/details.php'         => [$root . '/app/owner/cars/details.php'],
+            'cars/edit.php'            => [$root . '/app/owner/cars/edit.php'],
+            'reports/statistics.php'   => [$root . '/app/owner/reports/statistics.php'],
+            'admin/index.php'          => [$root . '/app/admin/index.php'],
+            'admin/maintenance.php'    => [$root . '/app/admin/maintenance.php'],
+        ];
+    }
+
+    /**
+     * Every template that loads a first-party minified asset must append
+     * ?v=<?= ASSET_VERSION ?>. A merge conflict or refactor that strips the
+     * suffix from any file would restore stale-asset delivery for all users.
+     */
+    #[DataProvider('templateFilesWithAssetVersionTag')]
+    public function test_templateFile_containsAssetVersionQueryParameter(string $path): void
+    {
+        $content = (string) file_get_contents($path);
+        $this->assertStringContainsString(
+            '?v=<?= ASSET_VERSION ?>',
+            $content,
+            basename($path) . ' must append ?v=<?= ASSET_VERSION ?> to its first-party asset tags'
+        );
+    }
+
+    /**
+     * config.php must be syntactically valid PHP so that it can be included
+     * by the application without parse errors.
+     */
+    public function test_configPhp_isValidPhp(): void
+    {
+        $configFile = dirname(__DIR__, 3) . '/usersc/includes/config.php';
+        $output = [];
+        $returnCode = 0;
+        exec("php -l " . escapeshellarg($configFile), $output, $returnCode);
+
+        $this->assertSame(0, $returnCode, 'config.php must pass PHP syntax check (php -l)');
+    }
+}

--- a/tests/unit/system/AssetVersionTest.php
+++ b/tests/unit/system/AssetVersionTest.php
@@ -343,6 +343,28 @@ class AssetVersionTest extends TestCase
     }
 
     /**
+     * config.php must log a warning via error_log() when file_get_contents()
+     * fails for an existing VERSION file. Silently falling back to 'dev' in
+     * that case would make deploy-hook failures invisible in server logs.
+     */
+    public function test_configPhp_logsErrorWhenFileGetContentsFails(): void
+    {
+        $configFile = dirname(__DIR__, 3) . '/usersc/includes/config.php';
+        $content = (string) file_get_contents($configFile);
+
+        $this->assertStringContainsString(
+            'error_log(',
+            $content,
+            "config.php must call error_log() to make VERSION read failures visible in server logs"
+        );
+        $this->assertStringContainsString(
+            'ASSET_VERSION: file_get_contents',
+            $content,
+            "config.php error_log() message must identify the ASSET_VERSION context for diagnosability"
+        );
+    }
+
+    /**
      * config.php must be syntactically valid PHP so that it can be included
      * by the application without parse errors.
      */

--- a/usersc/includes/config.php
+++ b/usersc/includes/config.php
@@ -43,3 +43,28 @@ define('BACKUP_DIR_AUTOMATED', BACKUP_BASE_DIR . 'automated/');
 define('BACKUP_DIR_MANUAL', BACKUP_BASE_DIR . 'manual/');
 define('BACKUP_DIR_ROLLBACK', BACKUP_BASE_DIR . 'rollback/');
 
+// ============================================================================
+// Asset Versioning
+// ============================================================================
+
+// Appended as ?v=<version> to all first-party .min.js/.min.css URLs for cache-busting.
+// Reads the VERSION file written by the post-receive deploy hook.
+// Allow-list ([a-zA-Z0-9.\-]+) matches git describe output and prevents XSS if the
+// file is tampered with. Falls back to 'dev' when absent (expected in dev/CI), empty,
+// or invalid — logs a warning when the file exists but cannot be read.
+$_versionFile = $abs_us_root . $us_url_root . 'VERSION';
+if (file_exists($_versionFile)) {
+    $_contents = file_get_contents($_versionFile);
+    if ($_contents === false) {
+        error_log('[ElanRegistry] ASSET_VERSION: file_get_contents() failed for ' . $_versionFile);
+        $_rawVersion = '';
+    } else {
+        $_rawVersion = trim($_contents);
+    }
+    unset($_contents);
+} else {
+    $_rawVersion = '';
+}
+define('ASSET_VERSION', (preg_match('/^[a-zA-Z0-9.\-]+$/', $_rawVersion) === 1) ? $_rawVersion : 'dev');
+unset($_versionFile, $_rawVersion);
+

--- a/usersc/includes/footer.php
+++ b/usersc/includes/footer.php
@@ -54,7 +54,7 @@ $er_footer_version_tag = ApplicationVersion::tagOnly();
 </script>
 
 <!-- ElanRegistry API Client - Pattern A standardized AJAX -->
-<script nonce="<?=htmlspecialchars($usespice_nonce ?? '')?>" src="<?=$us_url_root?>app/assets/js/api-client.min.js"></script>
+<script nonce="<?=htmlspecialchars($usespice_nonce ?? '')?>" src="<?=$us_url_root?>app/assets/js/api-client.min.js?v=<?= ASSET_VERSION ?>"></script>
 
 <!-- Patch: users/js/menu.js offClick handler (line 100) calls open.firstChild.click() where
      firstChild is a whitespace text node in indented HTML. Text nodes have no .click() method,

--- a/usersc/join.php
+++ b/usersc/join.php
@@ -335,10 +335,10 @@ includeHook($hooks, 'bottom');
 ?>
 
 <!-- Location Picker Styles -->
-<link rel="stylesheet" href="<?=$us_url_root?>app/assets/css/location-picker.min.css">
+<link rel="stylesheet" href="<?=$us_url_root?>app/assets/css/location-picker.min.css?v=<?= ASSET_VERSION ?>">
 
 <!-- Location Picker Script -->
-<script src="<?=$us_url_root?>app/assets/js/location-picker.min.js"></script>
+<script src="<?=$us_url_root?>app/assets/js/location-picker.min.js?v=<?= ASSET_VERSION ?>"></script>
 
 <script type="text/javascript">
     $(document).ready(function(){

--- a/usersc/user_settings.php
+++ b/usersc/user_settings.php
@@ -626,10 +626,10 @@ if ($userQ2->count() > 0) {
 require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; //custom template footer
 ?>
 <!-- Location Picker Styles -->
-<link rel="stylesheet" href="<?=$us_url_root?>app/assets/css/location-picker.min.css">
+<link rel="stylesheet" href="<?=$us_url_root?>app/assets/css/location-picker.min.css?v=<?= ASSET_VERSION ?>">
 
 <!-- Location Picker Script -->
-<script src="<?=$us_url_root?>app/assets/js/location-picker.min.js"></script>
+<script src="<?=$us_url_root?>app/assets/js/location-picker.min.js?v=<?= ASSET_VERSION ?>"></script>
 
 <!-- Place any per-page javascript here -->
 <script>


### PR DESCRIPTION
## Summary

- Defines `ASSET_VERSION` constant in `usersc/includes/config.php` by reading the `VERSION` file written by the post-receive deploy hook
- Allow-list validated against `[a-zA-Z0-9.\-]+` (git describe format) to prevent XSS; falls back to `'dev'` with an `error_log` entry when the file exists but cannot be read (silent fallback without logging was a deploy-hook failure blind spot)
- Appends `?v=<version>` to all 20 first-party `.min.js`/`.min.css` asset tags across 11 files, replacing the previous one-off `filemtime()` on `statistics.min.js`
- Fixes the production incident from v2.25.3→v2.25.4: `car_details.min.js` was cached stale post-deployment until a manual Cloudflare purge — this change makes cache-busting automatic on every deploy

## Key implementation note

`$abs_us_root` has no trailing slash (it is raw `DOCUMENT_ROOT`). The path is therefore `$abs_us_root . $us_url_root . 'VERSION'` — omitting `$us_url_root` would produce `/var/www/htmlVERSION` and the constant would permanently resolve to `'dev'`.

## Test plan

- [x] 22 PHPUnit unit tests added (`tests/unit/system/AssetVersionTest.php`):
  - VERSION file present, absent, empty, invalid content (allow-list rejection)
  - Whitespace variants including Windows CRLF and actual git-describe format
  - Parameterised template regression test for all 10 modified template files
  - Source-inspection tests for constant definition, path construction, allow-list, and `unset()` cleanup
- [x] 1010 unit tests passing, 4106 assertions
- [x] Pre-commit hooks: phpcs (0 errors), PHPStan (no errors), all tests green

## Bug escape analysis

The `statistics.min.js` asset already had a `?v=filemtime(...)` guard but the other 19 assets did not. No automated test existed to verify that asset tags include a version parameter — the parameterised template test added here prevents this class of regression.

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPsZLGHRisE3B38Gqc9zeq