### PR TITLE
fix: null-guard in getSeriesCounts() and DB error logging in executeQuery() (#1197)

### DIFF
--- a/usersc/classes/StatisticsDataService.php
+++ b/usersc/classes/StatisticsDataService.php
@@ -29,17 +29,26 @@ class StatisticsDataService {
      *
      * @param string $query SQL query to execute
      * @param bool $single Whether to return single result or array
-     * @return array|object|null Query results
+     * @return array|object|null Query results, or null/empty array on database error (error is logged)
      */
     private function executeQuery(string $query, bool $single = false): array|object|null {
         try {
             $result = $this->db->query($query);
+            // UserSpice DB class swallows errors internally and never throws — check explicitly.
+            if ($this->db->error()) {
+                logger(
+                    0,
+                    LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                    'StatisticsDataService query failed: ' . $this->db->errorString() . ' | Query: ' . substr($query, 0, 200)
+                );
+                return $single ? null : [];
+            }
             return $single ? $result->first() : $result->results();
         } catch (\Throwable $e) {
             logger(
                 0,
                 LogCategories::LOG_CATEGORY_DATABASE_ERROR,
-                'StatisticsDataService query failed: ' . $e->getMessage() . ' | Query: ' . substr($query, 0, 200)
+                'StatisticsDataService query threw: ' . $e->getMessage() . ' | Query: ' . substr($query, 0, 200)
             );
             return $single ? null : [];
         }
@@ -194,6 +203,9 @@ class StatisticsDataService {
              FROM cars",
             true
         );
+        if ($row === null) {
+            return ['s1' => 0, 's2' => 0, 's3' => 0, 's4' => 0, 'sprint' => 0, '+2' => 0];
+        }
         return [
             's1'     => (int)($row->s1     ?? 0),
             's2'     => (int)($row->s2     ?? 0),


### PR DESCRIPTION
## Summary

Fixes two silent-failure bugs in `StatisticsDataService`.

### HIGH-3 — null->property Fatal Error in getSeriesCounts()

`getSeriesCounts()` called `executeQuery($sql, true)` and then accessed properties on the return value directly. When the DB query fails, UserSpice's DB class returns `null` from `->first()` without throwing. In PHP 8.2, `$row->s1` on `null` raises a fatal `Error` before `??` can save it — the statistics page crashes completely.

Added an explicit `if ($row === null)` guard that returns a zero-filled array gracefully on DB failure.

### MEDIUM-1 — executeQuery() catch block dead for normal DB failures

The `try/catch (\Throwable)` in `executeQuery()` only fires for thrown exceptions. The UserSpice DB class swallows query errors internally and never throws — it sets an internal error flag. So query failures were silently returning empty results with no log entry.

Added a `$this->db->error()` check on the normal success path. Query failures now log via `LOG_CATEGORY_DATABASE_ERROR` and return the appropriate empty value.

## Files Changed
- `usersc/classes/StatisticsDataService.php`

## Tests
- All 1042 unit tests pass
- PHPStan and phpcs clean on changed file

Closes #1197