### PR TITLE
test: add ElanRegistry\Reference\ path assertion via SeriesData (#1255)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.26.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.0.md
@@ -1,0 +1,18 @@
+# Elan Registry v2.26.0 Release Notes
+
+**Release Date:** TBD
+**Type:** Minor Release - Namespace Migration
+
+## Required Actions After Deployment
+
+None.
+
+## Technical Changes
+
+### Improvements
+
+- **Autoloader test coverage** ([#1255](https://github.com/unibrain1/elanregistry/issues/1255)): Added `SeriesData` reference class and `ReflectionClass` path assertion to `AutoloaderTest`, ensuring the `ElanRegistry\Reference\` prefix mapping is verified against the correct directory.
+
+## Issues Resolved
+
+- [#1255](https://github.com/unibrain1/elanregistry/issues/1255) — AutoloaderTest: add path assertion for ElanRegistry\Reference\ prefix mapping

--- a/tests/unit/system/AutoloaderTest.php
+++ b/tests/unit/system/AutoloaderTest.php
@@ -127,17 +127,36 @@ class AutoloaderTest extends TestCase
      *
      * Note: bootstrap-unit.php pre-loads CarModel via an eval mock before the
      * autoloader registers, so class_exists() here confirms availability, not
-     * PSR-4 path resolution. A ReflectionClass path assertion is not possible
-     * here because the mock pre-empts the real autoloader load.
-     * TODO #1255: add a second (non-mocked) class under ElanRegistry\Reference\ so
-     * the prefix mapping to usersc/classes/Reference/ can be path-verified.
-     * See testPsr4RootPrefixResolution() for the pattern to follow.
+     * PSR-4 path resolution. Path verification for the ElanRegistry\Reference\
+     * prefix is covered by testReferencePrefixResolution() using SeriesData,
+     * which is not mocked.
      */
     public function testReferenceClassIsAvailable(): void
     {
         $this->assertTrue(
             class_exists('ElanRegistry\\Reference\\CarModel'),
             'ElanRegistry\\Reference\\CarModel must be available'
+        );
+    }
+
+    /**
+     * Test that the ElanRegistry\Reference\ prefix resolves to the correct file path.
+     *
+     * CarModel is pre-loaded by the bootstrap eval mock, so ReflectionClass cannot
+     * verify its path. SeriesData is not mocked, so the real autoloader fires and
+     * the path can be confirmed.
+     *
+     * This catches regressions where the Reference\ prefix mapping points at the
+     * wrong directory — e.g., the old usersc/classes/ElanRegistry/Reference/ path
+     * corrected in PR #1250.
+     */
+    public function testReferencePrefixResolution(): void
+    {
+        $rc = new ReflectionClass('ElanRegistry\\Reference\\SeriesData');
+        $this->assertStringEndsWith(
+            '/usersc/classes/Reference/SeriesData.php',
+            (string) $rc->getFileName(),
+            'ElanRegistry\\Reference\\SeriesData must load from usersc/classes/Reference/SeriesData.php via the ElanRegistry\\Reference\\ prefix mapping'
         );
     }
 

--- a/usersc/classes/Reference/SeriesData.php
+++ b/usersc/classes/Reference/SeriesData.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElanRegistry\Reference;
+
+/**
+ * SeriesData - Static reference data for Lotus Elan production series.
+ *
+ * Provides production-year ranges and canonical series names for the
+ * Lotus Elan series as compiled from factory records. All data is
+ * static — no database access required.
+ *
+ * @package ElanRegistry\Reference
+ * @since v2.26.0
+ */
+class SeriesData
+{
+    /**
+     * Production year ranges indexed by series name.
+     *
+     * @var array<string, array{from: int, to: int}>
+     */
+    public const PRODUCTION_YEARS = [
+        'S1'     => ['from' => 1963, 'to' => 1965],
+        'S2'     => ['from' => 1965, 'to' => 1966],
+        'S3'     => ['from' => 1966, 'to' => 1969],
+        'S4'     => ['from' => 1968, 'to' => 1971],
+        'Sprint' => ['from' => 1970, 'to' => 1973],
+        '+2'     => ['from' => 1967, 'to' => 1969],
+        '+2S'    => ['from' => 1969, 'to' => 1974],
+        '+2S130' => ['from' => 1971, 'to' => 1974],
+    ];
+
+    /**
+     * Return all canonical series names.
+     *
+     * @return list<string>
+     */
+    public static function allSeries(): array
+    {
+        return array_keys(self::PRODUCTION_YEARS);
+    }
+
+    /**
+     * Return the production year range for a given series, or null if unknown.
+     *
+     * @param string $series Canonical series name (S1, S2, S3, S4, Sprint, +2, +2S, +2S130)
+     * @return array{from: int, to: int}|null Year range, or null if the series is not recognised
+     */
+    public static function productionYears(string $series): ?array
+    {
+        return self::PRODUCTION_YEARS[$series] ?? null;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ElanRegistry\Reference\SeriesData` — a DB-free static class with Lotus Elan production year ranges. As a non-mocked class it allows the real autoloader to fire during tests.
- Adds `testReferencePrefixResolution()` to `AutoloaderTest`, using `ReflectionClass::getFileName()` to confirm the `ElanRegistry\Reference\` prefix maps to `usersc/classes/Reference/` — catching any regression to the old wrong path corrected in PR #1250.
- Updates the `testReferenceClassIsAvailable()` docblock to replace the TODO comment with a reference to the new test.

## Test plan

- [x] `composer test:quick --filter AutoloaderTest` — 10 tests, 41 assertions, all green
- [x] `composer test:quick` (full unit suite) — 1089 tests, 4243 assertions, all green
- [x] PHPStan and phpcs — no errors

Closes #1255

https://claude.ai/code/session_01EEutp1wr3Sh8nxMJzy5XHx