### PR TITLE
feat: add Account Cleanup admin tab with archive/restore safety net (#1127)

### DIFF
--- a/app/admin/includes/account-cleanup-helpers.php
+++ b/app/admin/includes/account-cleanup-helpers.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Return unverified (email_verified=0) accounts with no car associations older than $days.
+ *
+ * @param DB  $db   UserSpice DB instance
+ * @param int $days Minimum age in days (must be ≥30)
+ */
+function findUnverifiedOwnerlessAccounts(DB $db, int $days): array
+{
+    return $db->query(
+        "SELECT u.id, u.email, u.fname, u.lname, u.join_date,
+                DATEDIFF(NOW(), u.join_date) AS age_days,
+                p.city, p.state, p.country
+         FROM users u
+         LEFT JOIN profiles p ON u.id = p.user_id
+         WHERE u.email_verified = 0
+           AND u.active = 1
+           AND u.protected = 0
+           AND u.id != 1
+           AND u.username != 'noowner'
+           AND NOT EXISTS (SELECT 1 FROM cars c WHERE c.user_id = u.id)
+           AND NOT EXISTS (SELECT 1 FROM car_user cu WHERE cu.userid = u.id)
+           AND NOT EXISTS (SELECT 1 FROM cars_hist ch WHERE ch.user_id = u.id)
+           AND DATEDIFF(NOW(), u.join_date) >= ?
+         ORDER BY u.join_date ASC",
+        [$days]
+    )->results();
+}
+
+/**
+ * Return verified (email_verified=1) accounts with no car associations whose last_login
+ * is older than $days (or never logged in).
+ *
+ * @param DB  $db   UserSpice DB instance
+ * @param int $days Inactivity threshold in days (must be ≥1)
+ */
+function findVerifiedOwnerlessAccounts(DB $db, int $days): array
+{
+    return $db->query(
+        "SELECT u.id, u.email, u.fname, u.lname, u.join_date,
+                u.logins, u.last_login,
+                p.city, p.state, p.country
+         FROM users u
+         LEFT JOIN profiles p ON u.id = p.user_id
+         WHERE u.email_verified = 1
+           AND u.active = 1
+           AND u.protected = 0
+           AND u.id != 1
+           AND u.username != 'noowner'
+           AND NOT EXISTS (SELECT 1 FROM cars c WHERE c.user_id = u.id)
+           AND NOT EXISTS (SELECT 1 FROM car_user cu WHERE cu.userid = u.id)
+           AND NOT EXISTS (SELECT 1 FROM cars_hist ch WHERE ch.user_id = u.id)
+           AND (
+               u.last_login IS NULL
+               OR u.last_login = '0000-00-00 00:00:00'
+               OR DATEDIFF(NOW(), u.last_login) >= ?
+           )
+         ORDER BY u.last_login ASC, u.join_date ASC",
+        [$days]
+    )->results();
+}
+
+/**
+ * Snapshot a set of user accounts into deleted_accounts_archive before deletion.
+ *
+ * @param DB     $db            UserSpice DB instance
+ * @param int[]  $userIds       IDs to archive
+ * @param int    $deletedBy     Admin user ID performing the deletion
+ * @param string $deletionType  'unverified' or 'verified'
+ */
+function archiveAccounts(DB $db, array $userIds, int $deletedBy, string $deletionType): void
+{
+    if (empty($userIds)) {
+        return;
+    }
+
+    $placeholders = implode(',', array_fill(0, count($userIds), '?'));
+
+    // phpcs:disable - False positive: Using prepared statements correctly
+    $rows = $db->query(
+        "SELECT u.id, u.email, u.username, u.fname, u.lname,
+                u.join_date, u.last_login, u.logins, u.email_verified,
+                p.city, p.state, p.country, p.bio, p.website
+         FROM users u
+         LEFT JOIN profiles p ON p.user_id = u.id
+         WHERE u.id IN (" . $placeholders . ")",
+        $userIds
+    )->results();
+    // phpcs:enable
+
+    if ($db->error()) {
+        throw new RuntimeException('archiveAccounts: query failed — ' . $db->errorString());
+    }
+
+    $now = date('Y-m-d H:i:s');
+    $db->beginTransaction();
+    try {
+        foreach ($rows as $r) {
+            $ll = ($r->last_login && $r->last_login !== '0000-00-00 00:00:00')
+                ? $r->last_login
+                : null;
+
+            $ok = $db->insert('deleted_accounts_archive', [
+                'original_user_id' => (int) $r->id,
+                'email'            => $r->email,
+                'username'         => $r->username,
+                'fname'            => $r->fname,
+                'lname'            => $r->lname,
+                'join_date'        => $r->join_date,
+                'last_login'       => $ll,
+                'logins'           => (int) $r->logins,
+                'email_verified'   => (int) $r->email_verified,
+                'city'             => $r->city    ?? null,
+                'state'            => $r->state   ?? null,
+                'country'          => $r->country ?? null,
+                'bio'              => $r->bio     ?? null,
+                'website'          => $r->website ?? null,
+                'deleted_by'       => $deletedBy,
+                'deleted_at'       => $now,
+                'deletion_type'    => $deletionType,
+            ]);
+
+            if (!$ok) {
+                throw new RuntimeException(
+                    "archiveAccounts: failed to archive user id={$r->id} — " . $db->errorString()
+                );
+            }
+        }
+        $db->commit();
+    } catch (RuntimeException $e) {
+        $db->rollBack();
+        throw $e;
+    }
+}
+
+/**
+ * Restore an archived account: re-insert into users + profiles, mark archive row restored.
+ *
+ * Returns the new user ID on success, or throws on failure.
+ *
+ * @param DB  $db         UserSpice DB instance
+ * @param int $archiveId  Row ID in deleted_accounts_archive
+ * @param int $restoredBy Admin user ID performing the restore
+ *
+ * @throws RuntimeException if the archive row is not found, already restored, or any write fails
+ */
+function restoreArchivedAccount(DB $db, int $archiveId, int $restoredBy): int
+{
+    $row = $db->query(
+        "SELECT * FROM deleted_accounts_archive WHERE id = ? AND restored_at IS NULL LIMIT 1",
+        [$archiveId]
+    )->first();
+
+    if (!$row) {
+        throw new RuntimeException("Archive row #{$archiveId} not found or already restored.");
+    }
+
+    $db->beginTransaction();
+    try {
+        // Re-insert user (new auto-increment ID; original ID may have been reused).
+        // Password is not archived — restored account requires a password reset via forgot-password.
+        $ok = $db->insert('users', [
+            'email'          => $row->email,
+            'username'       => $row->username ?? $row->email,
+            'password'       => password_hash(bin2hex(random_bytes(32)), PASSWORD_BCRYPT),
+            'fname'          => $row->fname,
+            'lname'          => $row->lname,
+            'join_date'      => $row->join_date,
+            'last_login'     => $row->last_login,
+            'logins'         => (int) $row->logins,
+            'email_verified' => 0,  // require re-verification on restore
+            'active'         => 1,
+            'protected'      => 0,
+        ]);
+        if (!$ok) {
+            throw new RuntimeException('Failed to re-insert user — ' . $db->errorString());
+        }
+
+        $newUserId = (int) $db->lastId();
+        if ($newUserId === 0) {
+            throw new RuntimeException('User insert succeeded but returned no ID.');
+        }
+
+        // Recreate the base member permission (permission_id=1), as deleteUsers() removes it
+        $ok = $db->insert('user_permission_matches', [
+            'user_id'       => $newUserId,
+            'permission_id' => 1,
+        ]);
+        if (!$ok) {
+            throw new RuntimeException(
+                "User id={$newUserId} restored but permission insert failed — " . $db->errorString()
+            );
+        }
+
+        // Re-insert profile if location data was archived
+        if ($row->city || $row->state || $row->country || $row->bio || $row->website) {
+            $ok = $db->insert('profiles', [
+                'user_id' => $newUserId,
+                'city'    => $row->city    ?? null,
+                'state'   => $row->state   ?? null,
+                'country' => $row->country ?? null,
+                'bio'     => $row->bio     ?? null,
+                'website' => $row->website ?? null,
+            ]);
+            if (!$ok) {
+                throw new RuntimeException(
+                    "User id={$newUserId} restored but profile insert failed — " . $db->errorString()
+                );
+            }
+        }
+
+        // Mark as restored — keep the archive row as permanent audit trail
+        $db->query(
+            "UPDATE deleted_accounts_archive SET restored_at = NOW(), restored_by = ? WHERE id = ?",
+            [$restoredBy, $archiveId]
+        );
+        if ($db->error()) {
+            throw new RuntimeException(
+                "User id={$newUserId} restored but archive update failed — " . $db->errorString()
+            );
+        }
+
+        $db->commit();
+    } catch (RuntimeException $e) {
+        $db->rollBack();
+        throw $e;
+    }
+
+    return $newUserId;
+}
+
+/**
+ * Return all archive rows for the DataTables endpoint.
+ *
+ * @param DB $db UserSpice DB instance
+ */
+function findArchivedAccounts(DB $db): array
+{
+    return $db->query(
+        "SELECT a.id, a.original_user_id, a.email, a.fname, a.lname,
+                a.deletion_type, a.deleted_at,
+                a.city, a.state, a.country,
+                a.restored_at,
+                rb.fname AS restored_by_fname, rb.lname AS restored_by_lname
+         FROM deleted_accounts_archive a
+         LEFT JOIN users rb ON rb.id = a.restored_by
+         ORDER BY a.deleted_at DESC",
+        []
+    )->results();
+}

--- a/app/admin/includes/account-cleanup-helpers.php
+++ b/app/admin/includes/account-cleanup-helpers.php
@@ -130,7 +130,7 @@ function archiveAccounts(DB $db, array $userIds, int $deletedBy, string $deletio
             }
         }
         $db->commit();
-    } catch (RuntimeException $e) {
+    } catch (\Throwable $e) {
         $db->rollBack();
         throw $e;
     }
@@ -224,7 +224,7 @@ function restoreArchivedAccount(DB $db, int $archiveId, int $restoredBy): int
         }
 
         $db->commit();
-    } catch (RuntimeException $e) {
+    } catch (\Throwable $e) {
         $db->rollBack();
         throw $e;
     }

--- a/app/admin/includes/tab-account_cleanup.php
+++ b/app/admin/includes/tab-account_cleanup.php
@@ -41,7 +41,7 @@ if ($method === 'POST' && isset($_POST['ac_action'])) {
                 ]);
                 header('Location: ?' . $qs);
                 exit;
-            } catch (RuntimeException $e) {
+            } catch (\Throwable $e) {
                 $acFlashError = 'Restore failed: ' . $e->getMessage();
             }
         }
@@ -71,7 +71,7 @@ if ($method === 'POST' && isset($_POST['ac_action'])) {
             // Archive before permanent deletion — abort if archive fails
             try {
                 archiveAccounts($db, $toDelete, $currentUserId, $isVerified ? 'verified' : 'unverified');
-            } catch (RuntimeException $e) {
+            } catch (\Throwable $e) {
                 logger(
                     $currentUserId,
                     LogCategories::LOG_CATEGORY_USER_DELETION,

--- a/app/admin/includes/tab-account_cleanup.php
+++ b/app/admin/includes/tab-account_cleanup.php
@@ -1,0 +1,613 @@
+<?php
+declare(strict_types=1);
+
+// ---------------------------------------------------------------------------
+// Threshold values — read from GET so URL is bookmarkable / shareable
+// ---------------------------------------------------------------------------
+$acThreshold  = max(30,  (int) ($_GET['ac_threshold']  ?? 30));
+$acvThreshold = max(1,   (int) ($_GET['acv_threshold'] ?? 365));
+
+// ---------------------------------------------------------------------------
+// Handle POST delete actions — same TOCTOU-protected logic, then PRG redirect
+// ---------------------------------------------------------------------------
+if ($method === 'POST' && isset($_POST['ac_action'])) {
+    require_once __DIR__ . '/account-cleanup-helpers.php';
+
+    if (!isset($_POST['csrf']) || !Token::check($_POST['csrf'])) {
+        logger($currentUserId, LogCategories::LOG_CATEGORY_SECURITY,
+            'CSRF validation failed on account cleanup tab');
+        $acFlashError = 'Security token invalid. Please refresh the page and try again.';
+    } elseif (!isAdmin()) {
+        logger($currentUserId, LogCategories::LOG_CATEGORY_SECURITY,
+            'Non-admin attempted account cleanup action on ' . $php_self);
+        $acFlashError = 'Insufficient permissions.';
+    } elseif ($_POST['ac_action'] === 'restore_account') {
+        $archiveId = max(0, (int) ($_POST['archive_id'] ?? 0));
+        if ($archiveId <= 0) {
+            $acFlashError = 'Invalid archive record.';
+        } else {
+            try {
+                $newUserId = restoreArchivedAccount($db, $archiveId, $currentUserId);
+                logger(
+                    $currentUserId,
+                    LogCategories::LOG_CATEGORY_USER_DELETION,
+                    "Admin restored archived account: archive_id={$archiveId}, new_user_id={$newUserId}"
+                );
+                $qs = http_build_query([
+                    'tab'          => 'account-cleanup',
+                    'ac_threshold' => max(30, (int) ($_POST['ac_threshold']  ?? 30)),
+                    'acv_threshold'=> max(1,  (int) ($_POST['acv_threshold'] ?? 365)),
+                    'restored'     => $newUserId,
+                ]);
+                header('Location: ?' . $qs);
+                exit;
+            } catch (RuntimeException $e) {
+                $acFlashError = 'Restore failed: ' . $e->getMessage();
+            }
+        }
+    } else {
+        // Delete (delete_unverified or delete_verified)
+        $postThreshold  = max(30, (int) ($_POST['ac_threshold']  ?? 30));
+        $postVThreshold = max(1,  (int) ($_POST['acv_threshold'] ?? 365));
+        $isVerified     = $_POST['ac_action'] === 'delete_verified';
+        $idsField       = $isVerified ? 'acv_ids' : 'acu_ids';
+        $submittedIds   = array_values(array_filter(
+            array_map('intval', (array) ($_POST[$idsField] ?? [])),
+            fn(int $id): bool => $id > 0
+        ));
+
+        if (empty($submittedIds)) {
+            $acFlashError = 'No accounts selected for deletion.';
+        } else {
+            $eligible    = $isVerified
+                ? findVerifiedOwnerlessAccounts($db, $postVThreshold)
+                : findUnverifiedOwnerlessAccounts($db, $postThreshold);
+            $eligibleMap = [];
+            foreach ($eligible as $acct) {
+                $eligibleMap[(int) $acct->id] = $acct;
+            }
+            $toDelete = array_values(array_intersect($submittedIds, array_keys($eligibleMap)));
+
+            // Archive before permanent deletion — abort if archive fails
+            try {
+                archiveAccounts($db, $toDelete, $currentUserId, $isVerified ? 'verified' : 'unverified');
+            } catch (RuntimeException $e) {
+                logger(
+                    $currentUserId,
+                    LogCategories::LOG_CATEGORY_USER_DELETION,
+                    'Account archive failed — deletion aborted: ' . $e->getMessage()
+                );
+                $acFlashError = 'Could not archive accounts before deletion. Deletion aborted to prevent data loss.';
+            }
+
+            if (!isset($acFlashError)) {
+                foreach ($toDelete as $deleteId) {
+                    $acct = $eligibleMap[$deleteId];
+                    logger(
+                        $currentUserId,
+                        LogCategories::LOG_CATEGORY_USER_DELETION,
+                        sprintf(
+                            'Admin deleted %s ownerless account: id=%d, email=%s',
+                            $isVerified ? 'verified' : 'unverified',
+                            $acct->id,
+                            $acct->email
+                        )
+                    );
+                }
+                deleteUsers($toDelete);
+
+                $acPostAccounts = $isVerified
+                    ? findVerifiedOwnerlessAccounts($db, $postVThreshold)
+                    : findUnverifiedOwnerlessAccounts($db, $postThreshold);
+                $stillExistIds  = array_map(fn($a): int => (int) $a->id, $acPostAccounts);
+                $deleted        = count(array_diff($toDelete, $stillExistIds));
+
+                // PRG: redirect so a browser refresh doesn't re-POST
+                $qs = http_build_query([
+                    'tab'          => 'account-cleanup',
+                    'ac_threshold' => $postThreshold,
+                    'acv_threshold'=> $postVThreshold,
+                    'deleted'      => $deleted,
+                    'label'        => $isVerified ? 'verified' : 'unverified',
+                ]);
+                header('Location: ?' . $qs);
+                exit;
+            }
+        }
+    }
+}
+
+// Flash values from PRG redirect
+$acFlashDeleted  = isset($_GET['deleted'])  ? (int) $_GET['deleted']  : null;
+$acFlashRestored = isset($_GET['restored']) ? (int) $_GET['restored'] : null;
+$acFlashLabel    = in_array($_GET['label'] ?? '', ['verified', 'unverified'], true)
+    ? $_GET['label']
+    : null;
+
+?>
+
+<link rel="stylesheet" href="<?= $us_url_root ?>usersc/css/datatables.min.css">
+
+<!-- Account Cleanup Header -->
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h2 class="text-primary mb-1">
+            <i class="fas fa-user-slash"></i> Account Cleanup
+        </h2>
+        <p class="text-muted mb-0">Report and delete accounts with no car associations</p>
+    </div>
+</div>
+
+<?php if (isset($acFlashError)) { ?>
+    <div class="alert alert-danger" role="alert">
+        <i class="fas fa-exclamation-triangle"></i>
+        <?= htmlspecialchars($acFlashError, ENT_QUOTES, 'UTF-8') ?>
+    </div>
+<?php } ?>
+
+<?php if ($acFlashDeleted !== null && $acFlashLabel !== null) { ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <i class="fas fa-check-circle"></i>
+        Deleted <?= (int) $acFlashDeleted ?>
+        <?= htmlspecialchars($acFlashLabel, ENT_QUOTES, 'UTF-8') ?> account(s). Snapshots saved to archive.
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php } ?>
+
+<?php if ($acFlashRestored !== null) { ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <i class="fas fa-user-check"></i>
+        Account restored — new user ID: <strong><?= (int) $acFlashRestored ?></strong>.
+        Email verification required before login.
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php } ?>
+
+<!-- Threshold controls -->
+<div class="card registry-card mb-4">
+    <div class="card-body py-3">
+        <form method="GET" action="" class="row g-2 align-items-end">
+            <input type="hidden" name="tab" value="account-cleanup">
+            <div class="col-sm-4">
+                <label for="ac_threshold" class="form-label mb-1 small">
+                    Unverified — account age at least (days)
+                </label>
+                <input type="number" class="form-control form-control-sm"
+                       id="ac_threshold" name="ac_threshold"
+                       min="30" value="<?= (int) $acThreshold ?>">
+            </div>
+            <div class="col-sm-4">
+                <label for="acv_threshold" class="form-label mb-1 small">
+                    Verified — no login for at least (days)
+                </label>
+                <input type="number" class="form-control form-control-sm"
+                       id="acv_threshold" name="acv_threshold"
+                       min="1" value="<?= (int) $acvThreshold ?>">
+            </div>
+            <div class="col-sm-auto">
+                <button type="submit" class="btn btn-sm btn-primary">
+                    <i class="fas fa-sync-alt"></i> Apply
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php
+// Helper: render one section (table skeleton + hidden delete form)
+$renderSection = function (
+    string $prefix,          // 'acu' | 'acv'
+    string $tableId,         // 'acuTable' | 'acvTable'
+    string $sectionTitle,
+    array  $rules,
+    string $deleteAction,    // 'delete_unverified' | 'delete_verified'
+    string $idsField,        // 'acu_ids' | 'acv_ids'
+    bool   $isVerified
+) use ($acThreshold, $acvThreshold, $csrfToken): void {
+?>
+<div class="card registry-card mb-4">
+    <div class="card-header card-header-er-primary">
+        <div class="d-flex justify-content-between align-items-start">
+            <h5 class="mb-0 card-header-er-primary-text">
+                <i class="fas fa-user-slash"></i>
+                <?= htmlspecialchars($sectionTitle, ENT_QUOTES, 'UTF-8') ?>
+                <span id="<?= $prefix ?>Count" class="ms-1 badge bg-light text-dark fw-normal fs-6"></span>
+            </h5>
+            <ul class="list-unstyled mb-0 ms-4 small text-nowrap" style="opacity:.85">
+                <?php foreach ($rules as $rule) { ?>
+                    <li><i class="fas fa-circle-dot me-1" style="font-size:.6rem;vertical-align:middle"></i><?= htmlspecialchars($rule, ENT_QUOTES, 'UTF-8') ?></li>
+                <?php } ?>
+            </ul>
+        </div>
+    </div>
+    <div class="card-body">
+
+        <!-- Batch + delete controls -->
+        <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+            <div class="d-flex align-items-center gap-2">
+                <label for="<?= $prefix ?>BatchLimit" class="form-label mb-0 text-nowrap small">Batch limit:</label>
+                <input type="number" id="<?= $prefix ?>BatchLimit"
+                       class="form-control form-control-sm" style="width:80px"
+                       min="1" value="10">
+            </div>
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="<?= $prefix ?>SelectTopBtn">
+                Select All (top <span id="<?= $prefix ?>LimitDisplay">10</span>)
+            </button>
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="<?= $prefix ?>DeselectBtn">
+                Deselect All
+            </button>
+            <button type="button" class="btn btn-sm btn-danger" id="<?= $prefix ?>DeleteBtn" disabled>
+                <i class="fas fa-trash"></i> Delete Selected
+                (<span id="<?= $prefix ?>SelCount">0</span>)
+            </button>
+        </div>
+
+        <div class="table-responsive">
+            <table id="<?= $tableId ?>" class="table table-hover table-sm w-100">
+                <thead class="thead-light">
+                    <tr>
+                        <th></th>
+                        <th>ID</th>
+                        <th>Email</th>
+                        <th>Name</th>
+                        <th>City</th>
+                        <th>State</th>
+                        <th>Country</th>
+                        <?php if ($isVerified) { ?>
+                            <th>Account Created</th>
+                            <th>Last Login</th>
+                            <th>Logins</th>
+                        <?php } else { ?>
+                            <th>Joined</th>
+                            <th>Age (days)</th>
+                        <?php } ?>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+
+        <!-- Hidden delete form — JS populates ID inputs before submit -->
+        <form id="<?= $prefix ?>DeleteForm" method="POST" action="?tab=account-cleanup" class="d-none">
+            <input type="hidden" name="csrf"          value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+            <input type="hidden" name="ac_action"     value="<?= htmlspecialchars($deleteAction, ENT_QUOTES, 'UTF-8') ?>">
+            <input type="hidden" name="ac_threshold"  value="<?= (int) $acThreshold ?>">
+            <input type="hidden" name="acv_threshold" value="<?= (int) $acvThreshold ?>">
+        </form>
+
+    </div>
+</div>
+<?php
+}; // end $renderSection
+
+$renderSection(
+    'acu', 'acuTable',
+    'Unverified accounts with no car',
+    [
+        'Email not verified',
+        'No cars — current or historical',
+        'Account age ≥ ' . $acThreshold . ' days',
+        'Active, unprotected, non-system account',
+    ],
+    'delete_unverified', 'acu_ids', false
+);
+
+$renderSection(
+    'acv', 'acvTable',
+    'Verified accounts with no car',
+    [
+        'Email verified',
+        'No cars — current or historical',
+        'No login for ≥ ' . $acvThreshold . ' days (or never logged in)',
+        'Active, unprotected, non-system account',
+    ],
+    'delete_verified', 'acv_ids', true
+);
+?>
+
+<!-- Archive section -->
+<div class="card registry-card mb-4">
+    <div class="card-header card-header-er-secondary">
+        <h5 class="mb-0">
+            <i class="fas fa-archive"></i> Deleted Accounts Archive
+            <span id="arcCount" class="ms-1 badge bg-light text-dark fw-normal fs-6"></span>
+        </h5>
+    </div>
+    <div class="card-body">
+        <p class="text-muted small mb-3">
+            Every account deleted via this tool is preserved here. Restoring creates a new account
+            with the same details and requires the user to re-verify their email before logging in.
+        </p>
+        <div class="table-responsive">
+            <table id="arcTable" class="table table-hover table-sm w-100">
+                <thead>
+                    <tr>
+                        <th>Archive ID</th>
+                        <th>Orig. User ID</th>
+                        <th>Email</th>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Deleted At</th>
+                        <th>Location</th>
+                        <th>Status</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+
+        <!-- Single restore form — JS populates archive_id before submit -->
+        <form id="arcRestoreForm" method="POST" action="?tab=account-cleanup" class="d-none">
+            <input type="hidden" name="csrf"          value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+            <input type="hidden" name="ac_action"     value="restore_account">
+            <input type="hidden" name="ac_threshold"  value="<?= (int) $acThreshold ?>">
+            <input type="hidden" name="acv_threshold" value="<?= (int) $acvThreshold ?>">
+            <input type="hidden" name="archive_id"    id="arcRestoreId" value="">
+        </form>
+    </div>
+</div>
+
+<script src="<?= $us_url_root ?>usersc/js/datatables.min.js"></script>
+<script>
+(function () {
+    'use strict';
+
+    var DATA_URL    = <?= json_encode($us_url_root . 'app/api/admin/account-cleanup-data.php') ?>;
+    var AC_THRESH   = <?= (int) $acThreshold ?>;
+    var ACV_THRESH  = <?= (int) $acvThreshold ?>;
+
+    // Escape a value for safe insertion into HTML markup
+    function esc(s) {
+        var d = document.createElement('div');
+        d.textContent = String(s == null ? '' : s);
+        return d.innerHTML;
+    }
+
+    // -------------------------------------------------------------------------
+    // Generic section setup
+    // -------------------------------------------------------------------------
+    function setupSection(opts) {
+        var selected  = new Set();
+        var tableInst = null;
+
+        var batchInput  = document.getElementById(opts.prefix + 'BatchLimit');
+        var limitDisp   = document.getElementById(opts.prefix + 'LimitDisplay');
+        var selectBtn   = document.getElementById(opts.prefix + 'SelectTopBtn');
+        var deselBtn    = document.getElementById(opts.prefix + 'DeselectBtn');
+        var deleteBtn   = document.getElementById(opts.prefix + 'DeleteBtn');
+        var selCountDisp= document.getElementById(opts.prefix + 'SelCount');
+        var countBadge  = document.getElementById(opts.prefix + 'Count');
+        var deleteForm  = document.getElementById(opts.prefix + 'DeleteForm');
+
+        batchInput.addEventListener('input', function () {
+            limitDisp.textContent = this.value;
+        });
+
+        function updateSelCount() {
+            var n = selected.size;
+            selCountDisp.textContent = n;
+            deleteBtn.disabled       = n === 0;
+        }
+
+        function syncCheckboxes() {
+            document.querySelectorAll('.' + opts.prefix + '-chk').forEach(function (cb) {
+                cb.checked = selected.has(parseInt(cb.value, 10));
+            });
+            updateSelCount();
+        }
+
+        // data: null columns receive null as first arg — use row param for the actual data
+        var checkboxRender = function (data, type, row) {
+            return '<input type="checkbox" class="form-check-input ' + opts.prefix + '-chk" value="' + parseInt(row.id, 10) + '">';
+        };
+
+        var idRender = function (data, type, row) {
+            return '<a href="../../users/admin.php?view=user&amp;id=' + parseInt(row.id, 10) + '" target="_blank" title="View in UserSpice admin">' + parseInt(row.id, 10) + '</a>';
+        };
+
+        var textRender = $.fn.dataTable.render.text();
+
+        var dtColumns = [{ data: null, orderable: false, searchable: false, render: checkboxRender }]
+            .concat(opts.columns.map(function (col) {
+                if (col.render) return col;
+                return { data: col.data, title: col.title, render: textRender };
+            }));
+
+        // Replace the id column with a link
+        dtColumns[1] = { data: null, title: 'ID', render: idRender };
+
+        tableInst = $('#' + opts.tableId).DataTable({
+            ajax: {
+                url: DATA_URL,
+                dataSrc: 'data',
+                data: { type: opts.type, threshold: opts.threshold }
+            },
+            columns: dtColumns,
+            pageLength: 10,
+            order: [[opts.defaultSortCol + 1, 'asc']],
+            language: { emptyTable: 'No accounts match the current criteria.' },
+            initComplete: function () {
+                if (countBadge) {
+                    countBadge.textContent = this.api().rows().count();
+                }
+            },
+            drawCallback: function () {
+                syncCheckboxes();
+                if (countBadge) {
+                    countBadge.textContent = this.api().rows().count();
+                }
+            }
+        });
+
+        // Checkbox click — delegated (rows added/replaced on redraw)
+        $('#' + opts.tableId + ' tbody').on('change', '.' + opts.prefix + '-chk', function () {
+            var id = parseInt(this.value, 10);
+            if (this.checked) selected.add(id);
+            else              selected.delete(id);
+            updateSelCount();
+        });
+
+        // Select top-N across ALL rows (not just current page)
+        selectBtn.addEventListener('click', function () {
+            var limit = parseInt(batchInput.value, 10) || 10;
+            selected.clear();
+            tableInst.rows().data().each(function (row, idx) {
+                if (idx < limit) selected.add(parseInt(row.id, 10));
+            });
+            syncCheckboxes();
+        });
+
+        deselBtn.addEventListener('click', function () {
+            selected.clear();
+            syncCheckboxes();
+        });
+
+        // Delete button — populate form then submit (modal for >10)
+        var confirmed = false;
+
+        deleteBtn.addEventListener('click', function () {
+            var n = selected.size;
+            if (n === 0) return;
+
+            function doSubmit() {
+                // Remove stale ID inputs
+                deleteForm.querySelectorAll('input[name$="[]"]').forEach(function (el) { el.remove(); });
+                // Add current selection
+                selected.forEach(function (id) {
+                    var inp = document.createElement('input');
+                    inp.type  = 'hidden';
+                    inp.name  = opts.idsField + '[]';
+                    inp.value = id;
+                    deleteForm.appendChild(inp);
+                });
+                deleteForm.submit();
+            }
+
+            if (n > 10 && !confirmed) {
+                showConfirmDialog(
+                    'Confirm Bulk Deletion',
+                    'Delete ' + n + ' selected accounts? This cannot be undone.',
+                    function () { confirmed = true; doSubmit(); }
+                );
+            } else {
+                doSubmit();
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Unverified section
+    // -------------------------------------------------------------------------
+    setupSection({
+        prefix:         'acu',
+        tableId:        'acuTable',
+        type:           'unverified',
+        threshold:      AC_THRESH,
+        defaultSortCol: 6,   // Joined
+        idsField:       'acu_ids',
+        columns: [
+            { data: 'id',      title: 'ID'         },
+            { data: 'email',   title: 'Email'       },
+            { data: 'name',    title: 'Name'        },
+            { data: 'city',    title: 'City'        },
+            { data: 'state',   title: 'State'       },
+            { data: 'country', title: 'Country'     },
+            { data: 'joined',  title: 'Joined'      },
+            { data: 'age_days',title: 'Age (days)'  },
+        ]
+    });
+
+    // -------------------------------------------------------------------------
+    // Verified section
+    // -------------------------------------------------------------------------
+    setupSection({
+        prefix:         'acv',
+        tableId:        'acvTable',
+        type:           'verified',
+        threshold:      ACV_THRESH,
+        defaultSortCol: 7,   // Last Login (index in opts.columns; +1 added for checkbox col)
+        idsField:       'acv_ids',
+        columns: [
+            { data: 'id',         title: 'ID'               },
+            { data: 'email',      title: 'Email'            },
+            { data: 'name',       title: 'Name'             },
+            { data: 'city',       title: 'City'             },
+            { data: 'state',      title: 'State'            },
+            { data: 'country',    title: 'Country'          },
+            { data: 'joined',     title: 'Account Created'  },
+            { data: 'last_login', title: 'Last Login',
+              render: function (d) { return d ? esc(d) : '—'; } },
+            { data: 'logins',     title: 'Logins'           },
+        ]
+    });
+
+    // -------------------------------------------------------------------------
+    // Archive section
+    // -------------------------------------------------------------------------
+    (function () {
+        var restoreForm = document.getElementById('arcRestoreForm');
+        var restoreIdInput = document.getElementById('arcRestoreId');
+        var countBadge = document.getElementById('arcCount');
+
+        var restoreRender = function (data, type, row) {
+            if (row.restored_at) return '';
+            // data-id is numeric only; email looked up from DataTables row on click
+            return '<button type="button" class="btn btn-sm btn-outline-success arc-restore-btn" '
+                + 'data-id="' + parseInt(row.id, 10) + '">'
+                + '<i class="fas fa-undo"></i> Restore</button>';
+        };
+
+        var statusRender = function (data, type, row) {
+            if (row.restored_at) {
+                var by = row.restored_by ? ' by ' + esc(row.restored_by) : '';
+                return '<span class="badge bg-success">Restored ' + esc(row.restored_at.substring(0, 10)) + by + '</span>';
+            }
+            return '<span class="badge bg-secondary">Archived</span>';
+        };
+
+        var locationRender = function (data, type, row) {
+            return [row.city, row.state, row.country].filter(Boolean).map(esc).join(', ') || '—';
+        };
+
+        var textRender = $.fn.dataTable.render.text();
+        var arcTable = $('#arcTable').DataTable({
+            ajax: { url: DATA_URL, dataSrc: 'data', data: { type: 'archive' } },
+            columns: [
+                { data: 'id',               title: 'Archive ID'    },
+                { data: 'original_user_id', title: 'Orig. User ID' },
+                { data: 'email',            title: 'Email',       render: textRender },
+                { data: 'name',             title: 'Name',        render: textRender },
+                { data: 'deletion_type',    title: 'Type',        render: textRender },
+                { data: 'deleted_at',       title: 'Deleted At',  render: textRender },
+                { data: null,               title: 'Location',    render: locationRender, orderable: false },
+                { data: null,               title: 'Status',      render: statusRender },
+                { data: null,               title: '',            render: restoreRender, orderable: false, searchable: false },
+            ],
+            pageLength: 10,
+            order: [[5, 'desc']],
+            language: { emptyTable: 'No archived accounts.' },
+            initComplete: function () {
+                if (countBadge) countBadge.textContent = this.api().rows().count();
+            },
+            drawCallback: function () {
+                if (countBadge) countBadge.textContent = this.api().rows().count();
+            }
+        });
+
+        // Restore button click — email from DataTables row data (never from DOM attribute)
+        $('#arcTable tbody').on('click', '.arc-restore-btn', function () {
+            var archiveId = parseInt(this.dataset.id, 10);
+            var rowData   = arcTable.row($(this).closest('tr')).data();
+            var email     = rowData ? rowData.email : '';
+
+            showConfirmDialog(
+                'Restore Account',
+                'Restore ' + email + '?\nA new account will be created. The user will need to re-verify their email before logging in.',
+                function () { restoreIdInput.value = archiveId; restoreForm.submit(); }
+            );
+        });
+    }());
+
+}());
+</script>

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -51,6 +51,7 @@ $validTabs = [
     'car-mgmt' => 'Car/Owner Relationships',
     'manage-cars' => 'Manage Cars',
     'owner-mgmt' => 'Manage Owners',
+    'account-cleanup' => 'Account Cleanup',
 ];
 
 $activeTab = isset($_GET['tab']) && array_key_exists($_GET['tab'], $validTabs) ? $_GET['tab'] : 'car-mgmt';
@@ -488,6 +489,14 @@ if (Input::exists('post')) {
                                         <?php if ($systemStatus['owner_issues'] > 0) { ?>
                                             <span class="badge text-bg-warning badge-sm ms-1"><?= $systemStatus['owner_issues'] ?></span>
                                         <?php } ?>
+                                    </a>
+                                </li>
+
+                                <!-- Account Cleanup Tab -->
+                                <li class="nav-item">
+                                    <a class="nav-link <?= $activeTab === 'account-cleanup' ? 'active' : '' ?>"
+                                       href="?tab=account-cleanup" role="tab">
+                                        <i class="fas fa-user-slash"></i> Account Cleanup
                                     </a>
                                 </li>
 

--- a/app/admin/scripts/fix/25-Create-Deleted-Accounts-Archive.php
+++ b/app/admin/scripts/fix/25-Create-Deleted-Accounts-Archive.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Create Deleted Accounts Archive Table
+ *
+ * Administrative script to create the deleted_accounts_archive table used by
+ * the Account Cleanup tab to preserve a restorable snapshot of every account
+ * deleted via the cleanup tool.
+ * Issue #1127: Account cleanup admin tab with archive and restore
+ *
+ * Run once. Safe to re-run — skips table creation if already exists.
+ *
+ * DEPLOYMENT INSTRUCTIONS:
+ * 1. Access via the Maintenance tab or direct URL
+ * 2. Review the description, then click "Run Script"
+ */
+
+define('SECTION_SEPARATOR', '═══════════════════════════════════════════════════════');
+
+require_once '../../../../users/init.php';
+require_once $abs_us_root . $us_url_root . 'users/includes/template/prep.php';
+
+if (!securePage($php_self)) {
+    die();
+}
+
+set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline): bool {
+    if ($errno !== E_DEPRECATED) {
+        logger(isset($user) ? $user->data()->id : 0, LogCategories::LOG_CATEGORY_FIX_SCRIPT,
+            "Error [{$errno}]: {$errstr} in {$errfile}:{$errline}");
+    }
+    return true;
+});
+
+$db = DB::getInstance();
+
+?>
+
+<div id="page-wrapper">
+    <div class="container-fluid">
+        <div class="well">
+
+            <?php if (!isset($_GET['start'])): ?>
+            <div class="row">
+                <div class="col-lg-12 mb-4">
+                    <div class="card registry-card">
+                        <div class="card-header">
+                            <h2 class="mb-0">
+                                <i class="fas fa-archive"></i> Create Deleted Accounts Archive Table
+                            </h2>
+                        </div>
+                        <div class="card-body">
+                            <p class="mb-3">
+                                Creates the <code>deleted_accounts_archive</code> table. The Account Cleanup tab
+                                writes a snapshot of each deleted account here before permanent removal, enabling
+                                one-click restore from the admin dashboard.
+                            </p>
+
+                            <div class="alert alert-info">
+                                <h5><i class="fas fa-info-circle"></i> What this script does:</h5>
+                                <ul class="mb-0">
+                                    <li>Creates <code>deleted_accounts_archive</code> if it does not already exist</li>
+                                    <li>Stores: original user ID, email, name, join date, last login, logins count, location, deletion metadata (password hash is intentionally excluded)</li>
+                                    <li>Includes <code>restored_at</code> / <code>restored_by</code> columns for the restore audit trail</li>
+                                    <li>Safe to re-run — skips silently if the table already exists</li>
+                                </ul>
+                            </div>
+
+                            <div class="alert alert-warning">
+                                <h5><i class="fas fa-exclamation-triangle"></i> Notes:</h5>
+                                <ul class="mb-0">
+                                    <li>One-time migration — run once after deployment</li>
+                                    <li>No data is modified; this only creates a table</li>
+                                </ul>
+                            </div>
+
+                            <div class="text-center">
+                                <a href="?start=1" class="btn btn-success btn-lg">
+                                    <i class="fas fa-play"></i> Run Script
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <?php else:
+                ob_end_clean();
+                header('Content-Type: text/html; charset=utf-8');
+                echo str_repeat(' ', 1024);
+                flush();
+            ?>
+
+            <div class="card registry-card">
+                <div class="card-header">
+                    <h2 class="mb-0">
+                        <i class="fas fa-cogs"></i> Creating Archive Table
+                    </h2>
+                    <small class="text-muted">
+                        <i class="fas fa-clock"></i> Started: <?= date('Y-m-d H:i:s') ?>
+                    </small>
+                </div>
+                <div class="card-body">
+                    <pre style="background:#f5f5f5;padding:15px;border-radius:4px;max-height:600px;overflow-y:auto;font-family:'Courier New',monospace;font-size:13px;"><?php
+
+                    function logProgress(string $message, string $type = 'info'): void {
+                        $icons = ['info' => 'ℹ️', 'success' => '✅', 'error' => '❌', 'warning' => '⚠️', 'step' => '▶️'];
+                        echo date('[H:i:s] ') . ($icons[$type] ?? '•') . ' ' . $message . "\n";
+                        flush();
+                    }
+
+                    try {
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('Creating deleted_accounts_archive table', 'step');
+                        logProgress(SECTION_SEPARATOR, 'step');
+
+                        $db->query("
+                            CREATE TABLE IF NOT EXISTS deleted_accounts_archive (
+                                id               INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                                original_user_id INT UNSIGNED NOT NULL,
+                                email            VARCHAR(155)  DEFAULT NULL,
+                                username         VARCHAR(255)  DEFAULT NULL,
+                                fname            VARCHAR(255)  DEFAULT NULL,
+                                lname            VARCHAR(255)  DEFAULT NULL,
+                                join_date        DATETIME      DEFAULT NULL,
+                                last_login       DATETIME      DEFAULT NULL,
+                                logins           INT           DEFAULT 0,
+                                email_verified   TINYINT(1)    DEFAULT 0,
+                                city             VARCHAR(100)  DEFAULT NULL,
+                                state            VARCHAR(100)  DEFAULT NULL,
+                                country          VARCHAR(100)  DEFAULT NULL,
+                                bio              TEXT          DEFAULT NULL,
+                                website          VARCHAR(100)  DEFAULT NULL,
+                                deleted_by       INT UNSIGNED  NOT NULL,
+                                deleted_at       DATETIME      NOT NULL,
+                                deletion_type    ENUM('unverified','verified') NOT NULL,
+                                restored_at      DATETIME      DEFAULT NULL,
+                                restored_by      INT UNSIGNED  DEFAULT NULL,
+                                INDEX idx_original_user_id (original_user_id),
+                                INDEX idx_deleted_at (deleted_at)
+                            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+                        ", []);
+
+                        logProgress('Table deleted_accounts_archive created (or already existed)', 'success');
+
+                        $db->insert('fix_script_runs', [
+                            'script_name'  => '25-Create-Deleted-Accounts-Archive.php',
+                            'completed_at' => date('Y-m-d H:i:s'),
+                        ]);
+
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT,
+                            'Script 25-Create-Deleted-Accounts-Archive.php completed successfully');
+
+                        logProgress('', 'info');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('DONE — archive table is ready', 'success');
+                        logProgress(SECTION_SEPARATOR, 'step');
+                        logProgress('Next: Account Cleanup tab will now archive accounts before deletion', 'info');
+
+                    } catch (Exception $e) {
+                        logProgress('FATAL ERROR: ' . $e->getMessage(), 'error');
+                        logger($user->data()->id, LogCategories::LOG_CATEGORY_FIX_SCRIPT,
+                            'Fatal error in 25-Create-Deleted-Accounts-Archive: ' . $e->getMessage());
+                    }
+
+                    ?></pre>
+
+                    <div class="text-center mt-3">
+                        <a href="../../maintenance.php?tab=maintenance" class="btn btn-primary btn-lg">
+                            <i class="fas fa-arrow-left"></i> Return to Maintenance
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <?php endif; ?>
+
+        </div>
+    </div>
+</div>
+
+<?php require_once $abs_us_root . $us_url_root . 'users/includes/html_footer.php'; ?>

--- a/app/api/admin/account-cleanup-data.php
+++ b/app/api/admin/account-cleanup-data.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Account cleanup DataTables AJAX endpoint
+ *
+ * Returns ownerless or archived accounts as JSON for DataTables on the
+ * admin Account Cleanup tab.
+ *
+ * Query params:
+ *   type      — 'unverified' | 'verified' | 'archive'
+ *   threshold — int (days); ≥30 for unverified, ≥1 for verified; ignored for archive
+ */
+
+require_once '../../../users/init.php';
+require_once $abs_us_root . $us_url_root . 'app/admin/includes/account-cleanup-helpers.php';
+
+if (!isAdmin()) {
+    http_response_code(403);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['error' => 'Forbidden']);
+    exit;
+}
+
+$type      = $_GET['type']      ?? '';
+$threshold = (int) ($_GET['threshold'] ?? 30);
+
+header('Content-Type: application/json; charset=utf-8');
+
+if ($type === 'unverified') {
+    $threshold = max(30, $threshold);
+    $accounts  = findUnverifiedOwnerlessAccounts($db, $threshold);
+    if ($db->error()) {
+        logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'account-cleanup-data: unverified query failed — ' . $db->errorString());
+        http_response_code(500);
+        echo json_encode(['error' => 'Database error']);
+        exit;
+    }
+    $rows = array_map(static function (object $a): array {
+        return [
+            'id'       => (int) $a->id,
+            'email'    => (string) $a->email,
+            'name'     => trim(($a->fname ?? '') . ' ' . ($a->lname ?? '')),
+            'city'     => (string) ($a->city    ?? ''),
+            'state'    => (string) ($a->state   ?? ''),
+            'country'  => (string) ($a->country ?? ''),
+            'joined'   => (string) $a->join_date,
+            'age_days' => (int) $a->age_days,
+        ];
+    }, $accounts);
+} elseif ($type === 'verified') {
+    $threshold = max(1, $threshold);
+    $accounts  = findVerifiedOwnerlessAccounts($db, $threshold);
+    if ($db->error()) {
+        logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'account-cleanup-data: verified query failed — ' . $db->errorString());
+        http_response_code(500);
+        echo json_encode(['error' => 'Database error']);
+        exit;
+    }
+    $rows = array_map(static function (object $a): array {
+        $ll = $a->last_login ?? null;
+        return [
+            'id'         => (int) $a->id,
+            'email'      => (string) $a->email,
+            'name'       => trim(($a->fname ?? '') . ' ' . ($a->lname ?? '')),
+            'city'       => (string) ($a->city    ?? ''),
+            'state'      => (string) ($a->state   ?? ''),
+            'country'    => (string) ($a->country ?? ''),
+            'joined'     => (string) $a->join_date,
+            'last_login' => ($ll && $ll !== '0000-00-00 00:00:00') ? $ll : null,
+            'logins'     => (int) $a->logins,
+        ];
+    }, $accounts);
+} elseif ($type === 'archive') {
+    $accounts = findArchivedAccounts($db);
+    if ($db->error()) {
+        logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'account-cleanup-data: archive query failed — ' . $db->errorString());
+        http_response_code(500);
+        echo json_encode(['error' => 'Database error']);
+        exit;
+    }
+    $rows = array_map(static function (object $a): array {
+        $restoredBy = ($a->restored_by_fname || $a->restored_by_lname)
+            ? trim(($a->restored_by_fname ?? '') . ' ' . ($a->restored_by_lname ?? ''))
+            : null;
+        return [
+            'id'               => (int) $a->id,
+            'original_user_id' => (int) $a->original_user_id,
+            'email'            => (string) $a->email,
+            'name'             => trim(($a->fname ?? '') . ' ' . ($a->lname ?? '')),
+            'deletion_type'    => (string) $a->deletion_type,
+            'deleted_at'       => (string) $a->deleted_at,
+            'city'             => (string) ($a->city    ?? ''),
+            'state'            => (string) ($a->state   ?? ''),
+            'country'          => (string) ($a->country ?? ''),
+            'restored_at'      => $a->restored_at ?: null,
+            'restored_by'      => $restoredBy,
+        ];
+    }, $accounts);
+} else {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid type']);
+    exit;
+}
+
+echo json_encode(['data' => $rows]);

--- a/docs/releases/RELEASE_NOTES_v2.25.7.md
+++ b/docs/releases/RELEASE_NOTES_v2.25.7.md
@@ -20,7 +20,7 @@
 
 ### New Features
 
-- **Unverified account cleanup tool** ([#1127](https://github.com/unibrain1/elanregistry/issues/1127)): New maintenance script to review and delete unverified accounts with no car associations — an admin-initiated, GDPR-aligned replacement for the removed automated cleanup cron.
+- **Unverified account cleanup tool** ([#1127](https://github.com/unibrain1/elanregistry/issues/1127)): New tab on the admin dashboard to review and selectively delete unverified accounts with no car associations — an admin-initiated, GDPR-aligned replacement for the removed automated cleanup cron.
 
 ### Improvements
 

--- a/tests/integration/FindUnverifiedOwnerlessAccountsIntegrationTest.php
+++ b/tests/integration/FindUnverifiedOwnerlessAccountsIntegrationTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+require_once __DIR__ . '/../../app/admin/includes/account-cleanup-helpers.php';
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration tests for findUnverifiedOwnerlessAccounts().
+ *
+ * Each test creates real database fixtures (users, cars, car_user rows) and
+ * asserts that the function's SQL filters include or exclude those fixtures
+ * correctly. All fixtures are cleaned up automatically in tearDown().
+ *
+ * Tests assert presence/absence of a specific user ID in results; they never
+ * assert row counts because the live database contains other accounts.
+ *
+ * @see FindUnverifiedOwnerlessAccountsTest  (unit tests — SQL-agnostic)
+ */
+#[Group('integration')]
+#[Group('admin')]
+final class FindUnverifiedOwnerlessAccountsIntegrationTest extends IntegrationTestCase
+{
+    /** @var int[] car_user row IDs inserted directly by tests — cleaned in tearDown */
+    private array $createdCarUserIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        // Remove any car_user rows we inserted manually (before parent deletes the cars).
+        foreach ($this->createdCarUserIds as $carUserId) {
+            try {
+                $this->db->query("DELETE FROM car_user WHERE id = ?", [$carUserId]);
+            } catch (\Throwable $e) {
+                // Ignore cleanup errors — parent tearDown may have already removed them
+                // via the car_id cascade.
+            }
+        }
+        $this->createdCarUserIds = [];
+
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return a date string exactly $days days ago at midnight (00:00:00).
+     * Midnight keeps DATEDIFF deterministic regardless of the time the test runs.
+     */
+    private function daysAgo(int $days): string
+    {
+        return date('Y-m-d', strtotime("-{$days} days")) . ' 00:00:00';
+    }
+
+    /**
+     * Extract user IDs from results as strings.
+     *
+     * DB::query() returns integer columns as strings (PDO default behaviour).
+     * PHPUnit assertContains/assertNotContains use strict (===) comparison, so
+     * comparing an int $userId against a string '5003' would silently give the
+     * wrong answer. Casting here keeps assertions correct regardless of the
+     * underlying PDO fetch mode.
+     *
+     * @param array<object> $results
+     * @return string[]
+     */
+    private function idsFrom(array $results): array
+    {
+        return array_map('strval', array_column($results, 'id'));
+    }
+
+    // -------------------------------------------------------------------------
+    // Inclusion tests — the user SHOULD appear in results
+    // -------------------------------------------------------------------------
+
+    /**
+     * A user who is active, unverified, unprotected, not named 'noowner',
+     * has no cars, and joined more than 30 days ago must be included.
+     */
+    #[Group('integration')]
+    #[Group('admin')]
+    public function testFindsUnverifiedOwnerlessAccount(): void
+    {
+        $userId = $this->createTestUser(['join_date' => $this->daysAgo(31)]);
+
+        $results = findUnverifiedOwnerlessAccounts($this->db, 30);
+        $ids     = $this->idsFrom($results);
+
+        $this->assertContains((string) $userId, $ids, 'User with no cars and old enough join date should appear in results');
+    }
+
+    // -------------------------------------------------------------------------
+    // Exclusion tests — the user must NOT appear in results
+    // -------------------------------------------------------------------------
+
+    /**
+     * A user whose email is already verified must be excluded even if they
+     * have no cars and joined long ago.
+     */
+    #[Group('integration')]
+    #[Group('admin')]
+    public function testExcludesEmailVerifiedAccount(): void
+    {
+        $userId = $this->createTestUser([
+            'email_verified' => 1,
+            'join_date'      => $this->daysAgo(31),
+        ]);
+
+        $results = findUnverifiedOwnerlessAccounts($this->db, 30);
+        $ids     = $this->idsFrom($results);
+
+        $this->assertNotContains((string) $userId, $ids, 'Email-verified user must be excluded');
+    }
+
+    /**
+     * A user who owns a car (row in the `cars` table via user_id) must be
+     * excluded even though their email is unverified.
+     *
+     * createTestCar() inserts into both `cars` (user_id) and `car_user` (userid),
+     * exercising both NOT EXISTS clauses simultaneously. The first clause
+     * (NOT EXISTS cars WHERE user_id) alone is sufficient for exclusion here.
+     */
+    #[Group('integration')]
+    #[Group('admin')]
+    public function testExcludesAccountWithCarsRow(): void
+    {
+        $userId = $this->createTestUser(['join_date' => $this->daysAgo(31)]);
+        $this->createTestCar($userId);
+
+        $results = findUnverifiedOwnerlessAccounts($this->db, 30);
+        $ids     = $this->idsFrom($results);
+
+        $this->assertNotContains((string) $userId, $ids, 'User with a cars row must be excluded');
+    }
+
+    /**
+     * A user who appears in the car_user junction table (but has no row in
+     * the cars table as owner) must be excluded via the second NOT EXISTS clause.
+     *
+     * Setup:
+     *   1. Create the user under test (no cars of their own).
+     *   2. Create a separate dummy user and a car for them — this gives us a
+     *      real car_id to satisfy any FK constraints on car_user.car_id.
+     *   3. Insert a car_user row linking the test user to that car.
+     *   4. Track the inserted row ID for cleanup in tearDown().
+     */
+    #[Group('integration')]
+    #[Group('admin')]
+    public function testExcludesAccountWithCarUserRow(): void
+    {
+        $testUserId  = $this->createTestUser(['join_date' => $this->daysAgo(31)]);
+        $dummyUserId = $this->createTestUser();
+        $carId       = $this->createTestCar($dummyUserId);
+
+        // Manually link testUser → existing car via car_user.
+        $this->db->insert('car_user', ['userid' => $testUserId, 'car_id' => $carId]);
+        $row = $this->db->query(
+            "SELECT id FROM car_user WHERE userid = ? AND car_id = ? ORDER BY id DESC LIMIT 1",
+            [$testUserId, $carId]
+        )->first();
+        if ($row) {
+            $this->createdCarUserIds[] = (int) $row->id;
+        }
+
+        $results = findUnverifiedOwnerlessAccounts($this->db, 30);
+        $ids     = $this->idsFrom($results);
+
+        $this->assertNotContains((string) $testUserId, $ids, 'User with a car_user row must be excluded');
+    }
+
+    /**
+     * A protected account (protected = 1) must be excluded regardless of
+     * verification status or car ownership.
+     */
+    #[Group('integration')]
+    #[Group('admin')]
+    public function testExcludesProtectedAccount(): void
+    {
+        $userId = $this->createTestUser([
+            'protected' => 1,
+            'join_date' => $this->daysAgo(31),
+        ]);
+
+        $results = findUnverifiedOwnerlessAccounts($this->db, 30);
+        $ids     = $this->idsFrom($results);
+
+        $this->assertNotContains((string) $userId, $ids, 'Protected user must be excluded');
+    }
+
+    /**
+     * An account with username 'noowner' must be excluded because the query
+     * uses it as the "unassigned cars" sentinel user.
+     */
+    #[Group('integration')]
+    #[Group('admin')]
+    public function testExcludesNoownerUsername(): void
+    {
+        $userId = $this->createTestUser([
+            'username'  => 'noowner',
+            'join_date' => $this->daysAgo(31),
+        ]);
+
+        $results = findUnverifiedOwnerlessAccounts($this->db, 30);
+        $ids     = $this->idsFrom($results);
+
+        $this->assertNotContains((string) $userId, $ids, "User with username 'noowner' must be excluded");
+    }
+
+    // -------------------------------------------------------------------------
+    // Threshold boundary tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * A user whose account age equals the threshold exactly (DATEDIFF = 30 >= 30)
+     * must be included — the boundary is inclusive.
+     *
+     * join_date set to midnight exactly 30 days ago so DATEDIFF(NOW(), join_date)
+     * is stable at 30 regardless of test run time.
+     */
+    #[Group('integration')]
+    #[Group('admin')]
+    public function testThresholdBoundaryExactMatch(): void
+    {
+        $userId = $this->createTestUser(['join_date' => $this->daysAgo(30)]);
+
+        $results = findUnverifiedOwnerlessAccounts($this->db, 30);
+        $ids     = $this->idsFrom($results);
+
+        $this->assertContains((string) $userId, $ids, 'User whose account age equals the threshold (30 == 30) must be included');
+    }
+
+    /**
+     * A user whose account age is one day short of the threshold (DATEDIFF = 29 < 30)
+     * must NOT be included — the boundary is exclusive for younger accounts.
+     *
+     * join_date set to midnight exactly 29 days ago so DATEDIFF(NOW(), join_date)
+     * is stable at 29 regardless of test run time.
+     */
+    #[Group('integration')]
+    #[Group('admin')]
+    public function testThresholdBoundaryOneDayShort(): void
+    {
+        $userId = $this->createTestUser(['join_date' => $this->daysAgo(29)]);
+
+        $results = findUnverifiedOwnerlessAccounts($this->db, 30);
+        $ids     = $this->idsFrom($results);
+
+        $this->assertNotContains((string) $userId, $ids, 'User whose account age is one day below the threshold (29 < 30) must be excluded');
+    }
+}

--- a/tests/playwright/admin-unverified-account-cleanup.spec.js
+++ b/tests/playwright/admin-unverified-account-cleanup.spec.js
@@ -1,0 +1,73 @@
+// tests/playwright/admin-unverified-account-cleanup.spec.js
+//
+// Behavioral tests for the Account Cleanup tab on the admin index page.
+// Covers: threshold form, CSRF token, DataTables auto-load, confirmation modal.
+//
+// Requires local MAMP at http://localhost:9999/elan-registry
+// See: app/admin/index.php?tab=account-cleanup
+
+const { test, expect } = require('@playwright/test');
+const { ensureLoggedIn } = require('./auth-helper.js');
+
+const ADMIN_URL = 'http://localhost:9999/elan-registry/app/admin/index.php?tab=account-cleanup';
+
+test.describe('Admin Account Cleanup Tab', () => {
+    test.beforeEach(async ({ page }) => {
+        await ensureLoggedIn(page);
+        await page.goto(ADMIN_URL, { waitUntil: 'networkidle' });
+    });
+
+    test('page loads with threshold form and both table skeletons', async ({ page }) => {
+        const acInput  = page.locator('input[name="ac_threshold"]');
+        const acvInput = page.locator('input[name="acv_threshold"]');
+
+        await expect(acInput).toBeVisible();
+        await expect(acvInput).toBeVisible();
+
+        await expect(acInput).toHaveValue('30');
+        await expect(acvInput).toHaveValue('365');
+
+        expect(await acInput.getAttribute('min')).toBe('30');
+        expect(await acvInput.getAttribute('min')).toBe('1');
+
+        await expect(page.locator('button[type="submit"]').filter({ hasText: 'Apply' })).toBeVisible();
+
+        await expect(page.locator('#acuTable')).toBeAttached();
+        await expect(page.locator('#acvTable')).toBeAttached();
+    });
+
+    test('CSRF tokens are present in delete forms', async ({ page }) => {
+        // Two delete forms (acu + acv), each with a csrf hidden input
+        const csrfInputs = page.locator('form[id$="DeleteForm"] input[name="csrf"]');
+
+        await expect(csrfInputs).toHaveCount(2);
+
+        for (const input of await csrfInputs.all()) {
+            const value = await input.getAttribute('value');
+            expect(value).toBeTruthy();
+            expect(value.length).toBe(64);
+            expect(value).toMatch(/^[0-9a-f]+$/);
+        }
+    });
+
+    test('DataTables initializes without manual trigger', async ({ page }) => {
+        // DataTables replaces the plain <table> — wait for the wrapper div
+        await expect(page.locator('#acuTable_wrapper')).toBeVisible({ timeout: 10000 });
+        await expect(page.locator('#acvTable_wrapper')).toBeVisible({ timeout: 10000 });
+    });
+
+    test('confirmation modal structure and abort', async ({ page }) => {
+        await page.evaluate(() => {
+            const modal = new bootstrap.Modal(document.getElementById('confirmationModal'));
+            modal.show();
+        });
+
+        await expect(page.locator('#confirmationModal')).toBeVisible({ timeout: 3000 });
+
+        await expect(page.locator('#confirmButton')).toBeVisible();
+        await expect(page.locator('#confirmationModal .btn-secondary[data-bs-dismiss="modal"]')).toBeVisible();
+
+        await page.locator('#confirmationModal .btn-secondary[data-bs-dismiss="modal"]').click();
+        await expect(page.locator('#confirmationModal')).not.toBeVisible({ timeout: 3000 });
+    });
+});

--- a/tests/unit/admin/FindUnverifiedOwnerlessAccountsTest.php
+++ b/tests/unit/admin/FindUnverifiedOwnerlessAccountsTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../app/admin/includes/account-cleanup-helpers.php';
+
+/**
+ * Unit tests for findUnverifiedOwnerlessAccounts() in account-cleanup-helpers.php.
+ *
+ * These tests use an inline anonymous DB mock that extends the bootstrap's DB class
+ * so the strict `DB $db` type hint in the function under test is satisfied at runtime.
+ * The anonymous class returns a real QueryResult so the ->results() chain works without
+ * any special plumbing.
+ *
+ * What is NOT tested here (delegated to integration tests):
+ *   - Actual SQL filter correctness (email_verified, active, protected, NOT EXISTS)
+ *   - DATEDIFF boundary behaviour
+ *
+ * @see FindUnverifiedOwnerlessAccountsIntegrationTest
+ */
+#[Group('fast')]
+#[Group('unit')]
+#[Group('admin')]
+final class FindUnverifiedOwnerlessAccountsTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Factory helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a DB mock that returns $rows from ->results() and records the last
+     * SQL parameters for inspection via getLastParams().
+     *
+     * The anonymous class extends the bootstrap mock DB so the `DB $db` type
+     * hint in findUnverifiedOwnerlessAccounts() is satisfied at runtime.
+     */
+    private function makeDb(array $rows): object
+    {
+        return new class($rows) extends DB {
+            private array $lastParams = [];
+
+            public function __construct(private readonly array $rows) {}
+
+            public function query(string $sql, array $params = []): QueryResult
+            {
+                $this->lastParams = $params;
+                return new QueryResult($this->rows);
+            }
+
+            public function getLastParams(): array
+            {
+                return $this->lastParams;
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the database returns two rows the function must return exactly
+     * those two rows with their values intact.
+     */
+    #[Group('fast')]
+    #[Group('unit')]
+    #[Group('admin')]
+    public function testReturnsRowsProvidedByDatabase(): void
+    {
+        $row1 = (object) ['id' => 42, 'email' => 'alice@example.com', 'fname' => 'Alice', 'lname' => 'Smith'];
+        $row2 = (object) ['id' => 99, 'email' => 'bob@example.com',   'fname' => 'Bob',   'lname' => 'Jones'];
+
+        $db     = $this->makeDb([$row1, $row2]);
+        $result = findUnverifiedOwnerlessAccounts($db, 30);
+
+        $this->assertCount(2, $result);
+        $this->assertSame($row1, $result[0]);
+        $this->assertSame($row2, $result[1]);
+    }
+
+    /**
+     * When the database returns no rows the function must return an empty array,
+     * not null or false.
+     */
+    #[Group('fast')]
+    #[Group('unit')]
+    #[Group('admin')]
+    public function testReturnsEmptyArrayWhenNoRows(): void
+    {
+        $db     = $this->makeDb([]);
+        $result = findUnverifiedOwnerlessAccounts($db, 30);
+
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * The days threshold must be forwarded as the first (and only) positional
+     * parameter to DB::query() so the SQL placeholder is bound correctly.
+     */
+    #[Group('fast')]
+    #[Group('unit')]
+    #[Group('admin')]
+    public function testPassesDaysParameterToQuery(): void
+    {
+        $db = $this->makeDb([]);
+        findUnverifiedOwnerlessAccounts($db, 30);
+
+        $params = $db->getLastParams();
+
+        $this->assertCount(1, $params, 'Exactly one bind parameter expected');
+        $this->assertSame(30, $params[0]);
+    }
+
+    /**
+     * Verifies that a different threshold value (90) is forwarded unchanged —
+     * ruling out any accidental hard-coding of the default value inside the
+     * function.
+     */
+    #[Group('fast')]
+    #[Group('unit')]
+    #[Group('admin')]
+    public function testThresholdVariationPassedCorrectly(): void
+    {
+        $db = $this->makeDb([]);
+        findUnverifiedOwnerlessAccounts($db, 90);
+
+        $params = $db->getLastParams();
+
+        $this->assertSame(90, $params[0]);
+    }
+
+    /**
+     * The array returned by the function must be the exact array returned by
+     * QueryResult::results() — not a copy, subset, or re-keyed version.
+     */
+    #[Group('fast')]
+    #[Group('unit')]
+    #[Group('admin')]
+    public function testResultsAreReturnedDirectly(): void
+    {
+        $expected = [
+            (object) ['id' => 7,  'email' => 'x@example.com'],
+            (object) ['id' => 13, 'email' => 'y@example.com'],
+            (object) ['id' => 21, 'email' => 'z@example.com'],
+        ];
+
+        $db     = $this->makeDb($expected);
+        $result = findUnverifiedOwnerlessAccounts($db, 30);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Verifies that the function calls query() before accessing results().
+     *
+     * A shared-state sentinel object is passed into both the DB mock and the
+     * QueryResult-like object it returns. If results() were somehow reached
+     * without query() having run first, a RuntimeException would be thrown and
+     * the test would fail. The function under test calls the chain in the
+     * correct order, so the assertion on $state->queryWasCalled confirms the
+     * expected call sequence.
+     */
+    #[Group('fast')]
+    #[Group('unit')]
+    #[Group('admin')]
+    public function testQueryChainIsCalledCorrectly(): void
+    {
+        $state = (object) ['queryWasCalled' => false];
+
+        $db = new class($state) extends DB {
+            public function __construct(private readonly object $state) {}
+
+            public function query(string $sql, array $params = []): QueryResult
+            {
+                $this->state->queryWasCalled = true;
+                $s = $this->state;
+
+                // Return a QueryResult subclass whose results() enforces ordering.
+                return new class($s) extends QueryResult {
+                    public function __construct(private readonly object $s)
+                    {
+                        // Intentionally skip parent::__construct() — we override results().
+                    }
+
+                    public function results(): array
+                    {
+                        if (!$this->s->queryWasCalled) {
+                            throw new \RuntimeException('results() was reached before query() was called');
+                        }
+                        return [];
+                    }
+                };
+            }
+        };
+
+        $result = findUnverifiedOwnerlessAccounts($db, 30);
+
+        $this->assertIsArray($result);
+        $this->assertTrue($state->queryWasCalled, 'query() must be called before results()');
+    }
+}


### PR DESCRIPTION
## Summary

- New **Account Cleanup** tab on `app/admin/index.php` for reviewing and selectively deleting unverified and verified ownerless accounts (an admin-initiated replacement for the removed automated cleanup cron, issue #1066)
- Accounts are snapshotted to a new `deleted_accounts_archive` table before permanent deletion; restorable one-click from the same tab
- Password hashes intentionally excluded from the archive; restored accounts require a password reset via forgot-password flow

## Key design decisions

- **Archive-before-delete** with transaction: `archiveAccounts()` wraps all inserts in a transaction and throws `RuntimeException` on any failure; the delete path catches this and aborts without touching `deleteUsers()`
- **Restore safety**: `restoreArchivedAccount()` also runs in a transaction — re-inserts user + `user_permission_matches` (base member group) + profile, then marks the archive row restored; any write failure rolls back the whole operation
- **TOCTOU guard**: eligible accounts are re-queried at delete time and intersected with submitted IDs, so stale selections can't delete accounts that no longer qualify
- **DataTables AJAX**: three endpoints (`unverified` / `verified` / `archive`) on `app/api/admin/account-cleanup-data.php`; returns HTTP 500 + logger on DB failure

## Files

| File | Change |
|---|---|
| `app/admin/index.php` | Add `account-cleanup` tab to `$validTabs` + nav |
| `app/admin/includes/tab-account_cleanup.php` | New tab implementation |
| `app/admin/includes/account-cleanup-helpers.php` | Query + archive/restore helpers |
| `app/api/admin/account-cleanup-data.php` | DataTables AJAX endpoint |
| `app/admin/scripts/fix/25-Create-Deleted-Accounts-Archive.php` | One-time migration to create `deleted_accounts_archive` table |
| `tests/unit/admin/FindUnverifiedOwnerlessAccountsTest.php` | Unit tests |
| `tests/integration/FindUnverifiedOwnerlessAccountsIntegrationTest.php` | Integration tests |
| `tests/playwright/admin-unverified-account-cleanup.spec.js` | Playwright tests |

## Test plan

- [ ] Run fix script #25 from the Maintenance tab to create `deleted_accounts_archive`
- [ ] Visit `app/admin/index.php?tab=account-cleanup` — confirm tab renders with threshold form and both DataTables
- [ ] Adjust thresholds — confirm URL updates and tables reload
- [ ] Select accounts and delete — confirm archive rows appear in the Archive section
- [ ] Restore an archived account — confirm new user ID shown, archive row marked restored
- [ ] Confirm archive failure (table missing) aborts delete and shows error
- [ ] `composer test:quick` — 1042/1042 pass
- [ ] `composer test:medium` — integration suite passes

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM