### PR TITLE
refactor: replace Input::exists() with type-safe existsPost()/existsGet()

### DIFF
--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -34,7 +34,7 @@ $adminUserId = (int) $user->data()->id;
 $errors = [];
 $successes = [];
 
-if (Input::exists('post')) {
+if (Input::existsPost()) {
     $token = Input::get('csrf');
     if (!Token::check($token)) {
         include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -153,7 +153,7 @@ try {
 $errors = [];
 $successes = [];
 
-if (Input::exists('post')) {
+if (ElanInput::existsPost()) {
     $token = Input::get('csrf');
     if (!Token::check($token)) {
         include $abs_us_root . $us_url_root . 'usersc/scripts/token_error.php';

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -154,18 +154,18 @@ $errors = [];
 $successes = [];
 
 if (ElanInput::existsPost()) {
-    $token = Input::get('csrf');
+    $token = ElanInput::get('csrf');
     if (!Token::check($token)) {
         include $abs_us_root . $us_url_root . 'usersc/scripts/token_error.php';
     } else {
-        $command = Input::get('command');
+        $command = ElanInput::get('command');
 
         if ($command) {
             switch ($command) {
                 // Car reassignment
                 case "reassign":
-                    $user_id = (int) Input::get('user_id');
-                    $car_id  = (int) Input::get('car_id');
+                    $user_id = (int) ElanInput::get('user_id');
+                    $car_id  = (int) ElanInput::get('car_id');
 
                     if (!$user_id || !$car_id) {
                         $errors[] = 'Please provide valid car ID and user ID';
@@ -200,8 +200,8 @@ if (ElanInput::existsPost()) {
                 // Car merge
                 case "merge":
                     // Validate input
-                    $cars = Input::get('cars');
-                    $reason = Input::get('reason');
+                    $cars = ElanInput::get('cars');
+                    $reason = ElanInput::get('reason');
                     if (!$cars || !$reason) {
                         $errors[] = 'Select 2 cars to merge and a reason';
                         break;
@@ -349,8 +349,8 @@ if (ElanInput::existsPost()) {
 
                 // Car deletion
                 case "delete":
-                    $car_id = (int) Input::get('car_id');
-                    $confirmation = Input::get('confirmation');
+                    $car_id = (int) ElanInput::get('car_id');
+                    $confirmation = ElanInput::get('confirmation');
                     $reason = mb_substr(ElanInput::raw('reason') ?: 'Administrative deletion', 0, 500);
 
                     if (!$car_id) {

--- a/app/admin/verify/verify_car.php
+++ b/app/admin/verify/verify_car.php
@@ -1,6 +1,7 @@
 <?php
 
 use ElanRegistry\Car\Car;
+use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 
 require_once '../../users/init.php';
@@ -16,7 +17,7 @@ $base_url = $query->first()->verify_url;
 $message = '';
 $redirect = $base_url . $us_url_root;
 
-if (Input::exists('get') && Input::get('code') && Input::get('action')) {
+if (Input::existsGet() && Input::get('code') && Input::get('action')) {
     $code = Input::get('code');
     $action = Input::get('action');
     $token = Input::get('token');

--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -18,7 +18,7 @@ use ElanRegistry\ApiResponse;
 use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received', 400)->send();
 }
 

--- a/app/api/cars/factory-list.php
+++ b/app/api/cars/factory-list.php
@@ -26,7 +26,7 @@ if ($method !== 'POST') {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received')
         ->withDataArray([
             'draw' => 0,

--- a/app/api/cars/history.php
+++ b/app/api/cars/history.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use ElanRegistry\ApiResponse;
 use ElanRegistry\Car\Car;
 use ElanRegistry\Exceptions\ElanRegistryException;
+use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 
 /**
@@ -24,7 +25,7 @@ if ($method !== 'POST') {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received')->send();
 }
 

--- a/app/api/cars/list.php
+++ b/app/api/cars/list.php
@@ -26,7 +26,7 @@ if ($method !== 'POST') {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received')
         ->withDataArray([
             'draw' => 0,

--- a/app/api/cars/models.php
+++ b/app/api/cars/models.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 require_once '../../../users/init.php';
 
 use ElanRegistry\ApiResponse;
+use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Reference\CarModel;
 
@@ -28,7 +29,7 @@ if (strtolower(Server::get('HTTP_X_REQUESTED_WITH', '')) !== 'xmlhttprequest') {
     ApiResponse::error('Bad Request: AJAX only', 400)->send();
 }
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received', 400)->send();
 }
 

--- a/app/api/cars/transfer-request.php
+++ b/app/api/cars/transfer-request.php
@@ -22,7 +22,7 @@ use ElanRegistry\Transfer\TransferEmailService;
 require_once '../../../users/init.php';
 
 try {
-    if (!Input::exists('post') || !Token::check(Input::get('csrf'))) {
+    if (!Input::existsPost() || !Token::check(Input::get('csrf'))) {
         throw new CarTransferException('Invalid request token');
     }
 

--- a/app/api/contact/send-feedback.php
+++ b/app/api/contact/send-feedback.php
@@ -19,7 +19,7 @@ use ElanRegistry\LogCategories;
 require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
-if ($method !== 'POST' || !Input::exists('post')) {
+if ($method !== 'POST' || !Input::existsPost()) {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 

--- a/app/api/contact/send-owner-email.php
+++ b/app/api/contact/send-owner-email.php
@@ -21,7 +21,7 @@ use ElanRegistry\Owner;
 require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
-if ($method !== 'POST' || !Input::exists('post')) {
+if ($method !== 'POST' || !Input::existsPost()) {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 

--- a/app/owner/cars/edit.php
+++ b/app/owner/cars/edit.php
@@ -18,6 +18,7 @@ require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.ph
 
 use ElanRegistry\Car\Car;
 use ElanRegistry\Documentation\DocumentPortalTemplate;
+use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 
 if (!securePage($php_self)) {
@@ -62,7 +63,7 @@ $action = 'addCar';
 $errors = [];
 $successes = [];
 
-if (Input::exists('post')) {
+if (Input::existsPost()) {
     $token = Input::get('csrf');
     if (!Token::check($token)) {
         include_once $abs_us_root . $us_url_root . 'usersc/scripts/token_error.php';

--- a/docs/development/CODING_STANDARDS.md
+++ b/docs/development/CODING_STANDARDS.md
@@ -317,9 +317,12 @@ $cardetails['color'] = htmlspecialchars($color, ENT_QUOTES, 'UTF-8');
 **Rules:**
 
 - `Input::raw()` (via `use ElanRegistry\Input`) → values going to the database
+- `Input::existsPost()` / `Input::existsGet()` → POST/GET presence checks in files that import
+  `ElanRegistry\Input` — `ElanRegistry\Input::exists()` was removed in v2.26.1
 - `\Input::get()` → legacy pattern only (value used directly in HTML, no further escaping)
 - `htmlspecialchars()` → always at output (HTML templates, email templates)
 - Parameterised queries handle SQL safety; encoding at storage is never a SQL defence
+- `Input::raw()` second parameter is a **trim flag** (`bool $trim`), not a default value — use `Input::raw('field') ?? 'fallback'` to supply a default
 
 ### **Database Operations**
 

--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -14,6 +14,12 @@ None.
 - **Ownership transfer integrity** ([#1163](https://github.com/unibrain1/elanregistry/issues/1163)): Fixed a code path where car transfers inserted a new owner row without removing the previous one, preventing stale ownership records.
 - **Validator alignment** ([#1233](https://github.com/unibrain1/elanregistry/issues/1233)): Owner profile city/state/country fields now accept up to 100 characters (matching the database schema), preventing silent truncation when a long location is saved via the car form and then edited in the profile. Required-field validation no longer incorrectly rejects the value `"0"`. Unknown form fields with null or empty values are dropped rather than written to the database.
 
+## Developer-Facing Changes
+
+### Improvements
+
+- **Input class: type-safe POST/GET checks** ([#867](https://github.com/unibrain1/elanregistry/issues/867)): `ElanRegistry\Input::exists(string $type)` replaced by `Input::existsPost()` and `Input::existsGet()`, eliminating the runtime string dispatch in favour of method-name type safety. The key-based forms (`existsPost('field')` / `existsGet('field')`) enable per-key existence checks. All call sites updated. Documented in `CODING_STANDARDS.md` and `elanregistry_overrides`.
+
 ## Admin-Facing Changes
 
 ### Bug Fixes

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * PHPStan bootstrap — stubs UserSpice framework globals that config.php needs
+ * at analysis time. These are set by z_us_root.php in the normal page-load flow,
+ * but PHPStan bootstraps in isolation so they must be pre-declared here.
+ */
+$abs_us_root = '';
+$us_url_root = '';
+
+require_once __DIR__ . '/usersc/includes/config.php';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -59,9 +59,12 @@ parameters:
     # Don't report unmatched ignored errors
     reportUnmatchedIgnoredErrors: false
 
-    # Bootstrap files — load constants defined outside the analysed classes
+    # Bootstrap files — load constants defined outside the analysed classes.
+    # phpstan-bootstrap.php stubs the UserSpice globals ($abs_us_root, $us_url_root)
+    # that config.php needs; those are set by z_us_root.php at runtime but are
+    # undefined when PHPStan bootstraps in isolation.
     bootstrapFiles:
-        - usersc/includes/config.php
+        - phpstan-bootstrap.php
 
 # Custom rules (can be added via extensions)
 # extensions:

--- a/tests/unit/security/ElanRegistryInputTest.php
+++ b/tests/unit/security/ElanRegistryInputTest.php
@@ -447,6 +447,21 @@ final class ElanRegistryInputTest extends TestCase
         $this->assertFalse(Input::existsPost('missing'));
     }
 
+    /**
+     * existsPost('key') returns false when the key is present but its value is null.
+     *
+     * isset() returns false for null values. This differs from the no-key form:
+     * existsPost() (no key) would return true because $_POST is non-empty,
+     * while existsPost('x') returns false because isset($_POST['x']) is false.
+     * PHP HTTP superglobals never hold null in practice, but this documents the invariant.
+     */
+    #[Group('fast')]
+    public function test_existsPost_with_key_returns_false_when_key_is_null(): void
+    {
+        $_POST = ['x' => null];
+        $this->assertFalse(Input::existsPost('x'));
+    }
+
     // -------------------------------------------------------------------------
     // existsGet() presence checks (issue #867)
     // -------------------------------------------------------------------------
@@ -489,6 +504,21 @@ final class ElanRegistryInputTest extends TestCase
     {
         $_GET = [];
         $this->assertFalse(Input::existsGet('missing'));
+    }
+
+    /**
+     * existsGet('key') returns false when the key is present but its value is null.
+     *
+     * isset() returns false for null values. This differs from the no-key form:
+     * existsGet() (no key) would return true because $_GET is non-empty,
+     * while existsGet('x') returns false because isset($_GET['x']) is false.
+     * PHP HTTP superglobals never hold null in practice, but this documents the invariant.
+     */
+    #[Group('fast')]
+    public function test_existsGet_with_key_returns_false_when_key_is_null(): void
+    {
+        $_GET = ['x' => null];
+        $this->assertFalse(Input::existsGet('x'));
     }
 
     // -------------------------------------------------------------------------

--- a/tests/unit/security/ElanRegistryInputTest.php
+++ b/tests/unit/security/ElanRegistryInputTest.php
@@ -400,4 +400,130 @@ final class ElanRegistryInputTest extends TestCase
         $this->assertIsString($result);
         $this->assertSame('1969', $result);
     }
+
+    // -------------------------------------------------------------------------
+    // existsPost() presence checks (issue #867)
+    // -------------------------------------------------------------------------
+
+    /**
+     * existsPost() with no key returns true when $_POST holds any data.
+     *
+     * Mirrors the "did a POST request arrive?" check at the top of form handlers.
+     */
+    #[Group('fast')]
+    public function test_existsPost_returns_true_when_post_is_non_empty(): void
+    {
+        $_POST['x'] = 'value';
+        $this->assertTrue(Input::existsPost());
+    }
+
+    /**
+     * existsPost() with no key returns false when $_POST is empty.
+     */
+    #[Group('fast')]
+    public function test_existsPost_returns_false_when_post_is_empty(): void
+    {
+        $_POST = [];
+        $this->assertFalse(Input::existsPost());
+    }
+
+    /**
+     * existsPost('key') returns true when that key is present in $_POST.
+     */
+    #[Group('fast')]
+    public function test_existsPost_with_key_returns_true_when_key_present(): void
+    {
+        $_POST['x'] = 'value';
+        $this->assertTrue(Input::existsPost('x'));
+    }
+
+    /**
+     * existsPost('key') returns false when that key is absent from $_POST.
+     */
+    #[Group('fast')]
+    public function test_existsPost_with_key_returns_false_when_key_absent(): void
+    {
+        $_POST = [];
+        $this->assertFalse(Input::existsPost('missing'));
+    }
+
+    // -------------------------------------------------------------------------
+    // existsGet() presence checks (issue #867)
+    // -------------------------------------------------------------------------
+
+    /**
+     * existsGet() with no key returns true when $_GET holds any query params.
+     */
+    #[Group('fast')]
+    public function test_existsGet_returns_true_when_get_is_non_empty(): void
+    {
+        $_GET['x'] = 'value';
+        $this->assertTrue(Input::existsGet());
+    }
+
+    /**
+     * existsGet() with no key returns false when $_GET is empty.
+     */
+    #[Group('fast')]
+    public function test_existsGet_returns_false_when_get_is_empty(): void
+    {
+        $_GET = [];
+        $this->assertFalse(Input::existsGet());
+    }
+
+    /**
+     * existsGet('key') returns true when that key is present in $_GET.
+     */
+    #[Group('fast')]
+    public function test_existsGet_with_key_returns_true_when_key_present(): void
+    {
+        $_GET['x'] = 'value';
+        $this->assertTrue(Input::existsGet('x'));
+    }
+
+    /**
+     * existsGet('key') returns false when that key is absent from $_GET.
+     */
+    #[Group('fast')]
+    public function test_existsGet_with_key_returns_false_when_key_absent(): void
+    {
+        $_GET = [];
+        $this->assertFalse(Input::existsGet('missing'));
+    }
+
+    // -------------------------------------------------------------------------
+    // get() delegation contract (issue #867)
+    // -------------------------------------------------------------------------
+
+    /**
+     * get() delegates to the upstream \Input::get().
+     *
+     * The unit bootstrap stubs \Input::get() to return the raw superglobal
+     * value, so this confirms ElanRegistry\Input::get() forwards to it.
+     */
+    #[Group('fast')]
+    public function test_get_delegates_to_upstream_input_get(): void
+    {
+        $_POST['x'] = "Tom & Jerry's";
+        $result = Input::get('x');
+        $this->assertSame("Tom & Jerry's", (string)$result);
+    }
+
+    // -------------------------------------------------------------------------
+    // raw() trim flag is not a default value (issue #867)
+    // -------------------------------------------------------------------------
+
+    /**
+     * raw()'s second parameter is a trim flag, not a default value.
+     *
+     * Under strict_types=1, passing a non-bool second argument throws a
+     * TypeError. To supply a default, use `Input::raw('field') ?? 'fallback'`.
+     */
+    #[Group('fast')]
+    public function test_raw_second_param_is_trim_flag_not_default(): void
+    {
+        $_POST['x'] = '  hello  ';
+        $this->expectException(\TypeError::class);
+        Input::raw('x', 'fallback');
+    }
 }

--- a/tests/unit/security/ElanRegistryInputTest.php
+++ b/tests/unit/security/ElanRegistryInputTest.php
@@ -498,8 +498,10 @@ final class ElanRegistryInputTest extends TestCase
     /**
      * get() delegates to the upstream \Input::get().
      *
-     * The unit bootstrap stubs \Input::get() to return the raw superglobal
-     * value, so this confirms ElanRegistry\Input::get() forwards to it.
+     * The unit bootstrap stubs \Input::get() to return the raw superglobal value
+     * (without HTML-encoding — unlike the real upstream, which applies htmlspecialchars()).
+     * This test verifies that ElanRegistry\Input::get() forwards the call through;
+     * it does not assert encoding behaviour, which is a property of the real upstream.
      */
     #[Group('fast')]
     public function test_get_delegates_to_upstream_input_get(): void

--- a/usersc/classes/Input.php
+++ b/usersc/classes/Input.php
@@ -72,10 +72,12 @@ class Input
      * Checks whether $_POST is non-empty, or whether a specific key is present in $_POST.
      *
      * With no argument: delegates to \Input::exists('post') — true when $_POST is non-empty.
-     * With a key: returns isset($_POST[$key]).
+     * With a key: uses isset($_POST[$key]) directly, because \Input::exists() has no
+     * key-level API — it only tests superglobal emptiness.
      *
      * @param string $key Optional key to check for. When empty, checks the superglobal itself.
-     * @return bool True when $_POST is non-empty (no key) or contains $key.
+     * @return bool True when $_POST is non-empty (no key) or contains $key (with key).
+     * @since v2.26.1
      */
     public static function existsPost(string $key = ''): bool
     {
@@ -86,10 +88,12 @@ class Input
      * Checks whether $_GET is non-empty, or whether a specific key is present in $_GET.
      *
      * With no argument: delegates to \Input::exists('get') — true when $_GET is non-empty.
-     * With a key: returns isset($_GET[$key]).
+     * With a key: uses isset($_GET[$key]) directly, because \Input::exists() has no
+     * key-level API — it only tests superglobal emptiness.
      *
      * @param string $key Optional key to check for. When empty, checks the superglobal itself.
-     * @return bool True when $_GET is non-empty (no key) or contains $key.
+     * @return bool True when $_GET is non-empty (no key) or contains $key (with key).
+     * @since v2.26.1
      */
     public static function existsGet(string $key = ''): bool
     {

--- a/usersc/classes/Input.php
+++ b/usersc/classes/Input.php
@@ -10,7 +10,7 @@ namespace ElanRegistry;
  * Files that import this class with `use ElanRegistry\Input` can call:
  *   - Input::raw()  — unencoded value for database storage
  *   - Input::get()  — HTML-encoded value (delegates to \Input::get())
- *   - Input::exists() — POST/GET presence check (delegates to \Input::exists())
+ *   - Input::existsPost() / Input::existsGet() — POST/GET presence checks
  *
  * @since v2.23.0
  * @see https://github.com/unibrain1/elanregistry/issues/843
@@ -26,6 +26,9 @@ class Input
      *
      * Use for values that will be stored in the database. Always apply
      * htmlspecialchars() at the HTML output context to prevent XSS.
+     *
+     * The second parameter is a trim flag, NOT a default value. To supply a
+     * default, use `Input::raw('field') ?? 'fallback'`.
      *
      * @param string $item The POST/GET key to retrieve.
      * @param bool   $trim Whether to trim leading/trailing whitespace (default true).
@@ -66,21 +69,30 @@ class Input
     }
 
     /**
-     * Delegates to \Input::exists() — checks whether the named superglobal is non-empty.
+     * Checks whether $_POST is non-empty, or whether a specific key is present in $_POST.
      *
-     * Checks $_POST when $type is 'post', $_GET when $type is 'get'.
+     * With no argument: delegates to \Input::exists('post') — true when $_POST is non-empty.
+     * With a key: returns isset($_POST[$key]).
      *
-     * @param string $type 'post' or 'get' (default 'post').
-     * @return bool True when the superglobal is non-empty.
-     * @throws \InvalidArgumentException When $type is not 'post' or 'get'.
+     * @param string $key Optional key to check for. When empty, checks the superglobal itself.
+     * @return bool True when $_POST is non-empty (no key) or contains $key.
      */
-    public static function exists(string $type = 'post'): bool
+    public static function existsPost(string $key = ''): bool
     {
-        if ($type !== 'post' && $type !== 'get') {
-            throw new \InvalidArgumentException(
-                "ElanRegistry\\Input::exists() expects 'post' or 'get', got '{$type}'."
-            );
-        }
-        return \Input::exists($type);
+        return $key !== '' ? isset($_POST[$key]) : \Input::exists('post');
+    }
+
+    /**
+     * Checks whether $_GET is non-empty, or whether a specific key is present in $_GET.
+     *
+     * With no argument: delegates to \Input::exists('get') — true when $_GET is non-empty.
+     * With a key: returns isset($_GET[$key]).
+     *
+     * @param string $key Optional key to check for. When empty, checks the superglobal itself.
+     * @return bool True when $_GET is non-empty (no key) or contains $key.
+     */
+    public static function existsGet(string $key = ''): bool
+    {
+        return $key !== '' ? isset($_GET[$key]) : \Input::exists('get');
     }
 }

--- a/usersc/join.php
+++ b/usersc/join.php
@@ -80,8 +80,8 @@ if ($act == 1 || $settings->no_passwords == 1) {
     $pre = 1;
 }
 
-if (Input::exists()) {
-    $token = $_POST['csrf'];
+if (Input::existsPost()) {
+    $token = Input::get('csrf');
     if (!Token::check($token)) {
         include $abs_us_root.$us_url_root.'usersc/scripts/token_error.php';
     }

--- a/usersc/plugins/ai_prompts/custom_prompts/elanregistry_overrides.md.php
+++ b/usersc/plugins/ai_prompts/custom_prompts/elanregistry_overrides.md.php
@@ -39,6 +39,29 @@ escaping (the UserSpice convention). For anything going to the database, always 
 
 See `docs/development/CODING_STANDARDS.md` — Input Handling and Output Encoding.
 
+### POST/GET presence checks: `existsPost()` / `existsGet()`
+
+The shipped prompts show `Input::exists('post')` / `Input::exists('get')`. In files that
+import `ElanRegistry\Input`, use the typed replacements instead:
+
+```php
+// ✅ CORRECT in ElanRegistry files
+use ElanRegistry\Input;
+
+if (Input::existsPost()) { ... }          // "did a POST request arrive?"
+if (Input::existsGet()) { ... }           // "are there any query params?"
+
+// Key-specific form (isset check on the specific key):
+if (Input::existsPost('csrf')) { ... }    // "is 'csrf' present in $_POST?"
+
+// ❌ WRONG in files with `use ElanRegistry\Input` — calls removed ElanRegistry method
+if (Input::exists('post')) { ... }
+```
+
+`\Input::exists('post')` (the UserSpice upstream) still works in files that do **not**
+import `ElanRegistry\Input`, but any file using the ElanRegistry wrapper must call
+`existsPost()` / `existsGet()` — the `exists()` method was removed from the wrapper in v2.26.1.
+
 ---
 
 ## 2. Server variables: use validated globals, not `$_SERVER` directly


### PR DESCRIPTION
## Summary

- Replaces `ElanRegistry\Input::exists(string $type)` with `Input::existsPost(string $key = '')` and `Input::existsGet(string $key = '')`, eliminating runtime string dispatch in favour of method-name type safety
- Migrates all 13 ElanRegistry call sites; 5 previously-skipped files are now fully migrated with `use ElanRegistry\Input` added where missing
- Adds key-based form (`existsPost('field')` / `existsGet('field')`) for per-key existence checks via `isset()`
- Fixes `usersc/join.php` CSRF token retrieval from raw `$_POST['csrf']` to `Input::get('csrf')` for consistency with all other call sites
- Removes `ElanRegistry\Input::exists()` entirely; PHPStan catches any missed call sites as a type error

## Test plan

- [ ] `composer test:quick` — 1111 tests, 4270 assertions passing
- [ ] PHPStan clean on changed files (no `existsPost`/`existsGet` errors)
- [ ] 10 new unit tests in `tests/unit/security/ElanRegistryInputTest.php` covering both forms of `existsPost()`/`existsGet()`, `get()` delegation, and the `raw()` trim-flag TypeError trap
- [ ] Verify no remaining `ElanRegistry\Input::exists()` call sites: `grep -rn "Input::exists(" app/ usersc/ --include="*.php"` returns only the implementation body and archived files

## Notes

- Files without `use ElanRegistry\Input` (5 archived scripts, upstream UserSpice files) still call `\Input::exists()` — those are unaffected as they resolve to the UserSpice class
- `app/admin/index.php` uses `use ElanRegistry\Input as ElanInput`; line 156 correctly changed to `ElanInput::existsPost()`

Closes #867

https://claude.ai/code/session_01T9C2L2Eu6TwxSoZFP7JWca