### PR TITLE
fix: validator alignment — city length caps, default case guard, required-field check, and chassis routing

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -12,6 +12,7 @@ None.
 ### Bug Fixes
 
 - **Ownership transfer integrity** ([#1163](https://github.com/unibrain1/elanregistry/issues/1163)): Fixed a code path where car transfers inserted a new owner row without removing the previous one, preventing stale ownership records.
+- **Validator alignment** ([#1233](https://github.com/unibrain1/elanregistry/issues/1233)): Owner profile city/state/country fields now accept up to 100 characters (matching the database schema), preventing silent truncation when a long location is saved via the car form and then edited in the profile. Required-field validation no longer incorrectly rejects the value `"0"`. Unknown form fields with null or empty values are dropped rather than written to the database.
 
 ## Admin-Facing Changes
 

--- a/tests/integration/OwnerIntegrationTest.php
+++ b/tests/integration/OwnerIntegrationTest.php
@@ -307,4 +307,76 @@ class OwnerIntegrationTest extends IntegrationTestCase
             $this->db->query("DELETE FROM profiles WHERE user_id = ?", [$userId]);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // city/state/country length cap raised from 50 → 100 (issue #1233 fix 1)
+    // -------------------------------------------------------------------------
+
+    public function testCityAccepts75CharValue(): void
+    {
+        // 75-char value is well within the 100-char cap — must pass through unchanged
+        $city = str_repeat('x', 75);
+        $result = $this->callValidateAndSanitize(['city' => $city]);
+        $this->assertSame($city, $result['city']);
+    }
+
+    public function testCityAccepts100CharValue(): void
+    {
+        // Exactly at the new cap of 100 chars — must pass through unchanged
+        $city = str_repeat('x', 100);
+        $result = $this->callValidateAndSanitize(['city' => $city]);
+        $this->assertSame(100, strlen($result['city']));
+    }
+
+    public function testCityTruncatesAt100Chars(): void
+    {
+        // 101-char value exceeds the cap and must be truncated to exactly 100 chars
+        $city = str_repeat('x', 101);
+        $result = $this->callValidateAndSanitize(['city' => $city]);
+        $this->assertSame(100, strlen($result['city']));
+    }
+
+    // -------------------------------------------------------------------------
+    // validateRequiredFields() '0' acceptance (issue #1233 fix 3)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param array<string, string> $fields
+     * @param list<string>          $required
+     */
+    private function callValidateRequiredFields(array $fields, array $required): void
+    {
+        $owner = new Owner();
+        $method = new \ReflectionMethod($owner, 'validateRequiredFields');
+        $method->invoke($owner, $fields, $required);
+    }
+
+    public function testRequiredFieldAcceptsZeroString(): void
+    {
+        // '0' is a legitimate value — trim((string)'0') === '' is false, so no exception
+        $this->callValidateRequiredFields(
+            ['fname' => '0', 'lname' => '0', 'email' => 'test@example.com'],
+            ['fname', 'lname', 'email']
+        );
+        // If we reach here, no exception was thrown — that is the assertion
+        $this->assertTrue(true);
+    }
+
+    public function testRequiredFieldRejectsEmptyString(): void
+    {
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->callValidateRequiredFields(
+            ['fname' => '', 'lname' => 'Smith', 'email' => 'test@example.com'],
+            ['fname', 'lname', 'email']
+        );
+    }
+
+    public function testRequiredFieldRejectsWhitespaceOnly(): void
+    {
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->callValidateRequiredFields(
+            ['fname' => '   ', 'lname' => 'Smith', 'email' => 'test@example.com'],
+            ['fname', 'lname', 'email']
+        );
+    }
 }

--- a/tests/integration/OwnerIntegrationTest.php
+++ b/tests/integration/OwnerIntegrationTest.php
@@ -354,12 +354,11 @@ class OwnerIntegrationTest extends IntegrationTestCase
     public function testRequiredFieldAcceptsZeroString(): void
     {
         // '0' is a legitimate value — trim((string)'0') === '' is false, so no exception
+        $this->expectNotToPerformAssertions();
         $this->callValidateRequiredFields(
             ['fname' => '0', 'lname' => '0', 'email' => 'test@example.com'],
             ['fname', 'lname', 'email']
         );
-        // If we reach here, no exception was thrown — that is the assertion
-        $this->assertTrue(true);
     }
 
     public function testRequiredFieldRejectsEmptyString(): void

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -51,6 +51,14 @@ final class CarValidatorTest extends TestCase
         $this->validator->validateRequiredFields($fields, ['chassis', 'model', 'year']);
     }
 
+    public function testValidateRequiredFieldsAcceptsZeroString(): void
+    {
+        // '0' is a legitimate value — trim((string)'0') !== '', so no exception should be thrown
+        $fields = ['chassis' => '0', 'model' => 'S4|FHC|36', 'year' => '1970'];
+        $this->validator->validateRequiredFields($fields, ['chassis', 'model', 'year']);
+        $this->assertTrue(true); // no exception = pass
+    }
+
     // ============================================================
     // validateAndSanitizeFields tests
     // ============================================================
@@ -434,6 +442,111 @@ final class CarValidatorTest extends TestCase
     }
 
     // ============================================================
+    // default case — empty guard (issue #1233, fix 2)
+    // ============================================================
+
+    /**
+     * Unknown keys with a null value must be dropped from the result (not passed through).
+     */
+    #[Group('unit')]
+    public function testDefaultCaseDropsNullValue(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['unknownKey' => null], false);
+        $this->assertArrayNotHasKey('unknownKey', $result);
+    }
+
+    /**
+     * Unknown keys with an empty-string value must be dropped from the result (not passed through).
+     */
+    #[Group('unit')]
+    public function testDefaultCaseDropsEmptyStringValue(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['unknownKey' => ''], false);
+        $this->assertArrayNotHasKey('unknownKey', $result);
+    }
+
+    /**
+     * Unknown keys with a falsy string value ('0') must pass through — '0' is a legitimate
+     * value that !empty() would silently drop, motivating the !== null && !== '' guard.
+     */
+    #[Group('unit')]
+    public function testDefaultCasePassesThroughZeroString(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['unknownKey' => '0'], false);
+        $this->assertArrayHasKey('unknownKey', $result);
+        $this->assertSame('0', $result['unknownKey']);
+    }
+
+    // ============================================================
+    // chassis — ChassisValidator integration (issue #1233, fix 4)
+    // ============================================================
+
+    /**
+     * When year and model are present and year < 1970, ChassisValidator enforces the
+     * pre-1970 format (exactly 4 numeric digits).  A valid 4-digit numeric chassis must
+     * pass without exception and be stored in the result.
+     *
+     * Uses 'S3|FHC|36' — a combination present in the unit-test mock CarModel — so that
+     * the 'model' key also passes validation within the same call.
+     */
+    #[Group('unit')]
+    public function testChassisValidationUsesChassisValidatorForValidPre1970Chassis(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(
+            ['chassis' => '1234', 'year' => 1965, 'model' => 'S3|FHC|36'],
+            false
+        );
+        $this->assertSame('1234', $result['chassis']);
+    }
+
+    /**
+     * When year and model are present and year < 1970, a non-numeric chassis (e.g. 'ABCD')
+     * fails ChassisValidator's pre-1970 numeric rule (must be exactly 4 digits — letters are
+     * rejected) and must throw CarValidationException with a message beginning
+     * 'Chassis validation failed'.
+     *
+     * Uses 'S3|FHC|36' — a combination present in the unit-test mock CarModel — so that
+     * the 'model' key does not itself trigger a validation error before chassis is checked.
+     */
+    #[Group('unit')]
+    public function testChassisValidationRejectsInvalidPre1970FormatWhenYearModelPresent(): void
+    {
+        $this->expectException(CarValidationException::class);
+        $this->expectExceptionMessage('Chassis validation failed');
+
+        $this->validator->validateAndSanitizeFields(
+            ['chassis' => 'ABCD', 'year' => 1965, 'model' => 'S3|FHC|36'],
+            false
+        );
+    }
+
+    /**
+     * When chassis_override=1 is set and the chassis fails format validation, ChassisValidator
+     * grants the override and CarValidator must not throw.  '12345' is invalid for pre-1970
+     * (must be exactly 4 numeric digits), but the override allows it.
+     */
+    #[Group('unit')]
+    public function testChassisValidationPermitsInvalidChassisWhenOverrideSet(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(
+            ['chassis' => '12345', 'year' => 1965, 'model' => 'S3|FHC|36', 'chassis_override' => '1'],
+            false
+        );
+        $this->assertSame('12345', $result['chassis']);
+    }
+
+    /**
+     * When year and model are absent, ChassisValidator is not invoked.  The fallback
+     * 3-character minimum applies: a 3-character chassis must be accepted and stored.
+     */
+    #[Group('unit')]
+    public function testChassisValidationSkipsChassisValidatorWhenYearAbsent(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['chassis' => 'ABC'], false);
+        $this->assertSame('ABC', $result['chassis']);
+    }
+
+    // ============================================================
     // Full positive case: valid inputs return sanitized array
     // ============================================================
 
@@ -444,7 +557,7 @@ final class CarValidatorTest extends TestCase
     public function testValidateAndSanitizeFieldsReturnsFullSanitizedArray(): void
     {
         $fields = [
-            'chassis' => 'ABC123',
+            'chassis' => '1234A',
             'model' => 'S4|FHC|36', // Valid in mock CarModel
             'year' => '1970',
             'email' => 'owner@example.com',
@@ -460,7 +573,7 @@ final class CarValidatorTest extends TestCase
 
         $result = $this->validator->validateAndSanitizeFields($fields, true);
 
-        $this->assertEquals('ABC123', $result['chassis']);
+        $this->assertEquals('1234A', $result['chassis']);
         $this->assertEquals('S4|FHC|36', $result['model']);
         $this->assertSame(1970, $result['year']);
         $this->assertEquals('owner@example.com', $result['email']);

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -560,7 +560,7 @@ final class CarValidatorTest extends TestCase
     public function testValidateAndSanitizeFieldsReturnsFullSanitizedArray(): void
     {
         $fields = [
-            'chassis' => '1234A',
+            'chassis' => '1234A', // 1970 legacy 5-char format: 4 numeric digits + Elan suffix 'A' (valid letter code)
             'model' => 'S4|FHC|36', // Valid in mock CarModel
             'year' => '1970',
             'email' => 'owner@example.com',

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -29,9 +29,9 @@ final class CarValidatorTest extends TestCase
 
     public function testValidateRequiredFieldsPassesWithAllPresent(): void
     {
+        $this->expectNotToPerformAssertions();
         $fields = ['chassis' => 'ABC123', 'model' => 'Elan', 'year' => '1970'];
         $this->validator->validateRequiredFields($fields, ['chassis', 'model', 'year']);
-        $this->assertTrue(true); // No exception thrown
     }
 
     public function testValidateRequiredFieldsThrowsOnMissingField(): void
@@ -54,9 +54,9 @@ final class CarValidatorTest extends TestCase
     public function testValidateRequiredFieldsAcceptsZeroString(): void
     {
         // '0' is a legitimate value — trim((string)'0') !== '', so no exception should be thrown
+        $this->expectNotToPerformAssertions();
         $fields = ['chassis' => '0', 'model' => 'S4|FHC|36', 'year' => '1970'];
         $this->validator->validateRequiredFields($fields, ['chassis', 'model', 'year']);
-        $this->assertTrue(true); // no exception = pass
     }
 
     // ============================================================
@@ -468,6 +468,9 @@ final class CarValidatorTest extends TestCase
     /**
      * Unknown keys with a falsy string value ('0') must pass through — '0' is a legitimate
      * value that !empty() would silently drop, motivating the !== null && !== '' guard.
+     *
+     * Note: named-field cases (color, engine, model, etc.) intentionally still use !empty()
+     * because '0' is not a meaningful value for any of those domain fields. Tracked in #1262.
      */
     #[Group('unit')]
     public function testDefaultCasePassesThroughZeroString(): void

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ElanRegistry\Car;
 
 use DateTime;
+use ElanRegistry\ChassisValidator;
 use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\InputSanitizer;
 use ElanRegistry\Reference\CarModel;
@@ -29,12 +30,12 @@ class CarValidator
      * @param array<string, mixed> $fields Fields to validate
      * @param array<string> $requiredFields List of required field names
      * @return void
-     * @throws CarValidationException If any required field is missing or empty
+     * @throws CarValidationException If any required field is absent, empty, or whitespace-only
      */
     public function validateRequiredFields(array $fields, array $requiredFields): void
     {
         foreach ($requiredFields as $field) {
-            if (!isset($fields[$field]) || empty(trim((string) $fields[$field]))) {
+            if (!isset($fields[$field]) || trim((string)$fields[$field]) === '') {
                 throw new CarValidationException("Required field '{$field}' is missing or empty");
             }
         }
@@ -57,7 +58,15 @@ class CarValidator
                 case 'chassis':
                     if (!empty($value)) {
                         $validatedFields[$key] = InputSanitizer::normalize($value, 50);
-                        if (strlen($validatedFields[$key]) < 3) {
+                        $year  = (int)($fields['year'] ?? 0);
+                        $model = (string)($fields['model'] ?? '');
+                        if ($year > 0 && $model !== '') {
+                            $allowOverride = (isset($fields['chassis_override']) && (int)$fields['chassis_override'] === 1);
+                            $result = (new ChassisValidator())->validate($validatedFields[$key], $year, $model, $allowOverride);
+                            if (!$result['valid']) {
+                                throw new CarValidationException('Chassis validation failed: ' . ($result['error_reason'] ?: 'format check failed'));
+                            }
+                        } elseif (strlen($validatedFields[$key]) < 3) {
                             throw new CarValidationException('Chassis number must be at least 3 characters long');
                         }
                     } elseif ($requireAll) {
@@ -217,7 +226,10 @@ class CarValidator
                     break;
 
                 default:
-                    $validatedFields[$key] = $value;
+                    // Explicit check — !empty() would drop legitimate falsy values like '0' or 0
+                    if ($value !== null && $value !== '') {
+                        $validatedFields[$key] = $value;
+                    }
                     break;
             }
         }

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -58,6 +58,8 @@ class CarValidator
                 case 'chassis':
                     if (!empty($value)) {
                         $validatedFields[$key] = InputSanitizer::normalize($value, 50);
+                        // Read from raw $fields, not $validatedFields — switch processes in input
+                        // order, so year/model may not yet be in $validatedFields when chassis runs.
                         $year  = (int)($fields['year'] ?? 0);
                         $model = (string)($fields['model'] ?? '');
                         if ($year > 0 && $model !== '') {

--- a/usersc/classes/Owner.php
+++ b/usersc/classes/Owner.php
@@ -559,7 +559,7 @@ class Owner
     private function validateRequiredFields(array $fields, array $requiredFields): void
     {
         foreach ($requiredFields as $field) {
-            if (!isset($fields[$field]) || empty(trim($fields[$field]))) {
+            if (!isset($fields[$field]) || trim((string)$fields[$field]) === '') {
                 throw OwnerValidationException::withUserMessage(
                     "Required field '{$field}' is missing or empty",
                     "Required field '{$field}' is missing or empty."
@@ -619,7 +619,7 @@ class Owner
                 case 'state':
                 case 'country':
                     if (!empty($value)) {
-                        $validatedFields[$key] = InputSanitizer::normalize($value, 50);
+                        $validatedFields[$key] = InputSanitizer::normalize($value, 100);
                     }
                     break;
 


### PR DESCRIPTION
## Summary

- **Owner city/state/country cap:** raised from 50 → 100 chars to match the DB `varchar(100)` schema, preventing silent truncation when a long location saved via the car form is later edited in the owner profile
- **Required-field `'0'` acceptance:** both `Owner` and `CarValidator` `validateRequiredFields()` replaced `empty(trim())` with `trim((string)$field) === ''` — `empty('0')` returns `true` in PHP, incorrectly rejecting the value
- **Default case empty guard:** `CarValidator` switch default now uses `$value !== null && $value !== ''` instead of `!empty()`, preventing null/empty unknown fields from being written to the DB while still passing through falsy strings like `'0'`
- **Chassis routing through `ChassisValidator`:** when `year` and `model` are present in the validated fields, `CarValidator` now invokes `ChassisValidator::validate()` for full format checking; falls back to the existing 3-char minimum for partial updates where context is absent

## Bug Escape Analysis

| Fix | Root cause | Testing gap | Preventive test added |
|-----|-----------|------------|----------------------|
| City cap | `Owner` and `CarValidator` developed independently, cap never cross-checked | No test for 51–100 char city values | `testCityAccepts75CharValue`, `testCityAccepts100CharValue`, `testCityTruncatesAt100Chars` |
| `'0'` rejection | PHP `empty()` falsy-string trap, not caught in review | No parameterised test for falsy string values in required fields | `testRequiredFieldAcceptsZeroString`, `testValidateRequiredFieldsAcceptsZeroString` |
| Default case guard | Default case not reviewed against `Owner` pattern | Test for unknown fields only used non-empty value | `testDefaultCaseDropsNullValue`, `testDefaultCaseDropsEmptyStringValue`, `testDefaultCasePassesThroughZeroString` |
| Chassis path | `save.php` and `Car::create()` paths developed independently | `CarValidatorTest` only tested chassis length, not format | `testChassisValidationUsesChassisValidatorForValidPre1970Chassis`, `testChassisValidationRejectsInvalidPre1970FormatWhenYearModelPresent`, `testChassisValidationPermitsInvalidChassisWhenOverrideSet`, `testChassisValidationSkipsChassisValidatorWhenYearAbsent` |

## Notes

`app/api/cars/save.php` — not modified. `updateChassis()` retains its own `ChassisValidator` call for user-facing feedback and override tracking. The two paths are now equivalent; the `save.php` call is redundant and tracked for future cleanup in #1260.

## Test plan

- [ ] `composer test:quick` — 1101 tests, 4262 assertions, all passing
- [ ] `composer check:php` — PHPStan clean, no blocking phpcs errors
- [ ] Smoke-test: save a 75-char city on the car edit form, verify it appears correctly on the profile page
- [ ] Smoke-test: owner profile edit — verify city/state/country accepts long values without truncation

Closes #1233

https://claude.ai/code/session_01T9C2L2Eu6TwxSoZFP7JWca