### PR TITLE
refactor: consolidate statistics queries into service layer (#946)

### DIFF
--- a/app/owner/reports/statistics.php
+++ b/app/owner/reports/statistics.php
@@ -26,14 +26,7 @@ if (!securePage($php_self)) {
 $dataService = new StatisticsDataService($db);
 
 // Build inlined map marker data — targeted query, deterministic jitter
-$db->query(
-    "SELECT id, year, series, chassis, variant, image, type, city, state, country, fname AS owner, lat, lon
-     FROM cars WHERE lat != 0 AND lon != 0"
-);
-if ($db->error()) {
-    logger(0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, 'Map marker query failed: ' . $db->errorString());
-}
-$markerRows = $db->results();
+$markerRows = $dataService->getMapPins();
 
 $mapMarkers = [];
 foreach ($markerRows as $car) {
@@ -329,7 +322,7 @@ foreach ($markerRows as $car) {
 <script>
 window.statisticsRawData = {
     // Overview data - loaded immediately
-    timeline: <?= json_encode($dataService->getTimelineData()) ?>,
+    timeline: <?= $timelineJson ?>,
 
     // Basic counts for overview cards
     countriesCount: <?= count($dataService->getCountryData()) ?>,
@@ -347,6 +340,15 @@ window.statisticsConfig = {
 </script>
 
 <?php
+try {
+    $timelineJson = json_encode(
+        $dataService->getTimelineData(),
+        JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR
+    );
+} catch (\JsonException $e) {
+    logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Failed to encode timeline data: ' . $e->getMessage());
+    $timelineJson = '[]';
+}
 try {
     $mapMarkersJson = json_encode($mapMarkers, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR);
 } catch (\JsonException $e) {

--- a/app/owner/reports/statistics.php
+++ b/app/owner/reports/statistics.php
@@ -318,6 +318,24 @@ foreach ($markerRows as $car) {
     </div>
 </div>
 
+<?php
+try {
+    $timelineJson = json_encode(
+        $dataService->getTimelineData(),
+        JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR
+    );
+} catch (\JsonException $e) {
+    logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Failed to encode timeline data: ' . $e->getMessage());
+    $timelineJson = '[]';
+}
+try {
+    $mapMarkersJson = json_encode($mapMarkers, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR);
+} catch (\JsonException $e) {
+    logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Failed to encode map markers: ' . $e->getMessage());
+    $mapMarkersJson = '[]';
+}
+?>
+
 <!-- Data for JavaScript -->
 <script>
 window.statisticsRawData = {
@@ -338,24 +356,6 @@ window.statisticsConfig = {
     versatileStyleUrl: '<?= $us_url_root ?>usersc/js/versatiles-colorful.json'
 };
 </script>
-
-<?php
-try {
-    $timelineJson = json_encode(
-        $dataService->getTimelineData(),
-        JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR
-    );
-} catch (\JsonException $e) {
-    logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Failed to encode timeline data: ' . $e->getMessage());
-    $timelineJson = '[]';
-}
-try {
-    $mapMarkersJson = json_encode($mapMarkers, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_THROW_ON_ERROR);
-} catch (\JsonException $e) {
-    logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'Failed to encode map markers: ' . $e->getMessage());
-    $mapMarkersJson = '[]';
-}
-?>
 <script>
 window.elanMapMarkers = <?= $mapMarkersJson ?>;
 </script>

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -273,9 +273,16 @@ class StatisticsApiTest extends IntegrationTestCase
         $pins    = $service->getMapPins();
 
         $this->assertIsArray($pins);
+
         if (empty($pins)) {
-            $this->markTestSkipped('No cars with map coordinates in test DB — getMapPins() contract untestable');
+            if ($this->testUserId === null) {
+                $this->markTestSkipped('No users in test DB — cannot create fixture car for getMapPins() test');
+            }
+            $this->createTestCar($this->testUserId, ['lat' => '51.5074', 'lon' => '-0.1278']);
+            $pins = $service->getMapPins();
         }
+
+        $this->assertNotEmpty($pins, 'getMapPins() must return at least one car with coordinates');
         $pin = $pins[0];
         foreach (['id', 'year', 'series', 'lat', 'lon', 'owner'] as $field) {
             $this->assertObjectHasProperty($field, $pin, "getMapPins() row must have '$field'");

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -265,6 +265,24 @@ class StatisticsApiTest extends IntegrationTestCase
     }
 
     /**
+     * StatisticsDataService::getMapPins() returns an array; each row has required fields.
+     */
+    public function testGetMapPinsReturnsRowsWithRequiredFields(): void
+    {
+        $service = new StatisticsDataService($this->db);
+        $pins    = $service->getMapPins();
+
+        $this->assertIsArray($pins);
+        if (empty($pins)) {
+            $this->markTestSkipped('No cars with map coordinates in test DB — getMapPins() contract untestable');
+        }
+        $pin = $pins[0];
+        foreach (['id', 'year', 'series', 'lat', 'lon', 'owner'] as $field) {
+            $this->assertObjectHasProperty($field, $pin, "getMapPins() row must have '$field'");
+        }
+    }
+
+    /**
      * StatisticsDataService::getDataCompleteness() returns an object with required fields.
      *
      * Replaced a tautological test that asserted a locally-constructed error array.

--- a/usersc/classes/StatisticsDataService.php
+++ b/usersc/classes/StatisticsDataService.php
@@ -32,8 +32,17 @@ class StatisticsDataService {
      * @return array|object|null Query results
      */
     private function executeQuery(string $query, bool $single = false): array|object|null {
-        $result = $this->db->query($query);
-        return $single ? $result->first() : $result->results();
+        try {
+            $result = $this->db->query($query);
+            return $single ? $result->first() : $result->results();
+        } catch (\Throwable $e) {
+            logger(
+                0,
+                LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                'StatisticsDataService query failed: ' . $e->getMessage() . ' | Query: ' . substr($query, 0, 200)
+            );
+            return $single ? null : [];
+        }
     }
 
     // === GEOGRAPHIC DATA ===
@@ -174,14 +183,39 @@ class StatisticsDataService {
      * @return array Series counts by type
      */
     public function getSeriesCounts(): array {
+        $row = $this->executeQuery(
+            "SELECT
+                 SUM(series LIKE 's1%')     AS s1,
+                 SUM(series LIKE 's2%')     AS s2,
+                 SUM(series LIKE 's3%')     AS s3,
+                 SUM(series LIKE 's4%')     AS s4,
+                 SUM(series LIKE 'sprint%') AS sprint,
+                 SUM(series LIKE '+2%')     AS plus2
+             FROM cars",
+            true
+        );
         return [
-            's1' => $this->executeQuery("select count(*) as count from cars where series like 's1%'", true)->count,
-            's2' => $this->executeQuery("select count(*) as count from cars where series like 's2%'", true)->count,
-            's3' => $this->executeQuery("select count(*) as count from cars where series like 's3%'", true)->count,
-            's4' => $this->executeQuery("select count(*) as count from cars where series like 's4%'", true)->count,
-            'sprint' => $this->executeQuery("select count(*) as count from cars where series like 'sprint%'", true)->count,
-            '+2' => $this->executeQuery("select count(*) as count from cars where series like '+2%'", true)->count,
+            's1'     => (int)($row->s1     ?? 0),
+            's2'     => (int)($row->s2     ?? 0),
+            's3'     => (int)($row->s3     ?? 0),
+            's4'     => (int)($row->s4     ?? 0),
+            'sprint' => (int)($row->sprint ?? 0),
+            '+2'     => (int)($row->plus2  ?? 0),
         ];
+    }
+
+    /**
+     * Get map pin data for the world map
+     *
+     * @return array Cars with lat/lon coordinates
+     */
+    public function getMapPins(): array {
+        return $this->executeQuery(
+            "SELECT id, year, series, chassis, variant, image,
+                    city, state, country, fname AS owner, lat, lon
+             FROM cars
+             WHERE lat != 0 AND lon != 0"
+        );
     }
 
     // === COLOR DATA ===

--- a/usersc/classes/StatisticsDataService.php
+++ b/usersc/classes/StatisticsDataService.php
@@ -207,7 +207,9 @@ class StatisticsDataService {
     /**
      * Get map pin data for the world map
      *
-     * @return array Cars with lat/lon coordinates
+     * @return array<int, object{id: int, year: string, series: string, chassis: string,
+     *                           variant: string, image: string, city: string, state: string,
+     *                           country: string, owner: string, lat: float, lon: float}> Cars with coordinates
      */
     public function getMapPins(): array {
         return $this->executeQuery(


### PR DESCRIPTION
## Summary

- Replace 6 separate `COUNT(*)` queries in `StatisticsDataService::getSeriesCounts()` with a single conditional-aggregate (`SUM(series LIKE 'x%')`) — one round-trip instead of six
- Extract the inline map-pin query from `statistics.php` into a new `getMapPins()` service method, keeping SQL out of the view layer
- Add error handling to `executeQuery()` so DB failures log via `LogCategories::LOG_CATEGORY_DATABASE_ERROR` instead of silently producing empty results
- Harden timeline `json_encode()` with `JSON_HEX_*` flags and a `try/catch \JsonException` pattern consistent with the adjacent map markers encoding

## Test plan

- [x] `testGetSeriesCountsReturnsAllSixKeys()` — pre-existing integration test exercises the refactored query against live DB
- [x] `testGetMapPinsReturnsRowsWithRequiredFields()` — new integration test verifies field shape of `getMapPins()` results
- [x] 1036 unit tests passing
- [x] PHPStan: no errors
- [x] phpcs: no errors

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPsZLGHRisE3B38Gqc9zeq