### PR TITLE
test: add unit and integration coverage for archive/restore account helpers

### DIFF
--- a/app/admin/includes/account-cleanup-helpers.php
+++ b/app/admin/includes/account-cleanup-helpers.php
@@ -6,7 +6,8 @@ declare(strict_types=1);
  * Return unverified (email_verified=0) accounts with no car associations older than $days.
  *
  * @param DB  $db   UserSpice DB instance
- * @param int $days Minimum age in days (must be ≥30)
+ * @param int $days Minimum age in days; caller must pass ≥30
+ * @return array<object> Matching user rows, ordered by join_date ASC
  */
 function findUnverifiedOwnerlessAccounts(DB $db, int $days): array
 {
@@ -35,7 +36,8 @@ function findUnverifiedOwnerlessAccounts(DB $db, int $days): array
  * is older than $days (or never logged in).
  *
  * @param DB  $db   UserSpice DB instance
- * @param int $days Inactivity threshold in days (must be ≥1)
+ * @param int $days Inactivity threshold in days; caller must pass ≥1
+ * @return array<object> Matching user rows, ordered by last_login ASC, join_date ASC
  */
 function findVerifiedOwnerlessAccounts(DB $db, int $days): array
 {
@@ -176,7 +178,7 @@ function restoreArchivedAccount(DB $db, int $archiveId, int $restoredBy): int
             'fname'          => $row->fname,
             'lname'          => $row->lname,
             'join_date'      => $row->join_date,
-            'last_login'     => $row->last_login,
+            'last_login'     => $row->last_login ?? '0000-00-00 00:00:00',
             'logins'         => (int) $row->logins,
             'email_verified' => 0,  // require re-verification on restore
             'active'         => 1,
@@ -202,7 +204,7 @@ function restoreArchivedAccount(DB $db, int $archiveId, int $restoredBy): int
             );
         }
 
-        // Re-insert profile if location data was archived
+        // Re-insert profile if any profile data was archived
         if ($row->city || $row->state || $row->country || $row->bio || $row->website) {
             $ok = $db->insert('profiles', [
                 'user_id' => $newUserId,
@@ -243,6 +245,7 @@ function restoreArchivedAccount(DB $db, int $archiveId, int $restoredBy): int
  * Return all archive rows for the DataTables endpoint.
  *
  * @param DB $db UserSpice DB instance
+ * @return array<object> All deleted_accounts_archive rows, ordered by deleted_at DESC
  */
 function findArchivedAccounts(DB $db): array
 {

--- a/tests/integration/ArchiveAndRestoreIntegrationTest.php
+++ b/tests/integration/ArchiveAndRestoreIntegrationTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+require_once __DIR__ . '/../../app/admin/includes/account-cleanup-helpers.php';
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration tests for archiveAccounts() and restoreArchivedAccount().
+ *
+ * All fixtures are cleaned up in tearDown().
+ *
+ * @see ArchiveAccountsTest        (unit tests)
+ * @see RestoreArchivedAccountTest (unit tests)
+ */
+#[Group('integration')]
+#[Group('admin')]
+final class ArchiveAndRestoreIntegrationTest extends IntegrationTestCase
+{
+    /** @var int[] Archive row IDs created during this test */
+    private array $createdArchiveIds = [];
+
+    /** @var int[] New user IDs created by restoreArchivedAccount() */
+    private array $restoredUserIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->databaseConnected) {
+            foreach ($this->restoredUserIds as $userId) {
+                try {
+                    $this->db->query("DELETE FROM user_permission_matches WHERE user_id = ?", [$userId]);
+                    $this->db->delete('users', ['id', '=', $userId]);
+                } catch (RuntimeException $e) {
+                    // ignore cleanup errors
+                }
+            }
+            foreach ($this->createdArchiveIds as $archiveId) {
+                try {
+                    $this->db->query("DELETE FROM deleted_accounts_archive WHERE id = ?", [$archiveId]);
+                } catch (RuntimeException $e) {
+                    // ignore cleanup errors
+                }
+            }
+        }
+        $this->createdArchiveIds = [];
+        $this->restoredUserIds   = [];
+        parent::tearDown();
+    }
+
+    private function daysAgo(int $days): string
+    {
+        return date('Y-m-d', strtotime("-{$days} days")) . ' 00:00:00';
+    }
+
+    /** @return int[] */
+    private function archiveRowsFor(int $userId): array
+    {
+        $rows = $this->db->query(
+            "SELECT id FROM deleted_accounts_archive WHERE original_user_id = ?",
+            [$userId]
+        )->results();
+        return array_map(fn($r) => (int) $r->id, $rows);
+    }
+
+    // -------------------------------------------------------------------------
+    // archiveAccounts() integration tests
+    // -------------------------------------------------------------------------
+
+    public function testArchiveAccountsCreatesArchiveRows(): void
+    {
+        $userId1 = $this->createTestUser(['join_date' => $this->daysAgo(31)]);
+        $userId2 = $this->createTestUser(['join_date' => $this->daysAgo(45)]);
+
+        archiveAccounts($this->db, [$userId1, $userId2], 1, 'unverified');
+
+        $ids1 = $this->archiveRowsFor($userId1);
+        $ids2 = $this->archiveRowsFor($userId2);
+        $this->createdArchiveIds = array_merge($this->createdArchiveIds, $ids1, $ids2);
+
+        $this->assertCount(1, $ids1, 'One archive row created for user 1');
+        $this->assertCount(1, $ids2, 'One archive row created for user 2');
+
+        $row = $this->db->query(
+            "SELECT deletion_type FROM deleted_accounts_archive WHERE id = ?",
+            [$ids1[0]]
+        )->first();
+        $this->assertSame('unverified', $row->deletion_type);
+    }
+
+    public function testArchiveAccountsEmptyArrayIsNoOp(): void
+    {
+        $before = (int) $this->db->query(
+            "SELECT COUNT(*) AS cnt FROM deleted_accounts_archive"
+        )->first()->cnt;
+
+        archiveAccounts($this->db, [], 1, 'unverified');
+
+        $after = (int) $this->db->query(
+            "SELECT COUNT(*) AS cnt FROM deleted_accounts_archive"
+        )->first()->cnt;
+
+        $this->assertSame($before, $after, 'Empty user list must not insert any archive rows');
+    }
+
+    public function testDeletionTypeStoredCorrectly(): void
+    {
+        $userId1 = $this->createTestUser(['join_date' => $this->daysAgo(31)]);
+        $userId2 = $this->createTestUser(['join_date' => $this->daysAgo(45)]);
+
+        archiveAccounts($this->db, [$userId1], 1, 'unverified');
+        archiveAccounts($this->db, [$userId2], 1, 'verified');
+
+        $ids1 = $this->archiveRowsFor($userId1);
+        $ids2 = $this->archiveRowsFor($userId2);
+        $this->createdArchiveIds = array_merge($this->createdArchiveIds, $ids1, $ids2);
+
+        $row1 = $this->db->query("SELECT deletion_type FROM deleted_accounts_archive WHERE id = ?", [$ids1[0]])->first();
+        $row2 = $this->db->query("SELECT deletion_type FROM deleted_accounts_archive WHERE id = ?", [$ids2[0]])->first();
+
+        $this->assertSame('unverified', $row1->deletion_type);
+        $this->assertSame('verified', $row2->deletion_type);
+    }
+
+    // -------------------------------------------------------------------------
+    // restoreArchivedAccount() integration tests
+    // -------------------------------------------------------------------------
+
+    public function testRestoreArchivedAccountCreatesUserAndPermission(): void
+    {
+        $originalUserId = $this->createTestUser([
+            'join_date' => $this->daysAgo(31),
+            'fname'     => 'Restore',
+            'lname'     => 'Test',
+        ]);
+
+        archiveAccounts($this->db, [$originalUserId], 1, 'unverified');
+        $archiveId = $this->archiveRowsFor($originalUserId)[0];
+        $this->createdArchiveIds[] = $archiveId;
+
+        // Simulate deletion: remove permissions and user row
+        $this->db->query("DELETE FROM user_permission_matches WHERE user_id = ?", [$originalUserId]);
+        $this->db->delete('users', ['id', '=', $originalUserId]);
+
+        $newUserId = restoreArchivedAccount($this->db, $archiveId, 1);
+        $this->restoredUserIds[] = $newUserId;
+
+        $user = $this->db->query("SELECT email_verified FROM users WHERE id = ?", [$newUserId])->first();
+        $this->assertNotNull($user, 'Restored user must exist');
+        $this->assertSame('0', (string) $user->email_verified, 'Restored user must have email_verified = 0');
+
+        $perm = $this->db->query(
+            "SELECT id FROM user_permission_matches WHERE user_id = ? AND permission_id = 1",
+            [$newUserId]
+        )->first();
+        $this->assertNotNull($perm, 'Restored user must have base permission (permission_id=1)');
+
+        $archiveRow = $this->db->query(
+            "SELECT restored_at FROM deleted_accounts_archive WHERE id = ?",
+            [$archiveId]
+        )->first();
+        $this->assertNotNull($archiveRow->restored_at, 'Archive row must have restored_at set');
+    }
+
+    public function testRestoreThrowsForAlreadyRestoredRow(): void
+    {
+        $userId = $this->createTestUser(['join_date' => $this->daysAgo(31)]);
+        archiveAccounts($this->db, [$userId], 1, 'unverified');
+        $archiveId = $this->archiveRowsFor($userId)[0];
+        $this->createdArchiveIds[] = $archiveId;
+
+        $this->db->query(
+            "UPDATE deleted_accounts_archive SET restored_at = NOW(), restored_by = 1 WHERE id = ?",
+            [$archiveId]
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/not found or already restored/');
+        restoreArchivedAccount($this->db, $archiveId, 1);
+    }
+
+    public function testRestoreThrowsForNonExistentArchiveId(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/not found or already restored/');
+        restoreArchivedAccount($this->db, 999999999, 1);
+    }
+}

--- a/tests/unit/admin/ArchiveAccountsTest.php
+++ b/tests/unit/admin/ArchiveAccountsTest.php
@@ -133,10 +133,13 @@ final class ArchiveAccountsTest extends TestCase
         ];
         $db = $this->makeDb(false, [$row]);
 
-        $this->expectException(RuntimeException::class);
-        archiveAccounts($db, [5], 1, 'unverified');
-
-        $this->assertSame(1, $db->rollBackCalls, 'Transaction must roll back on insert failure');
+        try {
+            archiveAccounts($db, [5], 1, 'unverified');
+            $this->fail('Expected RuntimeException on insert failure');
+        } catch (RuntimeException) {
+            $this->assertSame(1, $db->rollBackCalls, 'Transaction must roll back on insert failure');
+            $this->assertSame(0, $db->commitCalls);
+        }
     }
 
     #[Group('fast')] #[Group('unit')] #[Group('admin')]

--- a/tests/unit/admin/ArchiveAccountsTest.php
+++ b/tests/unit/admin/ArchiveAccountsTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../app/admin/includes/account-cleanup-helpers.php';
+
+/**
+ * Unit tests for archiveAccounts() in account-cleanup-helpers.php.
+ *
+ * Uses an inline anonymous DB mock so the strict `DB $db` type hint is satisfied.
+ * DB-level SQL correctness and constraint enforcement are left to integration tests.
+ *
+ * @see ArchiveAndRestoreIntegrationTest
+ */
+#[Group('fast')]
+#[Group('unit')]
+#[Group('admin')]
+final class ArchiveAccountsTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Build a DB mock. $insertOk controls insert() return value; $queryRows drives query().results(). */
+    private function makeDb(bool $insertOk = true, array $queryRows = []): object
+    {
+        return new class($insertOk, $queryRows) extends DB {
+            public int $commitCalls   = 0;
+            public int $rollBackCalls = 0;
+            public ?array $lastInsertData = null;
+
+            private bool $errorFlag = false;
+
+            public function __construct(
+                private readonly bool $insertOk,
+                private readonly array $queryRows
+            ) {}
+
+            public function query(string $sql, array $params = []): QueryResult
+            {
+                return new QueryResult($this->queryRows);
+            }
+
+            public function insert(string $table, array $data): bool
+            {
+                $this->lastInsertData = $data;
+                return $this->insertOk;
+            }
+
+            public function error(): bool   { return $this->errorFlag; }
+            public function errorString(): string { return ''; }
+
+            public function setError(): void { $this->errorFlag = true; }
+
+            public function beginTransaction(): void {}
+            public function commit(): void   { $this->commitCalls++; }
+            public function rollBack(): void { $this->rollBackCalls++; }
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testEmptyUserIdsReturnsImmediately(): void
+    {
+        $db = $this->makeDb();
+        archiveAccounts($db, [], 1, 'unverified');
+
+        $this->assertSame(0, $db->commitCalls, 'No commit expected for empty input');
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testZeroDateLastLoginNormalizedToNull(): void
+    {
+        $row = (object)[
+            'id' => 5, 'email' => 'a@x.com', 'username' => 'a', 'fname' => 'A', 'lname' => 'B',
+            'join_date' => '2024-01-01 00:00:00', 'last_login' => '0000-00-00 00:00:00',
+            'logins' => 0, 'email_verified' => 0,
+            'city' => null, 'state' => null, 'country' => null, 'bio' => null, 'website' => null,
+        ];
+        $db = $this->makeDb(true, [$row]);
+
+        archiveAccounts($db, [5], 1, 'unverified');
+
+        $this->assertNull($db->lastInsertData['last_login'], 'Zero-date must be normalised to null');
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testNullLastLoginStoredAsNull(): void
+    {
+        $row = (object)[
+            'id' => 5, 'email' => 'a@x.com', 'username' => 'a', 'fname' => 'A', 'lname' => 'B',
+            'join_date' => '2024-01-01 00:00:00', 'last_login' => null,
+            'logins' => 0, 'email_verified' => 0,
+            'city' => null, 'state' => null, 'country' => null, 'bio' => null, 'website' => null,
+        ];
+        $db = $this->makeDb(true, [$row]);
+
+        archiveAccounts($db, [5], 1, 'unverified');
+
+        $this->assertNull($db->lastInsertData['last_login']);
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testRealLastLoginPreserved(): void
+    {
+        $row = (object)[
+            'id' => 7, 'email' => 'b@x.com', 'username' => 'b', 'fname' => 'C', 'lname' => 'D',
+            'join_date' => '2024-01-01 00:00:00', 'last_login' => '2025-06-01 12:00:00',
+            'logins' => 3, 'email_verified' => 0,
+            'city' => null, 'state' => null, 'country' => null, 'bio' => null, 'website' => null,
+        ];
+        $db = $this->makeDb(true, [$row]);
+
+        archiveAccounts($db, [7], 1, 'unverified');
+
+        $this->assertSame('2025-06-01 12:00:00', $db->lastInsertData['last_login']);
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testThrowsOnInsertFailure(): void
+    {
+        $row = (object)[
+            'id' => 5, 'email' => 'a@x.com', 'username' => 'a', 'fname' => 'A', 'lname' => 'B',
+            'join_date' => '2024-01-01 00:00:00', 'last_login' => null,
+            'logins' => 0, 'email_verified' => 0,
+            'city' => null, 'state' => null, 'country' => null, 'bio' => null, 'website' => null,
+        ];
+        $db = $this->makeDb(false, [$row]);
+
+        $this->expectException(RuntimeException::class);
+        archiveAccounts($db, [5], 1, 'unverified');
+
+        $this->assertSame(1, $db->rollBackCalls, 'Transaction must roll back on insert failure');
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testThrowsOnQueryError(): void
+    {
+        $db = $this->makeDb(true, []);
+        $db->setError();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/query failed/');
+        archiveAccounts($db, [5], 1, 'unverified');
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testCommitCalledOnSuccess(): void
+    {
+        $row = (object)[
+            'id' => 5, 'email' => 'a@x.com', 'username' => 'a', 'fname' => 'A', 'lname' => 'B',
+            'join_date' => '2024-01-01 00:00:00', 'last_login' => null,
+            'logins' => 0, 'email_verified' => 0,
+            'city' => null, 'state' => null, 'country' => null, 'bio' => null, 'website' => null,
+        ];
+        $db = $this->makeDb(true, [$row]);
+
+        archiveAccounts($db, [5], 1, 'unverified');
+
+        $this->assertSame(1, $db->commitCalls, 'commit() must be called exactly once on success');
+        $this->assertSame(0, $db->rollBackCalls, 'rollBack() must not be called on success');
+    }
+}

--- a/tests/unit/admin/RestoreArchivedAccountTest.php
+++ b/tests/unit/admin/RestoreArchivedAccountTest.php
@@ -130,11 +130,13 @@ final class RestoreArchivedAccountTest extends TestCase
     {
         $db = $this->makeDb($this->archiveRow(), insertOk: false);
 
-        $this->expectException(RuntimeException::class);
-        restoreArchivedAccount($db, 10, 1);
-
-        $this->assertSame(1, $db->rollBackCalls);
-        $this->assertSame(0, $db->commitCalls);
+        try {
+            restoreArchivedAccount($db, 10, 1);
+            $this->fail('Expected RuntimeException on insert failure');
+        } catch (RuntimeException) {
+            $this->assertSame(1, $db->rollBackCalls);
+            $this->assertSame(0, $db->commitCalls);
+        }
     }
 
     #[Group('fast')] #[Group('unit')] #[Group('admin')]

--- a/tests/unit/admin/RestoreArchivedAccountTest.php
+++ b/tests/unit/admin/RestoreArchivedAccountTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../app/admin/includes/account-cleanup-helpers.php';
+
+/**
+ * Unit tests for restoreArchivedAccount() in account-cleanup-helpers.php.
+ *
+ * Uses an inline anonymous DB mock; SQL correctness delegated to integration tests.
+ *
+ * @see ArchiveAndRestoreIntegrationTest
+ */
+#[Group('fast')]
+#[Group('unit')]
+#[Group('admin')]
+final class RestoreArchivedAccountTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a mock DB for restoreArchivedAccount().
+     *
+     * @param object|null $archiveRow  Row returned by the initial SELECT, or null to simulate "not found"
+     * @param bool        $insertOk   Whether insert() should succeed
+     * @param int         $lastId     Value returned by lastId()
+     * @param bool        $queryError Whether the first query() should set an error flag
+     */
+    private function makeDb(
+        ?object $archiveRow,
+        bool $insertOk = true,
+        int $lastId = 42,
+        bool $queryError = false
+    ): object {
+        return new class($archiveRow, $insertOk, $lastId, $queryError) extends DB {
+            public int $commitCalls   = 0;
+            public int $rollBackCalls = 0;
+
+            private bool $errorFlag     = false;
+            private bool $firstQueryDone = false;
+
+            public function __construct(
+                private readonly ?object $archiveRow,
+                private readonly bool    $insertOk,
+                private readonly int     $lastIdValue,
+                private readonly bool    $queryError
+            ) {}
+
+            public function query(string $sql, array $params = []): QueryResult
+            {
+                if (!$this->firstQueryDone) {
+                    $this->firstQueryDone = true;
+                    if ($this->queryError) {
+                        $this->errorFlag = true;
+                        return new QueryResult([]);
+                    }
+                    return new QueryResult($this->archiveRow ? [$this->archiveRow] : []);
+                }
+                // Subsequent queries (UPDATE, etc.) succeed silently
+                $this->errorFlag = false;
+                return new QueryResult([]);
+            }
+
+            public function insert(string $table, array $data): bool
+            {
+                return $this->insertOk;
+            }
+
+            public function lastId(): int    { return $this->lastIdValue; }
+            public function error(): bool    { return $this->errorFlag; }
+            public function errorString(): string { return 'mock error'; }
+
+            public function beginTransaction(): void {}
+            public function commit(): void   { $this->commitCalls++; }
+            public function rollBack(): void { $this->rollBackCalls++; }
+        };
+    }
+
+    private function archiveRow(): object
+    {
+        return (object)[
+            'id'             => 10,
+            'email'          => 'test@example.com',
+            'username'       => 'testuser',
+            'fname'          => 'Test',
+            'lname'          => 'User',
+            'join_date'      => '2024-01-01 00:00:00',
+            'last_login'     => null,
+            'logins'         => 0,
+            'email_verified' => 0,
+            'city'           => null,
+            'state'          => null,
+            'country'        => null,
+            'bio'            => null,
+            'website'        => null,
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testThrowsWhenDbErrorOnLookup(): void
+    {
+        $db = $this->makeDb(null, true, 42, queryError: true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/DB error reading archive row/');
+        restoreArchivedAccount($db, 10, 1);
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testThrowsWhenArchiveRowNotFound(): void
+    {
+        $db = $this->makeDb(null);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/not found or already restored/');
+        restoreArchivedAccount($db, 99, 1);
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testThrowsAndRollsBackOnInsertFailure(): void
+    {
+        $db = $this->makeDb($this->archiveRow(), insertOk: false);
+
+        $this->expectException(RuntimeException::class);
+        restoreArchivedAccount($db, 10, 1);
+
+        $this->assertSame(1, $db->rollBackCalls);
+        $this->assertSame(0, $db->commitCalls);
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testThrowsWhenLastIdIsZero(): void
+    {
+        $db = $this->makeDb($this->archiveRow(), insertOk: true, lastId: 0);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/returned no ID/');
+        restoreArchivedAccount($db, 10, 1);
+    }
+
+    #[Group('fast')] #[Group('unit')] #[Group('admin')]
+    public function testReturnsNewUserIdOnSuccess(): void
+    {
+        $db = $this->makeDb($this->archiveRow(), insertOk: true, lastId: 42);
+
+        $result = restoreArchivedAccount($db, 10, 1);
+
+        $this->assertSame(42, $result, 'Must return the new user ID from lastId()');
+        $this->assertSame(1, $db->commitCalls);
+        $this->assertSame(0, $db->rollBackCalls);
+    }
+}

--- a/tests/unit/exceptions/ExceptionHierarchyTest.php
+++ b/tests/unit/exceptions/ExceptionHierarchyTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use ElanRegistry\Exceptions\AdminContactException;
+use ElanRegistry\Exceptions\AdminOperationException;
 use ElanRegistry\Exceptions\BackupException;
 use ElanRegistry\Exceptions\CarCreationException;
 use ElanRegistry\Exceptions\CarDatabaseException;
@@ -38,6 +40,8 @@ class ExceptionHierarchyTest extends TestCase
      * All exception classes that should extend ElanRegistryException
      */
     private const EXCEPTION_CLASSES = [
+        AdminContactException::class,
+        AdminOperationException::class,
         CarNotFoundException::class,
         CarCreationException::class,
         CarValidationException::class,
@@ -392,6 +396,8 @@ class ExceptionHierarchyTest extends TestCase
             'OwnerValidationException' => [OwnerValidationException::class, 'ValidationError'],
             'OwnerUpdateException' => [OwnerUpdateException::class, 'OwnerActions'],
             'ImageProcessingException' => [ImageProcessingException::class, 'FileError'],
+            'AdminContactException' => [AdminContactException::class, 'CarActions'],
+            'AdminOperationException' => [AdminOperationException::class, 'SystemError'],
             'BackupException' => [BackupException::class, 'BackupError'],
             'ValidationException' => [ValidationException::class, 'ValidationError'],
             'LocationServiceException' => [LocationServiceException::class, 'SystemError'],
@@ -419,6 +425,8 @@ class ExceptionHierarchyTest extends TestCase
             'OwnerValidationException' => [OwnerValidationException::class, 422],
             'OwnerUpdateException' => [OwnerUpdateException::class, 500],
             'ImageProcessingException' => [ImageProcessingException::class, 500],
+            'AdminContactException' => [AdminContactException::class, 500],
+            'AdminOperationException' => [AdminOperationException::class, 500],
             'BackupException' => [BackupException::class, 500],
             'ValidationException' => [ValidationException::class, 422],
             'LocationServiceException' => [LocationServiceException::class, 500],


### PR DESCRIPTION
## Summary

- Adds 7 unit tests for `archiveAccounts()` covering last_login normalization, insert failure rollback, query error propagation, and commit-on-success path
- Adds 5 unit tests for `restoreArchivedAccount()` covering DB error detection, not-found handling, insert failure rollback, and zero-lastId guard
- Adds 6 integration tests verifying real DB behavior: archive row creation, empty-array no-op, deletion_type accuracy, and full restore flow including permission grant and archive-row timestamp
- Adds `AdminContactException` and `AdminOperationException` to `ExceptionHierarchyTest`
- Fixes `restoreArchivedAccount()` to pass `'0000-00-00 00:00:00'` when `last_login` is null (discovered by integration tests hitting the `NOT NULL` constraint on `users.last_login`)

Closes #1198

## Test plan

- [x] `composer test:quick` passes (1072 tests, 4204 assertions)
- [x] `./vendor/bin/phpunit -c phpunit-integration.xml --filter ArchiveAndRestoreIntegrationTest` passes (6 tests, 14 assertions)
- [x] PHPStan: no errors on changed files
- [x] Pre-commit hooks: all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141jHXoouirghvFhg5t7mBM