### PR TITLE
fix: always confirm deletion and use ApiResponse for errors (#1200)

### DIFF
--- a/app/admin/includes/tab-account_cleanup.php
+++ b/app/admin/includes/tab-account_cleanup.php
@@ -482,9 +482,7 @@ $renderSection(
             syncCheckboxes();
         });
 
-        // Delete button — populate form then submit (modal for >10)
-        var confirmed = false;
-
+        // Delete button — always confirm before submitting
         deleteBtn.addEventListener('click', function () {
             var n = selected.size;
             if (n === 0) return;
@@ -503,15 +501,11 @@ $renderSection(
                 deleteForm.submit();
             }
 
-            if (n > 10 && !confirmed) {
-                showConfirmDialog(
-                    'Confirm Bulk Deletion',
-                    'Delete ' + n + ' selected accounts? This cannot be undone.',
-                    function () { confirmed = true; doSubmit(); }
-                );
-            } else {
-                doSubmit();
-            }
+            showConfirmDialog(
+                'Confirm Deletion',
+                'Delete ' + n + ' selected account' + (n === 1 ? '' : 's') + '? Accounts will be archived and can be restored if needed.',
+                doSubmit
+            );
         });
     }
 

--- a/app/api/admin/account-cleanup-data.php
+++ b/app/api/admin/account-cleanup-data.php
@@ -17,24 +17,19 @@ require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'app/admin/includes/account-cleanup-helpers.php';
 
 if (!isAdmin()) {
-    http_response_code(403);
-    header('Content-Type: application/json; charset=utf-8');
-    echo json_encode(['error' => 'Forbidden']);
+    ApiResponse::forbidden('Forbidden')->send();
     exit;
 }
 
 $type      = $_GET['type']      ?? '';
 $threshold = (int) ($_GET['threshold'] ?? 30);
 
-header('Content-Type: application/json; charset=utf-8');
-
 if ($type === 'unverified') {
     $threshold = max(30, $threshold);
     $accounts  = findUnverifiedOwnerlessAccounts($db, $threshold);
     if ($db->error()) {
         logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'account-cleanup-data: unverified query failed — ' . $db->errorString());
-        http_response_code(500);
-        echo json_encode(['error' => 'Database error']);
+        ApiResponse::serverError('Database error')->send();
         exit;
     }
     $rows = array_map(static function (object $a): array {
@@ -54,8 +49,7 @@ if ($type === 'unverified') {
     $accounts  = findVerifiedOwnerlessAccounts($db, $threshold);
     if ($db->error()) {
         logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'account-cleanup-data: verified query failed — ' . $db->errorString());
-        http_response_code(500);
-        echo json_encode(['error' => 'Database error']);
+        ApiResponse::serverError('Database error')->send();
         exit;
     }
     $rows = array_map(static function (object $a): array {
@@ -76,8 +70,7 @@ if ($type === 'unverified') {
     $accounts = findArchivedAccounts($db);
     if ($db->error()) {
         logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'account-cleanup-data: archive query failed — ' . $db->errorString());
-        http_response_code(500);
-        echo json_encode(['error' => 'Database error']);
+        ApiResponse::serverError('Database error')->send();
         exit;
     }
     $rows = array_map(static function (object $a): array {
@@ -99,9 +92,9 @@ if ($type === 'unverified') {
         ];
     }, $accounts);
 } else {
-    http_response_code(400);
-    echo json_encode(['error' => 'Invalid type']);
+    ApiResponse::error('Invalid type', 400)->send();
     exit;
 }
 
+header('Content-Type: application/json; charset=utf-8');
 echo json_encode(['data' => $rows]);


### PR DESCRIPTION
## Summary

- Confirmation modal now shown for **all** deletions regardless of count (previously only triggered for >10 accounts — ≤10 submitted immediately with no confirmation)
- Updated confirmation copy from "This cannot be undone" to "Accounts will be archived and can be restored if needed." — accurately reflects the archive-based safety net
- `account-cleanup-data.php` error branches replaced with `ApiResponse::forbidden()`, `ApiResponse::serverError()`, and `ApiResponse::error()` — aligns with Pattern A AJAX standard per CLAUDE.md

## Files changed
- `app/admin/includes/tab-account_cleanup.php` — JS delete handler always calls `showConfirmDialog`
- `app/api/admin/account-cleanup-data.php` — error responses use ApiResponse

Closes #1200