### PR TITLE
fix: eliminate N+1 query in owner search (#1230)

### DIFF
--- a/app/admin/includes/process-owner-search.php
+++ b/app/admin/includes/process-owner-search.php
@@ -34,8 +34,7 @@ try {
     // Enhance results with data quality scoring
     $enhancedResults = [];
     foreach ($searchResults as $owner) {
-        $ownerProfile = new Owner((int)$owner->id);
-        $qualityScore = $ownerProfile->getProfileQualityScore();
+        $qualityScore = Owner::qualityScoreFromRow($owner);
 
         $enhancedResults[] = [
             'id' => (int)$owner->id,

--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -1,0 +1,37 @@
+# Elan Registry v2.26.1 Release Notes
+
+**Release Date:** TBD
+**Type:** Patch Release — Validation & Input Fixes
+
+## Required Actions After Deployment
+
+None.
+
+## User-Facing Changes
+
+### Bug Fixes
+
+- **Ownership transfer integrity** ([#1163](https://github.com/unibrain1/elanregistry/issues/1163)): Fixed a code path where car transfers inserted a new owner row without removing the previous one, preventing stale ownership records.
+
+## Admin-Facing Changes
+
+### Bug Fixes
+
+- **Admin contact email — readable car model** ([#1236](https://github.com/unibrain1/elanregistry/issues/1236)): Admin-to-owner contact emails now display a human-readable car model (e.g. "Series 1 / Drophead Coupé") instead of the raw internal pipe-delimited value.
+
+### Improvements
+
+- **Owner search performance** ([#1230](https://github.com/unibrain1/elanregistry/issues/1230)): Admin owner search now executes 1 database query regardless of result count, down from N+1 (26 queries for 25 results).
+
+## Issues Resolved
+
+- [#268](https://github.com/unibrain1/elanregistry/issues/268) — Remove users_carsview database view and integrate with Car class architecture
+- [#867](https://github.com/unibrain1/elanregistry/issues/867) — refactor: Input class improvements — type-safe exists() and clarify raw() signature in docs
+- [#993](https://github.com/unibrain1/elanregistry/issues/993) — refactor: add FK constraints for 4 relationships currently enforced only in application code
+- [#1069](https://github.com/unibrain1/elanregistry/issues/1069) — refactor: consolidate site name and email subject prefix into shared constants
+- [#1160](https://github.com/unibrain1/elanregistry/issues/1160) — fix: remove 3 stale car_user rows left by incomplete ownership transfers
+- [#1163](https://github.com/unibrain1/elanregistry/issues/1163) — fix: transfer code path inserts new car_user row without removing old owner row
+- [#1230](https://github.com/unibrain1/elanregistry/issues/1230) — fix: N+1 query in owner search — use Owner::qualityScoreFromRow() directly on search result rows
+- [#1233](https://github.com/unibrain1/elanregistry/issues/1233) — fix: validator alignment — city length caps, default case guard, required-field check, and chassis routing
+- [#1236](https://github.com/unibrain1/elanregistry/issues/1236) — fix: admin contact email sends raw pipe-delimited model string in carContext instead of human-readable label
+- [#1252](https://github.com/unibrain1/elanregistry/issues/1252) — test: fix stale e2e paths and add smoke tests for docs portal pages

--- a/tests/unit/classes/OwnerProfileTest.php
+++ b/tests/unit/classes/OwnerProfileTest.php
@@ -357,6 +357,7 @@ final class OwnerProfileTest extends TestCase
             'lon'     => '-122.6765',
         ];
 
+        // 7/7 = 100.0
         $this->assertSame(100.0, Owner::qualityScoreFromRow($row));
     }
 
@@ -376,5 +377,26 @@ final class OwnerProfileTest extends TestCase
 
         // 3 simple fields → round(3/7 * 100, 1) = 42.9
         $this->assertSame(42.9, Owner::qualityScoreFromRow($row));
+    }
+
+    public function testUnionBranchShapedRowScoresCorrectly(): void
+    {
+        // searchOwners() UNION branch returns an extra `priority` column.
+        // Confirms qualityScoreFromRow() ignores unknown columns.
+        $row = (object) [
+            'id'       => 7,
+            'fname'    => 'Greg',
+            'lname'    => 'Surcouf',
+            'email'    => 'greg@example.com',
+            'city'     => 'London',
+            'state'    => '',
+            'country'  => 'GB',
+            'lat'      => '51.5074',
+            'lon'      => '-0.1278',
+            'priority' => 1,
+        ];
+
+        // 5 simple fields + lat/lon → round(6/7 * 100, 1) = 85.7
+        $this->assertSame(85.7, Owner::qualityScoreFromRow($row));
     }
 }

--- a/tests/unit/classes/OwnerProfileTest.php
+++ b/tests/unit/classes/OwnerProfileTest.php
@@ -335,4 +335,46 @@ final class OwnerProfileTest extends TestCase
             $this->owner->validateProfileCompleteness()
         );
     }
+
+    // -----------------------------------------------------------------------
+    // qualityScoreFromRow() on search-result-shaped rows
+    // Regression guard for issue #1230: process-owner-search.php now calls
+    // qualityScoreFromRow() directly on rows from searchOwners(), which include
+    // extra columns (e.g. id). These tests confirm the scoring is unaffected.
+    // -----------------------------------------------------------------------
+
+    public function testSearchResultShapedRowScoresCorrectly(): void
+    {
+        $row = (object) [
+            'id'      => 42,
+            'fname'   => 'Jim',
+            'lname'   => 'Boone',
+            'email'   => 'jim@example.com',
+            'city'    => 'Portland',
+            'state'   => 'OR',
+            'country' => 'USA',
+            'lat'     => '45.5231',
+            'lon'     => '-122.6765',
+        ];
+
+        $this->assertSame(100.0, Owner::qualityScoreFromRow($row));
+    }
+
+    public function testSearchResultShapedRowWithPartialDataScoresCorrectly(): void
+    {
+        $row = (object) [
+            'id'      => 99,
+            'fname'   => 'Jane',
+            'lname'   => 'Smith',
+            'email'   => 'jane@example.com',
+            'city'    => '',
+            'state'   => '',
+            'country' => '',
+            'lat'     => '',
+            'lon'     => '',
+        ];
+
+        // 3 simple fields → round(3/7 * 100, 1) = 42.9
+        $this->assertSame(42.9, Owner::qualityScoreFromRow($row));
+    }
 }


### PR DESCRIPTION
## Summary

- Replaces `new Owner($id)->getProfileQualityScore()` in the `process-owner-search.php` result loop with `Owner::qualityScoreFromRow($owner)` — reducing admin owner search from N+1 queries (26 for 25 results) to 1 query total
- Adds 2 unit tests confirming `qualityScoreFromRow()` handles search-result-shaped rows (which include an extra `id` column) correctly

## Bug Escape Analysis

**Root cause:** `process-owner-search.php` instantiated a full `Owner` object per result row to call `getProfileQualityScore()`, which each trigger a `getUserWithProfile()` DB query. The static `Owner::qualityScoreFromRow()` method accepting a plain row object already existed and the search query already returns all required fields.

**Testing gap:** Unit tests covered each component in isolation but no test bridged the `searchOwners() → qualityScoreFromRow()` consumption path. The new tests close that gap by verifying the static method works correctly on the exact row shape returned by `searchOwners()`.

## Test plan

- [x] `composer test:quick` — 1091 tests, all passing
- [x] PHPStan — no errors
- [x] phpcs — no blocking issues

Closes #1230

https://claude.ai/code/session_01T9C2L2Eu6TwxSoZFP7JWca