### PR TITLE
v2.26.1 — Validation & Input Fixes

### DIFF
--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -124,11 +124,12 @@ if (Input::exists('post')) {
 
                 if ($carData) {
                     $template['carContext'] = [
-                        'id' => $carData->id,
-                        'year' => $carData->year,
-                        'model' => $carData->model,
-                        'series' => $carData->series,
-                        'chassis' => $carData->chassis
+                        'id'      => $carData->id,
+                        'year'    => $carData->year,
+                        'series'  => $carData->series  ?? '',
+                        'variant' => $carData->variant ?? '',
+                        'type'    => $carData->type    ?? '',
+                        'chassis' => $carData->chassis,
                     ];
                 }
 

--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -43,7 +43,7 @@ if (Input::existsPost()) {
 
     $action = Input::get('action');
     if ($action === 'admin_contact_owner') {
-        $message = trim(Input::raw('message'));
+        $message = trim(Input::raw('message') ?? '');
         $carId = Input::get('car_id');
         $ownerId = Input::get('owner_id');
         $qualityIssue = Input::raw('quality_issue');

--- a/app/admin/includes/process-admin-contact.php
+++ b/app/admin/includes/process-admin-contact.php
@@ -34,7 +34,7 @@ $adminUserId = (int) $user->data()->id;
 $errors = [];
 $successes = [];
 
-if (Input::exists('post')) {
+if (Input::existsPost()) {
     $token = Input::get('csrf');
     if (!Token::check($token)) {
         include($abs_us_root . $us_url_root . 'usersc/scripts/token_error.php');

--- a/app/admin/includes/process-owner-search.php
+++ b/app/admin/includes/process-owner-search.php
@@ -34,8 +34,7 @@ try {
     // Enhance results with data quality scoring
     $enhancedResults = [];
     foreach ($searchResults as $owner) {
-        $ownerProfile = new Owner((int)$owner->id);
-        $qualityScore = $ownerProfile->getProfileQualityScore();
+        $qualityScore = Owner::qualityScoreFromRow($owner);
 
         $enhancedResults[] = [
             'id' => (int)$owner->id,

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -153,19 +153,19 @@ try {
 $errors = [];
 $successes = [];
 
-if (Input::exists('post')) {
-    $token = Input::get('csrf');
+if (ElanInput::existsPost()) {
+    $token = ElanInput::get('csrf');
     if (!Token::check($token)) {
         include $abs_us_root . $us_url_root . 'usersc/scripts/token_error.php';
     } else {
-        $command = Input::get('command');
+        $command = ElanInput::get('command');
 
         if ($command) {
             switch ($command) {
                 // Car reassignment
                 case "reassign":
-                    $user_id = (int) Input::get('user_id');
-                    $car_id  = (int) Input::get('car_id');
+                    $user_id = (int) ElanInput::get('user_id');
+                    $car_id  = (int) ElanInput::get('car_id');
 
                     if (!$user_id || !$car_id) {
                         $errors[] = 'Please provide valid car ID and user ID';
@@ -200,8 +200,8 @@ if (Input::exists('post')) {
                 // Car merge
                 case "merge":
                     // Validate input
-                    $cars = Input::get('cars');
-                    $reason = Input::get('reason');
+                    $cars = ElanInput::get('cars');
+                    $reason = ElanInput::get('reason');
                     if (!$cars || !$reason) {
                         $errors[] = 'Select 2 cars to merge and a reason';
                         break;
@@ -349,8 +349,8 @@ if (Input::exists('post')) {
 
                 // Car deletion
                 case "delete":
-                    $car_id = (int) Input::get('car_id');
-                    $confirmation = Input::get('confirmation');
+                    $car_id = (int) ElanInput::get('car_id');
+                    $confirmation = ElanInput::get('confirmation');
                     $reason = mb_substr(ElanInput::raw('reason') ?: 'Administrative deletion', 0, 500);
 
                     if (!$car_id) {

--- a/app/admin/verify/verify_car.php
+++ b/app/admin/verify/verify_car.php
@@ -1,6 +1,7 @@
 <?php
 
 use ElanRegistry\Car\Car;
+use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 
 require_once '../../users/init.php';
@@ -16,7 +17,7 @@ $base_url = $query->first()->verify_url;
 $message = '';
 $redirect = $base_url . $us_url_root;
 
-if (Input::exists('get') && Input::get('code') && Input::get('action')) {
+if (Input::existsGet() && Input::get('code') && Input::get('action')) {
     $code = Input::get('code');
     $action = Input::get('action');
     $token = Input::get('token');

--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -18,7 +18,7 @@ use ElanRegistry\ApiResponse;
 use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received', 400)->send();
 }
 

--- a/app/api/cars/factory-list.php
+++ b/app/api/cars/factory-list.php
@@ -26,7 +26,7 @@ if ($method !== 'POST') {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received')
         ->withDataArray([
             'draw' => 0,

--- a/app/api/cars/history.php
+++ b/app/api/cars/history.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use ElanRegistry\ApiResponse;
 use ElanRegistry\Car\Car;
 use ElanRegistry\Exceptions\ElanRegistryException;
+use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 
 /**
@@ -24,7 +25,7 @@ if ($method !== 'POST') {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received')->send();
 }
 

--- a/app/api/cars/list.php
+++ b/app/api/cars/list.php
@@ -26,7 +26,7 @@ if ($method !== 'POST') {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received')
         ->withDataArray([
             'draw' => 0,

--- a/app/api/cars/models.php
+++ b/app/api/cars/models.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 require_once '../../../users/init.php';
 
 use ElanRegistry\ApiResponse;
+use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Reference\CarModel;
 
@@ -28,7 +29,7 @@ if (strtolower(Server::get('HTTP_X_REQUESTED_WITH', '')) !== 'xmlhttprequest') {
     ApiResponse::error('Bad Request: AJAX only', 400)->send();
 }
 
-if (!Input::exists('post')) {
+if (!Input::existsPost()) {
     ApiResponse::error('No data received', 400)->send();
 }
 

--- a/app/api/cars/transfer-request.php
+++ b/app/api/cars/transfer-request.php
@@ -22,7 +22,7 @@ use ElanRegistry\Transfer\TransferEmailService;
 require_once '../../../users/init.php';
 
 try {
-    if (!Input::exists('post') || !Token::check(Input::get('csrf'))) {
+    if (!Input::existsPost() || !Token::check(Input::get('csrf'))) {
         throw new CarTransferException('Invalid request token');
     }
 

--- a/app/api/contact/send-feedback.php
+++ b/app/api/contact/send-feedback.php
@@ -19,7 +19,7 @@ use ElanRegistry\LogCategories;
 require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
-if ($method !== 'POST' || !Input::exists('post')) {
+if ($method !== 'POST' || !Input::existsPost()) {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 

--- a/app/api/contact/send-owner-email.php
+++ b/app/api/contact/send-owner-email.php
@@ -21,7 +21,7 @@ use ElanRegistry\Owner;
 require_once '../../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
-if ($method !== 'POST' || !Input::exists('post')) {
+if ($method !== 'POST' || !Input::existsPost()) {
     ApiResponse::error('Method not allowed', 405)->send();
 }
 

--- a/app/owner/cars/edit.php
+++ b/app/owner/cars/edit.php
@@ -18,6 +18,7 @@ require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.ph
 
 use ElanRegistry\Car\Car;
 use ElanRegistry\Documentation\DocumentPortalTemplate;
+use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
 
 if (!securePage($php_self)) {
@@ -62,7 +63,7 @@ $action = 'addCar';
 $errors = [];
 $successes = [];
 
-if (Input::exists('post')) {
+if (Input::existsPost()) {
     $token = Input::get('csrf');
     if (!Token::check($token)) {
         include_once $abs_us_root . $us_url_root . 'usersc/scripts/token_error.php';

--- a/app/views/email/_admin_to_owner.php
+++ b/app/views/email/_admin_to_owner.php
@@ -22,7 +22,7 @@ $adminDetails =
 
 $carContextBox = '';
 if ($hasCarContext) {
-    $carDetails = $emailTemplate->createDetailRow('Car ID', $carContext['id']);
+    $carDetails = $emailTemplate->createDetailRow('Car ID', (string)$carContext['id']);
     $vehicleLabel = '';
     if (!empty($carContext['year'])) {
         $vehicleLabel .= (int)$carContext['year'];

--- a/app/views/email/_admin_to_owner.php
+++ b/app/views/email/_admin_to_owner.php
@@ -23,8 +23,22 @@ $adminDetails =
 $carContextBox = '';
 if ($hasCarContext) {
     $carDetails = $emailTemplate->createDetailRow('Car ID', $carContext['id']);
-    if (isset($carContext['year']) && isset($carContext['model'])) {
-        $carDetails .= $emailTemplate->createDetailRow('Vehicle', $carContext['year'] . ' ' . $carContext['model']);
+    $vehicleLabel = '';
+    if (!empty($carContext['year'])) {
+        $vehicleLabel .= (int)$carContext['year'];
+    }
+    if (!empty($carContext['series'])) {
+        $prefix = $vehicleLabel !== '' ? ' ' : '';
+        $vehicleLabel .= $prefix . 'Elan ' . $carContext['series'];
+    }
+    if (!empty($carContext['variant'])) {
+        $vehicleLabel .= ' ' . $carContext['variant'];
+    }
+    if (!empty($carContext['type'])) {
+        $vehicleLabel .= ' (Type ' . $carContext['type'] . ')';
+    }
+    if ($vehicleLabel !== '') {
+        $carDetails .= $emailTemplate->createDetailRow('Vehicle', $vehicleLabel);
     }
     if (isset($carContext['chassis'])) {
         $carDetails .= $emailTemplate->createDetailRow('Chassis', $carContext['chassis']);

--- a/docs/development/CODING_STANDARDS.md
+++ b/docs/development/CODING_STANDARDS.md
@@ -317,9 +317,12 @@ $cardetails['color'] = htmlspecialchars($color, ENT_QUOTES, 'UTF-8');
 **Rules:**
 
 - `Input::raw()` (via `use ElanRegistry\Input`) → values going to the database
+- `Input::existsPost()` / `Input::existsGet()` → POST/GET presence checks in files that import
+  `ElanRegistry\Input` — `ElanRegistry\Input::exists()` was removed in v2.26.1
 - `\Input::get()` → legacy pattern only (value used directly in HTML, no further escaping)
 - `htmlspecialchars()` → always at output (HTML templates, email templates)
 - Parameterised queries handle SQL safety; encoding at storage is never a SQL defence
+- `Input::raw()` second parameter is a **trim flag** (`bool $trim`), not a default value — use `Input::raw('field') ?? 'fallback'` to supply a default
 
 ### **Database Operations**
 

--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -11,7 +11,6 @@ None.
 
 ### Bug Fixes
 
-- **Ownership transfer integrity** ([#1163](https://github.com/unibrain1/elanregistry/issues/1163)): Fixed a code path where car transfers inserted a new owner row without removing the previous one, preventing stale ownership records.
 - **Validator alignment** ([#1233](https://github.com/unibrain1/elanregistry/issues/1233)): Owner profile city/state/country fields now accept up to 100 characters (matching the database schema), preventing silent truncation when a long location is saved via the car form and then edited in the profile. Required-field validation no longer incorrectly rejects the value `"0"`. Unknown form fields with null or empty values are dropped rather than written to the database.
 
 ## Developer-Facing Changes
@@ -33,12 +32,7 @@ None.
 
 ## Issues Resolved
 
-- [#268](https://github.com/unibrain1/elanregistry/issues/268) — Remove users_carsview database view and integrate with Car class architecture
 - [#867](https://github.com/unibrain1/elanregistry/issues/867) — refactor: Input class improvements — type-safe exists() and clarify raw() signature in docs
-- [#993](https://github.com/unibrain1/elanregistry/issues/993) — refactor: add FK constraints for 4 relationships currently enforced only in application code
-- [#1069](https://github.com/unibrain1/elanregistry/issues/1069) — refactor: consolidate site name and email subject prefix into shared constants
-- [#1160](https://github.com/unibrain1/elanregistry/issues/1160) — fix: remove 3 stale car_user rows left by incomplete ownership transfers
-- [#1163](https://github.com/unibrain1/elanregistry/issues/1163) — fix: transfer code path inserts new car_user row without removing old owner row
 - [#1230](https://github.com/unibrain1/elanregistry/issues/1230) — fix: N+1 query in owner search — use Owner::qualityScoreFromRow() directly on search result rows
 - [#1233](https://github.com/unibrain1/elanregistry/issues/1233) — fix: validator alignment — city length caps, default case guard, required-field check, and chassis routing
 - [#1236](https://github.com/unibrain1/elanregistry/issues/1236) — fix: admin contact email sends raw pipe-delimited model string in carContext instead of human-readable label

--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -12,6 +12,7 @@ None.
 ### Bug Fixes
 
 - **Ownership transfer integrity** ([#1163](https://github.com/unibrain1/elanregistry/issues/1163)): Fixed a code path where car transfers inserted a new owner row without removing the previous one, preventing stale ownership records.
+- **Validator alignment** ([#1233](https://github.com/unibrain1/elanregistry/issues/1233)): Owner profile city/state/country fields now accept up to 100 characters (matching the database schema), preventing silent truncation when a long location is saved via the car form and then edited in the profile. Required-field validation no longer incorrectly rejects the value `"0"`. Unknown form fields with null or empty values are dropped rather than written to the database.
 
 ## Admin-Facing Changes
 

--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -19,6 +19,7 @@ None.
 
 - **Input class: type-safe POST/GET checks** ([#867](https://github.com/unibrain1/elanregistry/issues/867)): `ElanRegistry\Input::exists(string $type)` replaced by `Input::existsPost()` and `Input::existsGet()`, eliminating the runtime string dispatch in favour of method-name type safety. The key-based forms (`existsPost('field')` / `existsGet('field')`) enable per-key existence checks. All call sites updated. Documented in `CODING_STANDARDS.md` and `elanregistry_overrides`.
 - **E2E smoke coverage for docs portal** ([#1252](https://github.com/unibrain1/elanregistry/issues/1252)): Fixed two stale paths in the not-logged-in e2e suite (`/docs/reference-library.php` → `/docs/reference/index.php`, `/docs/faq/index.php` → `/docs/guides/index.php`) and added smoke tests for 12 additional docs portal pages (docs index, all reference sub-pages, car stories, guides, and pdf-viewer). Also corrected two pre-existing stale selectors for List Cars and Car Stories.
+- **Remove redundant ChassisValidator call** ([#1260](https://github.com/unibrain1/elanregistry/issues/1260)): `CarValidator::validateAndSanitizeFields()` no longer calls `ChassisValidator` — format validation is the sole responsibility of `save.php::updateChassis()`, which already ran before `Car::update()`/`Car::create()`. The `CarValidator` chassis case now only sanitizes and enforces the 3-character minimum. Three superseded tests removed; two new focused tests added.
 
 ## Admin-Facing Changes
 
@@ -37,3 +38,4 @@ None.
 - [#1233](https://github.com/unibrain1/elanregistry/issues/1233) — fix: validator alignment — city length caps, default case guard, required-field check, and chassis routing
 - [#1236](https://github.com/unibrain1/elanregistry/issues/1236) — fix: admin contact email sends raw pipe-delimited model string in carContext instead of human-readable label
 - [#1252](https://github.com/unibrain1/elanregistry/issues/1252) — test: fix stale e2e paths and add smoke tests for docs portal pages
+- [#1260](https://github.com/unibrain1/elanregistry/issues/1260) — refactor: remove redundant ChassisValidator call from CarValidator

--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -14,6 +14,12 @@ None.
 - **Ownership transfer integrity** ([#1163](https://github.com/unibrain1/elanregistry/issues/1163)): Fixed a code path where car transfers inserted a new owner row without removing the previous one, preventing stale ownership records.
 - **Validator alignment** ([#1233](https://github.com/unibrain1/elanregistry/issues/1233)): Owner profile city/state/country fields now accept up to 100 characters (matching the database schema), preventing silent truncation when a long location is saved via the car form and then edited in the profile. Required-field validation no longer incorrectly rejects the value `"0"`. Unknown form fields with null or empty values are dropped rather than written to the database.
 
+## Developer-Facing Changes
+
+### Improvements
+
+- **Input class: type-safe POST/GET checks** ([#867](https://github.com/unibrain1/elanregistry/issues/867)): `ElanRegistry\Input::exists(string $type)` replaced by `Input::existsPost()` and `Input::existsGet()`, eliminating the runtime string dispatch in favour of method-name type safety. The key-based forms (`existsPost('field')` / `existsGet('field')`) enable per-key existence checks. All call sites updated. Documented in `CODING_STANDARDS.md` and `elanregistry_overrides`.
+
 ## Admin-Facing Changes
 
 ### Bug Fixes

--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -19,6 +19,7 @@ None.
 ### Improvements
 
 - **Input class: type-safe POST/GET checks** ([#867](https://github.com/unibrain1/elanregistry/issues/867)): `ElanRegistry\Input::exists(string $type)` replaced by `Input::existsPost()` and `Input::existsGet()`, eliminating the runtime string dispatch in favour of method-name type safety. The key-based forms (`existsPost('field')` / `existsGet('field')`) enable per-key existence checks. All call sites updated. Documented in `CODING_STANDARDS.md` and `elanregistry_overrides`.
+- **E2E smoke coverage for docs portal** ([#1252](https://github.com/unibrain1/elanregistry/issues/1252)): Fixed two stale paths in the not-logged-in e2e suite (`/docs/reference-library.php` → `/docs/reference/index.php`, `/docs/faq/index.php` → `/docs/guides/index.php`) and added smoke tests for 12 additional docs portal pages (docs index, all reference sub-pages, car stories, guides, and pdf-viewer). Also corrected two pre-existing stale selectors for List Cars and Car Stories.
 
 ## Admin-Facing Changes
 

--- a/docs/releases/RELEASE_NOTES_v2.26.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.1.md
@@ -1,0 +1,37 @@
+# Elan Registry v2.26.1 Release Notes
+
+**Release Date:** TBD
+**Type:** Patch Release — Validation & Input Fixes
+
+## Required Actions After Deployment
+
+None.
+
+## User-Facing Changes
+
+### Bug Fixes
+
+- **Ownership transfer integrity** ([#1163](https://github.com/unibrain1/elanregistry/issues/1163)): Fixed a code path where car transfers inserted a new owner row without removing the previous one, preventing stale ownership records.
+
+## Admin-Facing Changes
+
+### Bug Fixes
+
+- **Admin contact email — readable car model** ([#1236](https://github.com/unibrain1/elanregistry/issues/1236)): Admin-to-owner contact emails now display a human-readable car model (e.g. "Series 1 / Drophead Coupé") instead of the raw internal pipe-delimited value.
+
+### Improvements
+
+- **Owner search performance** ([#1230](https://github.com/unibrain1/elanregistry/issues/1230)): Admin owner search now executes 1 database query regardless of result count, down from N+1 (26 queries for 25 results).
+
+## Issues Resolved
+
+- [#268](https://github.com/unibrain1/elanregistry/issues/268) — Remove users_carsview database view and integrate with Car class architecture
+- [#867](https://github.com/unibrain1/elanregistry/issues/867) — refactor: Input class improvements — type-safe exists() and clarify raw() signature in docs
+- [#993](https://github.com/unibrain1/elanregistry/issues/993) — refactor: add FK constraints for 4 relationships currently enforced only in application code
+- [#1069](https://github.com/unibrain1/elanregistry/issues/1069) — refactor: consolidate site name and email subject prefix into shared constants
+- [#1160](https://github.com/unibrain1/elanregistry/issues/1160) — fix: remove 3 stale car_user rows left by incomplete ownership transfers
+- [#1163](https://github.com/unibrain1/elanregistry/issues/1163) — fix: transfer code path inserts new car_user row without removing old owner row
+- [#1230](https://github.com/unibrain1/elanregistry/issues/1230) — fix: N+1 query in owner search — use Owner::qualityScoreFromRow() directly on search result rows
+- [#1233](https://github.com/unibrain1/elanregistry/issues/1233) — fix: validator alignment — city length caps, default case guard, required-field check, and chassis routing
+- [#1236](https://github.com/unibrain1/elanregistry/issues/1236) — fix: admin contact email sends raw pipe-delimited model string in carContext instead of human-readable label
+- [#1252](https://github.com/unibrain1/elanregistry/issues/1252) — test: fix stale e2e paths and add smoke tests for docs portal pages

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * PHPStan bootstrap — stubs UserSpice framework globals that config.php needs
+ * at analysis time. These are set by z_us_root.php in the normal page-load flow,
+ * but PHPStan bootstraps in isolation so they must be pre-declared here.
+ */
+$abs_us_root = '';
+$us_url_root = '';
+
+require_once __DIR__ . '/usersc/includes/config.php';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -59,9 +59,12 @@ parameters:
     # Don't report unmatched ignored errors
     reportUnmatchedIgnoredErrors: false
 
-    # Bootstrap files — load constants defined outside the analysed classes
+    # Bootstrap files — load constants defined outside the analysed classes.
+    # phpstan-bootstrap.php stubs the UserSpice globals ($abs_us_root, $us_url_root)
+    # that config.php needs; those are set by z_us_root.php at runtime but are
+    # undefined when PHPStan bootstraps in isolation.
     bootstrapFiles:
-        - usersc/includes/config.php
+        - phpstan-bootstrap.php
 
 # Custom rules (can be added via extensions)
 # extensions:

--- a/tests/integration/OwnerIntegrationTest.php
+++ b/tests/integration/OwnerIntegrationTest.php
@@ -307,4 +307,75 @@ class OwnerIntegrationTest extends IntegrationTestCase
             $this->db->query("DELETE FROM profiles WHERE user_id = ?", [$userId]);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // city/state/country length cap raised from 50 → 100 (issue #1233 fix 1)
+    // -------------------------------------------------------------------------
+
+    public function testCityAccepts75CharValue(): void
+    {
+        // 75-char value is well within the 100-char cap — must pass through unchanged
+        $city = str_repeat('x', 75);
+        $result = $this->callValidateAndSanitize(['city' => $city]);
+        $this->assertSame($city, $result['city']);
+    }
+
+    public function testCityAccepts100CharValue(): void
+    {
+        // Exactly at the new cap of 100 chars — must pass through unchanged
+        $city = str_repeat('x', 100);
+        $result = $this->callValidateAndSanitize(['city' => $city]);
+        $this->assertSame(100, strlen($result['city']));
+    }
+
+    public function testCityTruncatesAt100Chars(): void
+    {
+        // 101-char value exceeds the cap and must be truncated to exactly 100 chars
+        $city = str_repeat('x', 101);
+        $result = $this->callValidateAndSanitize(['city' => $city]);
+        $this->assertSame(100, strlen($result['city']));
+    }
+
+    // -------------------------------------------------------------------------
+    // validateRequiredFields() '0' acceptance (issue #1233 fix 3)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param array<string, string> $fields
+     * @param list<string>          $required
+     */
+    private function callValidateRequiredFields(array $fields, array $required): void
+    {
+        $owner = new Owner();
+        $method = new \ReflectionMethod($owner, 'validateRequiredFields');
+        $method->invoke($owner, $fields, $required);
+    }
+
+    public function testRequiredFieldAcceptsZeroString(): void
+    {
+        // '0' is a legitimate value — trim((string)'0') === '' is false, so no exception
+        $this->expectNotToPerformAssertions();
+        $this->callValidateRequiredFields(
+            ['fname' => '0', 'lname' => '0', 'email' => 'test@example.com'],
+            ['fname', 'lname', 'email']
+        );
+    }
+
+    public function testRequiredFieldRejectsEmptyString(): void
+    {
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->callValidateRequiredFields(
+            ['fname' => '', 'lname' => 'Smith', 'email' => 'test@example.com'],
+            ['fname', 'lname', 'email']
+        );
+    }
+
+    public function testRequiredFieldRejectsWhitespaceOnly(): void
+    {
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        $this->callValidateRequiredFields(
+            ['fname' => '   ', 'lname' => 'Smith', 'email' => 'test@example.com'],
+            ['fname', 'lname', 'email']
+        );
+    }
 }

--- a/tests/playwright/e2e/not-logged-in.spec.js
+++ b/tests/playwright/e2e/not-logged-in.spec.js
@@ -18,7 +18,7 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
       path: '/app/owner/cars/index.php',
       name: 'List Cars',
       selector: 'h2',
-      expectedText: 'List Cars',
+      expectedText: 'Registry Cars',
     },
     {
       path: '/users/join.php',
@@ -45,22 +45,82 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
       expectedText: 'Elan Factory Information',
     },
     {
-      path: '/docs/reference-library.php',
-      name: 'Reference Library',
-      selector: 'h2',
-      expectedText: 'Reference Library',
+      path: '/docs/',
+      name: 'Docs Index',
+      selector: 'h1',
+      expectedText: 'Documentation',
+    },
+    {
+      path: '/docs/reference/index.php',
+      name: 'Reference Index',
+      selector: 'h1',
+      expectedText: 'Technical Reference',
+    },
+    {
+      path: '/docs/reference/chassis-validation.php',
+      name: 'Chassis Validation',
+      selector: 'h1',
+      expectedText: 'Chassis Validation Rules',
+    },
+    {
+      path: '/docs/reference/paint-colors.php',
+      name: 'Paint Colors',
+      selector: 'h1',
+      expectedText: 'Lotus Elan',
+    },
+    {
+      path: '/docs/reference/technical-articles.php',
+      name: 'Technical Articles',
+      selector: 'h1',
+      expectedText: 'Technical Articles',
+    },
+    {
+      path: '/docs/reference/workshop.php',
+      name: 'Workshop & Parts',
+      selector: 'h1',
+      expectedText: 'Workshop',
     },
     {
       path: '/docs/car-stories.php',
       name: 'Car Stories',
-      selector: 'h2',
+      selector: 'h1',
       expectedText: 'Car Stories',
     },
     {
-      path: '/docs/faq/index.php',
-      name: 'FAQ',
+      path: '/docs/stories/brian_walton/index.php',
+      name: 'Brian Walton Story',
       selector: 'h1',
-      expectedText: 'FAQ & User Guides',
+      expectedText: 'Elan Experimental Rally Car',
+    },
+    {
+      path: '/docs/stories/SGO_2F/index.php',
+      name: 'SGO 2F Story',
+      selector: 'h1',
+      expectedText: 'SGO 2F',
+    },
+    {
+      path: '/docs/stories/type26register.php',
+      name: 'Type 26 Register',
+      selector: 'h2',
+      expectedText: 'type26register.com',
+    },
+    {
+      path: '/docs/guides/index.php',
+      name: 'Owner Guides',
+      selector: 'h1',
+      expectedText: 'Owner Guides',
+    },
+    {
+      path: '/docs/guides/car-transfer-faq.php',
+      name: 'Car Transfer FAQ',
+      selector: 'h1',
+      expectedText: 'Car Transfer FAQ',
+    },
+    {
+      path: '/docs/pdf-viewer.php',
+      name: 'PDF Viewer',
+      selector: 'h1',
+      expectedText: 'Document Viewer',
     },
     {
       path: 'usersc/login.php',
@@ -77,31 +137,23 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
     },
   ];
 
-  pages.forEach(({ path, name, selector, expectedText, isRedirect, expectedRedirectPattern, isLoginPage }) => {
+  pages.forEach(({ path, name, selector, expectedText, isLoginPage }) => {
     test(`should be able to reach ${name} page`, async ({ page }) => {
-      // Navigate to the page
       const response = await page.goto(path);
 
-      // Layer 1: Check that we got a successful response
+      // Layer 1: HTTP response must be successful
       expect(response.status()).toBeLessThan(400);
 
-      // Wait for the page DOM to load (don't wait for all images/resources)
       await page.waitForLoadState('domcontentloaded');
 
-      // Layer 2: CRITICAL - Verify we're NOT on the login page (not redirected to login)
-      // Skip this check for the login page itself, since it should contain login.php in URL
+      // Layer 2: Must not have been redirected to the login page
+      // (skip this check for the login page itself)
       if (!isLoginPage) {
         expect(page.url()).not.toContain('login.php');
       }
 
-      // Layer 3: CRITICAL - Verify actual page content (not just body length)
-      if (isRedirect && expectedRedirectPattern) {
-        // For pages that redirect, verify the redirect URL matches expected pattern
-        expect(page.url()).toMatch(expectedRedirectPattern);
-      }
-
+      // Layer 3: Verify expected page content is present
       if (selector && expectedText) {
-        // Verify the specific content is visible on the page
         await expect(page.locator(selector)).toContainText(expectedText);
       }
 
@@ -118,9 +170,9 @@ test.describe('Internal Links Discovery and Testing (Not Logged In)', () => {
     { path: '/app/owner/reports/statistics.php', name: 'Statistics' },
     { path: '/docs/reference/identification-guide.php', name: 'Identification Guide' },
     { path: '/app/owner/cars/factory.php', name: 'Factory Data' },
-    { path: '/docs/reference-library.php', name: 'Reference Library' },
+    { path: '/docs/reference/index.php', name: 'Reference Index' },
     { path: '/docs/car-stories.php', name: 'Car Stories' },
-    { path: '/docs/faq/index.php', name: 'FAQ' },
+    { path: '/docs/guides/index.php', name: 'Owner Guides' },
     { path: 'usersc/login.php', name: 'Log In' },
     { path: '/users/forgot_password.php', name: 'Forgot Password' },
   ];
@@ -196,8 +248,9 @@ test.describe('Internal Links Discovery and Testing (Not Logged In)', () => {
 
   test('test all unique internal links found across all pages', async ({ page }) => {
     test.setTimeout(120000); // 2 minutes for testing 50+ links on production
-    const allInternalLinks = new Map(); // Changed to Map to track which page each link was found on
-    const publicPageNames = ['Home', 'List Cars', 'Register', 'Statistics', 'Identification Guide', 'Factory Data', 'Reference Library', 'Car Stories', 'FAQ', 'Log In'];
+    const allInternalLinks = new Map();
+    // All discovery pages except Forgot Password count as public pages for warning purposes
+    const publicPageNames = pages.filter(p => p.name !== 'Forgot Password').map(p => p.name);
 
     console.log('\n=== Discovering Internal Links ===');
     for (const { path, name } of pages) {

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -29,9 +29,9 @@ final class CarValidatorTest extends TestCase
 
     public function testValidateRequiredFieldsPassesWithAllPresent(): void
     {
+        $this->expectNotToPerformAssertions();
         $fields = ['chassis' => 'ABC123', 'model' => 'Elan', 'year' => '1970'];
         $this->validator->validateRequiredFields($fields, ['chassis', 'model', 'year']);
-        $this->assertTrue(true); // No exception thrown
     }
 
     public function testValidateRequiredFieldsThrowsOnMissingField(): void
@@ -48,6 +48,14 @@ final class CarValidatorTest extends TestCase
         $this->expectException(CarValidationException::class);
 
         $fields = ['chassis' => '   ', 'model' => 'Elan', 'year' => '1970'];
+        $this->validator->validateRequiredFields($fields, ['chassis', 'model', 'year']);
+    }
+
+    public function testValidateRequiredFieldsAcceptsZeroString(): void
+    {
+        // '0' is a legitimate value — trim((string)'0') !== '', so no exception should be thrown
+        $this->expectNotToPerformAssertions();
+        $fields = ['chassis' => '0', 'model' => 'S4|FHC|36', 'year' => '1970'];
         $this->validator->validateRequiredFields($fields, ['chassis', 'model', 'year']);
     }
 
@@ -434,6 +442,114 @@ final class CarValidatorTest extends TestCase
     }
 
     // ============================================================
+    // default case — empty guard (issue #1233, fix 2)
+    // ============================================================
+
+    /**
+     * Unknown keys with a null value must be dropped from the result (not passed through).
+     */
+    #[Group('unit')]
+    public function testDefaultCaseDropsNullValue(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['unknownKey' => null], false);
+        $this->assertArrayNotHasKey('unknownKey', $result);
+    }
+
+    /**
+     * Unknown keys with an empty-string value must be dropped from the result (not passed through).
+     */
+    #[Group('unit')]
+    public function testDefaultCaseDropsEmptyStringValue(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['unknownKey' => ''], false);
+        $this->assertArrayNotHasKey('unknownKey', $result);
+    }
+
+    /**
+     * Unknown keys with a falsy string value ('0') must pass through — '0' is a legitimate
+     * value that !empty() would silently drop, motivating the !== null && !== '' guard.
+     *
+     * Note: named-field cases (color, engine, model, etc.) intentionally still use !empty()
+     * because '0' is not a meaningful value for any of those domain fields. Tracked in #1262.
+     */
+    #[Group('unit')]
+    public function testDefaultCasePassesThroughZeroString(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['unknownKey' => '0'], false);
+        $this->assertArrayHasKey('unknownKey', $result);
+        $this->assertSame('0', $result['unknownKey']);
+    }
+
+    // ============================================================
+    // chassis — ChassisValidator integration (issue #1233, fix 4)
+    // ============================================================
+
+    /**
+     * When year and model are present and year < 1970, ChassisValidator enforces the
+     * pre-1970 format (exactly 4 numeric digits).  A valid 4-digit numeric chassis must
+     * pass without exception and be stored in the result.
+     *
+     * Uses 'S3|FHC|36' — a combination present in the unit-test mock CarModel — so that
+     * the 'model' key also passes validation within the same call.
+     */
+    #[Group('unit')]
+    public function testChassisValidationUsesChassisValidatorForValidPre1970Chassis(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(
+            ['chassis' => '1234', 'year' => 1965, 'model' => 'S3|FHC|36'],
+            false
+        );
+        $this->assertSame('1234', $result['chassis']);
+    }
+
+    /**
+     * When year and model are present and year < 1970, a non-numeric chassis (e.g. 'ABCD')
+     * fails ChassisValidator's pre-1970 numeric rule (must be exactly 4 digits — letters are
+     * rejected) and must throw CarValidationException with a message beginning
+     * 'Chassis validation failed'.
+     *
+     * Uses 'S3|FHC|36' — a combination present in the unit-test mock CarModel — so that
+     * the 'model' key does not itself trigger a validation error before chassis is checked.
+     */
+    #[Group('unit')]
+    public function testChassisValidationRejectsInvalidPre1970FormatWhenYearModelPresent(): void
+    {
+        $this->expectException(CarValidationException::class);
+        $this->expectExceptionMessage('Chassis validation failed');
+
+        $this->validator->validateAndSanitizeFields(
+            ['chassis' => 'ABCD', 'year' => 1965, 'model' => 'S3|FHC|36'],
+            false
+        );
+    }
+
+    /**
+     * When chassis_override=1 is set and the chassis fails format validation, ChassisValidator
+     * grants the override and CarValidator must not throw.  '12345' is invalid for pre-1970
+     * (must be exactly 4 numeric digits), but the override allows it.
+     */
+    #[Group('unit')]
+    public function testChassisValidationPermitsInvalidChassisWhenOverrideSet(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(
+            ['chassis' => '12345', 'year' => 1965, 'model' => 'S3|FHC|36', 'chassis_override' => '1'],
+            false
+        );
+        $this->assertSame('12345', $result['chassis']);
+    }
+
+    /**
+     * When year and model are absent, ChassisValidator is not invoked.  The fallback
+     * 3-character minimum applies: a 3-character chassis must be accepted and stored.
+     */
+    #[Group('unit')]
+    public function testChassisValidationSkipsChassisValidatorWhenYearAbsent(): void
+    {
+        $result = $this->validator->validateAndSanitizeFields(['chassis' => 'ABC'], false);
+        $this->assertSame('ABC', $result['chassis']);
+    }
+
+    // ============================================================
     // Full positive case: valid inputs return sanitized array
     // ============================================================
 
@@ -444,7 +560,7 @@ final class CarValidatorTest extends TestCase
     public function testValidateAndSanitizeFieldsReturnsFullSanitizedArray(): void
     {
         $fields = [
-            'chassis' => 'ABC123',
+            'chassis' => '1234A', // 1970 legacy 5-char format: 4 numeric digits + Elan suffix 'A' (valid letter code)
             'model' => 'S4|FHC|36', // Valid in mock CarModel
             'year' => '1970',
             'email' => 'owner@example.com',
@@ -460,7 +576,7 @@ final class CarValidatorTest extends TestCase
 
         $result = $this->validator->validateAndSanitizeFields($fields, true);
 
-        $this->assertEquals('ABC123', $result['chassis']);
+        $this->assertEquals('1234A', $result['chassis']);
         $this->assertEquals('S4|FHC|36', $result['model']);
         $this->assertSame(1970, $result['year']);
         $this->assertEquals('owner@example.com', $result['email']);

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -481,72 +481,30 @@ final class CarValidatorTest extends TestCase
     }
 
     // ============================================================
-    // chassis — ChassisValidator integration (issue #1233, fix 4)
+    // chassis — sanitization and minimum-length guard
     // ============================================================
 
     /**
-     * When year and model are present and year < 1970, ChassisValidator enforces the
-     * pre-1970 format (exactly 4 numeric digits).  A valid 4-digit numeric chassis must
-     * pass without exception and be stored in the result.
-     *
-     * Uses 'S3|FHC|36' — a combination present in the unit-test mock CarModel — so that
-     * the 'model' key also passes validation within the same call.
+     * A chassis value at the 3-character minimum must be accepted and stored unchanged.
+     * Format validation (ChassisValidator) is the responsibility of save.php::updateChassis().
      */
     #[Group('unit')]
-    public function testChassisValidationUsesChassisValidatorForValidPre1970Chassis(): void
-    {
-        $result = $this->validator->validateAndSanitizeFields(
-            ['chassis' => '1234', 'year' => 1965, 'model' => 'S3|FHC|36'],
-            false
-        );
-        $this->assertSame('1234', $result['chassis']);
-    }
-
-    /**
-     * When year and model are present and year < 1970, a non-numeric chassis (e.g. 'ABCD')
-     * fails ChassisValidator's pre-1970 numeric rule (must be exactly 4 digits — letters are
-     * rejected) and must throw CarValidationException with a message beginning
-     * 'Chassis validation failed'.
-     *
-     * Uses 'S3|FHC|36' — a combination present in the unit-test mock CarModel — so that
-     * the 'model' key does not itself trigger a validation error before chassis is checked.
-     */
-    #[Group('unit')]
-    public function testChassisValidationRejectsInvalidPre1970FormatWhenYearModelPresent(): void
-    {
-        $this->expectException(CarValidationException::class);
-        $this->expectExceptionMessage('Chassis validation failed');
-
-        $this->validator->validateAndSanitizeFields(
-            ['chassis' => 'ABCD', 'year' => 1965, 'model' => 'S3|FHC|36'],
-            false
-        );
-    }
-
-    /**
-     * When chassis_override=1 is set and the chassis fails format validation, ChassisValidator
-     * grants the override and CarValidator must not throw.  '12345' is invalid for pre-1970
-     * (must be exactly 4 numeric digits), but the override allows it.
-     */
-    #[Group('unit')]
-    public function testChassisValidationPermitsInvalidChassisWhenOverrideSet(): void
-    {
-        $result = $this->validator->validateAndSanitizeFields(
-            ['chassis' => '12345', 'year' => 1965, 'model' => 'S3|FHC|36', 'chassis_override' => '1'],
-            false
-        );
-        $this->assertSame('12345', $result['chassis']);
-    }
-
-    /**
-     * When year and model are absent, ChassisValidator is not invoked.  The fallback
-     * 3-character minimum applies: a 3-character chassis must be accepted and stored.
-     */
-    #[Group('unit')]
-    public function testChassisValidationSkipsChassisValidatorWhenYearAbsent(): void
+    public function testChassisMinimumLengthAccepted(): void
     {
         $result = $this->validator->validateAndSanitizeFields(['chassis' => 'ABC'], false);
         $this->assertSame('ABC', $result['chassis']);
+    }
+
+    /**
+     * A chassis value shorter than 3 characters must throw CarValidationException.
+     */
+    #[Group('unit')]
+    public function testChassisTooShortThrows(): void
+    {
+        $this->expectException(CarValidationException::class);
+        $this->expectExceptionMessage('Chassis number must be at least 3 characters long');
+
+        $this->validator->validateAndSanitizeFields(['chassis' => 'AB'], false);
     }
 
     // ============================================================

--- a/tests/unit/classes/EmailTemplateTest.php
+++ b/tests/unit/classes/EmailTemplateTest.php
@@ -557,7 +557,7 @@ final class EmailTemplateTest extends TestCase
             'to'           => 'Jane Smith',
             'from'         => 'Admin User',
             'message'      => 'Please update your car details.',
-            'carContext'   => ['id' => '123', 'year' => '1972', 'model' => 'Elan S4', 'chassis' => 'CH123456'],
+            'carContext'   => ['id' => '123', 'year' => '1972', 'series' => 'S4', 'variant' => '', 'type' => '', 'chassis' => 'CH123456'],
             'qualityIssue' => 'Missing chassis number',
         ]);
 
@@ -598,7 +598,7 @@ final class EmailTemplateTest extends TestCase
             'to'           => 'Jane Smith',
             'from'         => 'Admin User',
             'message'      => 'Update required.',
-            'carContext'   => ['id' => '99', 'year' => '1971', 'model' => 'Elan Sprint', 'chassis' => 'ABCDEF'],
+            'carContext'   => ['id' => '99', 'year' => '1971', 'series' => 'Sprint', 'variant' => '', 'type' => '', 'chassis' => 'ABCDEF'],
             'qualityIssue' => 'Missing engine number',
         ]);
 
@@ -607,6 +607,23 @@ final class EmailTemplateTest extends TestCase
         $this->assertStringContainsString('Elan Sprint', $html);
         $this->assertStringContainsString('ABCDEF', $html);
         $this->assertStringContainsString('Missing engine number', $html);
+    }
+
+    public function testAdminContactOwnerViewRendersFullVehicleLabelWithVariantAndType(): void
+    {
+        $html = $this->renderView('_admin_to_owner.php', [
+            'to'           => 'Jane Smith',
+            'from'         => 'Admin User',
+            'message'      => 'Update required.',
+            'carContext'   => ['id' => '77', 'year' => '1968', 'series' => '+2', 'variant' => 'FHC', 'type' => '50', 'chassis' => 'GHIJKL'],
+            'qualityIssue' => 'Verify engine specs',
+        ]);
+
+        $this->assertStringContainsString('77', $html);
+        $this->assertStringContainsString('1968', $html);
+        $this->assertStringContainsString('Elan +2 FHC (Type 50)', $html);
+        $this->assertStringContainsString('GHIJKL', $html);
+        $this->assertStringContainsString('Verify engine specs', $html);
     }
 
     public function testAdminContactOwnerViewOmitsCarBoxWhenCarContextEmpty(): void
@@ -661,11 +678,12 @@ final class EmailTemplateTest extends TestCase
             'to'          => 'Alice',
             'from'        => 'Admin Name',
             'message'     => 'Please correct the data.',
-            'carContext'  => ['id' => '99', 'year' => '1971', 'model' => 'Elan S4', 'chassis' => 'ELAN/6/1234'],
+            'carContext'  => ['id' => '99', 'year' => '1971', 'series' => 'S4', 'variant' => '', 'type' => '', 'chassis' => 'ELAN/6/1234'],
             'qualityIssue' => 'Year is incorrect',
         ]);
 
         $this->assertStringContainsString('Update Your Car Record', $html);
+        $this->assertStringContainsString('Elan S4', $html);
     }
 
     public function testAdminContactOwnerViewShowsRegistryLinkWhenNoQualityIssue(): void
@@ -688,7 +706,7 @@ final class EmailTemplateTest extends TestCase
             'to'          => 'Alice',
             'from'        => 'Admin Name',
             'message'     => 'Please fix the data.',
-            'carContext'  => ['id' => '99', 'year' => '1971', 'model' => 'Elan S4', 'chassis' => 'ELAN/6/1234'],
+            'carContext'  => ['id' => '99', 'year' => '1971', 'series' => 'S4', 'variant' => '', 'type' => '', 'chassis' => 'ELAN/6/1234'],
             'qualityIssue' => '<script>alert("xss")</script>',
         ]);
 

--- a/tests/unit/classes/OwnerProfileTest.php
+++ b/tests/unit/classes/OwnerProfileTest.php
@@ -335,4 +335,68 @@ final class OwnerProfileTest extends TestCase
             $this->owner->validateProfileCompleteness()
         );
     }
+
+    // -----------------------------------------------------------------------
+    // qualityScoreFromRow() on search-result-shaped rows
+    // Regression guard for issue #1230: process-owner-search.php now calls
+    // qualityScoreFromRow() directly on rows from searchOwners(), which include
+    // extra columns (e.g. id). These tests confirm the scoring is unaffected.
+    // -----------------------------------------------------------------------
+
+    public function testSearchResultShapedRowScoresCorrectly(): void
+    {
+        $row = (object) [
+            'id'      => 42,
+            'fname'   => 'Jim',
+            'lname'   => 'Boone',
+            'email'   => 'jim@example.com',
+            'city'    => 'Portland',
+            'state'   => 'OR',
+            'country' => 'USA',
+            'lat'     => '45.5231',
+            'lon'     => '-122.6765',
+        ];
+
+        // 7/7 = 100.0
+        $this->assertSame(100.0, Owner::qualityScoreFromRow($row));
+    }
+
+    public function testSearchResultShapedRowWithPartialDataScoresCorrectly(): void
+    {
+        $row = (object) [
+            'id'      => 99,
+            'fname'   => 'Jane',
+            'lname'   => 'Smith',
+            'email'   => 'jane@example.com',
+            'city'    => '',
+            'state'   => '',
+            'country' => '',
+            'lat'     => '',
+            'lon'     => '',
+        ];
+
+        // 3 simple fields → round(3/7 * 100, 1) = 42.9
+        $this->assertSame(42.9, Owner::qualityScoreFromRow($row));
+    }
+
+    public function testUnionBranchShapedRowScoresCorrectly(): void
+    {
+        // searchOwners() UNION branch returns an extra `priority` column.
+        // Confirms qualityScoreFromRow() ignores unknown columns.
+        $row = (object) [
+            'id'       => 7,
+            'fname'    => 'Greg',
+            'lname'    => 'Surcouf',
+            'email'    => 'greg@example.com',
+            'city'     => 'London',
+            'state'    => '',
+            'country'  => 'GB',
+            'lat'      => '51.5074',
+            'lon'      => '-0.1278',
+            'priority' => 1,
+        ];
+
+        // 5 simple fields + lat/lon → round(6/7 * 100, 1) = 85.7
+        $this->assertSame(85.7, Owner::qualityScoreFromRow($row));
+    }
 }

--- a/tests/unit/security/ElanRegistryInputTest.php
+++ b/tests/unit/security/ElanRegistryInputTest.php
@@ -400,4 +400,162 @@ final class ElanRegistryInputTest extends TestCase
         $this->assertIsString($result);
         $this->assertSame('1969', $result);
     }
+
+    // -------------------------------------------------------------------------
+    // existsPost() presence checks (issue #867)
+    // -------------------------------------------------------------------------
+
+    /**
+     * existsPost() with no key returns true when $_POST holds any data.
+     *
+     * Mirrors the "did a POST request arrive?" check at the top of form handlers.
+     */
+    #[Group('fast')]
+    public function test_existsPost_returns_true_when_post_is_non_empty(): void
+    {
+        $_POST['x'] = 'value';
+        $this->assertTrue(Input::existsPost());
+    }
+
+    /**
+     * existsPost() with no key returns false when $_POST is empty.
+     */
+    #[Group('fast')]
+    public function test_existsPost_returns_false_when_post_is_empty(): void
+    {
+        $_POST = [];
+        $this->assertFalse(Input::existsPost());
+    }
+
+    /**
+     * existsPost('key') returns true when that key is present in $_POST.
+     */
+    #[Group('fast')]
+    public function test_existsPost_with_key_returns_true_when_key_present(): void
+    {
+        $_POST['x'] = 'value';
+        $this->assertTrue(Input::existsPost('x'));
+    }
+
+    /**
+     * existsPost('key') returns false when that key is absent from $_POST.
+     */
+    #[Group('fast')]
+    public function test_existsPost_with_key_returns_false_when_key_absent(): void
+    {
+        $_POST = [];
+        $this->assertFalse(Input::existsPost('missing'));
+    }
+
+    /**
+     * existsPost('key') returns false when the key is present but its value is null.
+     *
+     * isset() returns false for null values. This differs from the no-key form:
+     * existsPost() (no key) would return true because $_POST is non-empty,
+     * while existsPost('x') returns false because isset($_POST['x']) is false.
+     * PHP HTTP superglobals never hold null in practice, but this documents the invariant.
+     */
+    #[Group('fast')]
+    public function test_existsPost_with_key_returns_false_when_key_is_null(): void
+    {
+        $_POST = ['x' => null];
+        $this->assertFalse(Input::existsPost('x'));
+    }
+
+    // -------------------------------------------------------------------------
+    // existsGet() presence checks (issue #867)
+    // -------------------------------------------------------------------------
+
+    /**
+     * existsGet() with no key returns true when $_GET holds any query params.
+     */
+    #[Group('fast')]
+    public function test_existsGet_returns_true_when_get_is_non_empty(): void
+    {
+        $_GET['x'] = 'value';
+        $this->assertTrue(Input::existsGet());
+    }
+
+    /**
+     * existsGet() with no key returns false when $_GET is empty.
+     */
+    #[Group('fast')]
+    public function test_existsGet_returns_false_when_get_is_empty(): void
+    {
+        $_GET = [];
+        $this->assertFalse(Input::existsGet());
+    }
+
+    /**
+     * existsGet('key') returns true when that key is present in $_GET.
+     */
+    #[Group('fast')]
+    public function test_existsGet_with_key_returns_true_when_key_present(): void
+    {
+        $_GET['x'] = 'value';
+        $this->assertTrue(Input::existsGet('x'));
+    }
+
+    /**
+     * existsGet('key') returns false when that key is absent from $_GET.
+     */
+    #[Group('fast')]
+    public function test_existsGet_with_key_returns_false_when_key_absent(): void
+    {
+        $_GET = [];
+        $this->assertFalse(Input::existsGet('missing'));
+    }
+
+    /**
+     * existsGet('key') returns false when the key is present but its value is null.
+     *
+     * isset() returns false for null values. This differs from the no-key form:
+     * existsGet() (no key) would return true because $_GET is non-empty,
+     * while existsGet('x') returns false because isset($_GET['x']) is false.
+     * PHP HTTP superglobals never hold null in practice, but this documents the invariant.
+     */
+    #[Group('fast')]
+    public function test_existsGet_with_key_returns_false_when_key_is_null(): void
+    {
+        $_GET = ['x' => null];
+        $this->assertFalse(Input::existsGet('x'));
+    }
+
+    // -------------------------------------------------------------------------
+    // get() delegation contract (issue #867)
+    // -------------------------------------------------------------------------
+
+    /**
+     * get() delegates to the upstream \Input::get().
+     *
+     * The unit bootstrap stubs \Input::get() to return the raw superglobal value
+     * (without HTML-encoding — unlike the real upstream, which applies htmlspecialchars()).
+     * This test verifies that ElanRegistry\Input::get() forwards the call through;
+     * it does not assert encoding behaviour, which is a property of the real upstream.
+     */
+    #[Group('fast')]
+    public function test_get_delegates_to_upstream_input_get(): void
+    {
+        $_POST['x'] = "Tom & Jerry's";
+        $result = Input::get('x');
+        $this->assertSame("Tom & Jerry's", (string)$result);
+    }
+
+    // -------------------------------------------------------------------------
+    // raw() trim flag is not a default value (issue #867)
+    // -------------------------------------------------------------------------
+
+    /**
+     * raw()'s second parameter is a trim flag, not a default value.
+     *
+     * Under strict_types=1, passing a non-bool second argument throws a
+     * TypeError. To supply a default, use `Input::raw('field') ?? 'fallback'`.
+     */
+    #[Group('fast')]
+    public function test_raw_second_param_is_trim_flag_not_default(): void
+    {
+        $_POST['x'] = '  hello  ';
+        $this->expectException(\TypeError::class);
+        Input::raw('x', 'fallback');
+    }
 }

--- a/tests/unit/security/ElanRegistryInputTest.php
+++ b/tests/unit/security/ElanRegistryInputTest.php
@@ -462,6 +462,19 @@ final class ElanRegistryInputTest extends TestCase
         $this->assertFalse(Input::existsPost('x'));
     }
 
+    /**
+     * Parity invariant: when $_POST holds a present, non-null key, existsPost() (no key)
+     * and existsPost('key') both return true — confirming the two code paths agree on the
+     * common case even though they use different implementations internally.
+     */
+    #[Group('fast')]
+    public function test_existsPost_no_key_and_key_form_agree_when_key_present(): void
+    {
+        $_POST = ['x' => 'value'];
+        $this->assertTrue(Input::existsPost());
+        $this->assertTrue(Input::existsPost('x'));
+    }
+
     // -------------------------------------------------------------------------
     // existsGet() presence checks (issue #867)
     // -------------------------------------------------------------------------

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ElanRegistry\Car;
 
 use DateTime;
+use ElanRegistry\ChassisValidator;
 use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\InputSanitizer;
 use ElanRegistry\Reference\CarModel;
@@ -29,12 +30,12 @@ class CarValidator
      * @param array<string, mixed> $fields Fields to validate
      * @param array<string> $requiredFields List of required field names
      * @return void
-     * @throws CarValidationException If any required field is missing or empty
+     * @throws CarValidationException If any required field is absent, empty, or whitespace-only
      */
     public function validateRequiredFields(array $fields, array $requiredFields): void
     {
         foreach ($requiredFields as $field) {
-            if (!isset($fields[$field]) || empty(trim((string) $fields[$field]))) {
+            if (!isset($fields[$field]) || trim((string)$fields[$field]) === '') {
                 throw new CarValidationException("Required field '{$field}' is missing or empty");
             }
         }
@@ -57,7 +58,17 @@ class CarValidator
                 case 'chassis':
                     if (!empty($value)) {
                         $validatedFields[$key] = InputSanitizer::normalize($value, 50);
-                        if (strlen($validatedFields[$key]) < 3) {
+                        // Read from raw $fields, not $validatedFields — switch processes in input
+                        // order, so year/model may not yet be in $validatedFields when chassis runs.
+                        $year  = (int)($fields['year'] ?? 0);
+                        $model = (string)($fields['model'] ?? '');
+                        if ($year > 0 && $model !== '') {
+                            $allowOverride = (isset($fields['chassis_override']) && (int)$fields['chassis_override'] === 1);
+                            $result = (new ChassisValidator())->validate($validatedFields[$key], $year, $model, $allowOverride);
+                            if (!$result['valid']) {
+                                throw new CarValidationException('Chassis validation failed: ' . ($result['error_reason'] ?: 'format check failed'));
+                            }
+                        } elseif (strlen($validatedFields[$key]) < 3) {
                             throw new CarValidationException('Chassis number must be at least 3 characters long');
                         }
                     } elseif ($requireAll) {
@@ -217,7 +228,10 @@ class CarValidator
                     break;
 
                 default:
-                    $validatedFields[$key] = $value;
+                    // Explicit check — !empty() would drop legitimate falsy values like '0' or 0
+                    if ($value !== null && $value !== '') {
+                        $validatedFields[$key] = $value;
+                    }
                     break;
             }
         }

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Car;
 
 use DateTime;
-use ElanRegistry\ChassisValidator;
 use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\InputSanitizer;
 use ElanRegistry\Reference\CarModel;
@@ -58,17 +57,7 @@ class CarValidator
                 case 'chassis':
                     if (!empty($value)) {
                         $validatedFields[$key] = InputSanitizer::normalize($value, 50);
-                        // Read from raw $fields, not $validatedFields — switch processes in input
-                        // order, so year/model may not yet be in $validatedFields when chassis runs.
-                        $year  = (int)($fields['year'] ?? 0);
-                        $model = (string)($fields['model'] ?? '');
-                        if ($year > 0 && $model !== '') {
-                            $allowOverride = (isset($fields['chassis_override']) && (int)$fields['chassis_override'] === 1);
-                            $result = (new ChassisValidator())->validate($validatedFields[$key], $year, $model, $allowOverride);
-                            if (!$result['valid']) {
-                                throw new CarValidationException('Chassis validation failed: ' . ($result['error_reason'] ?: 'format check failed'));
-                            }
-                        } elseif (strlen($validatedFields[$key]) < 3) {
+                        if (strlen($validatedFields[$key]) < 3) {
                             throw new CarValidationException('Chassis number must be at least 3 characters long');
                         }
                     } elseif ($requireAll) {

--- a/usersc/classes/Input.php
+++ b/usersc/classes/Input.php
@@ -10,7 +10,7 @@ namespace ElanRegistry;
  * Files that import this class with `use ElanRegistry\Input` can call:
  *   - Input::raw()  — unencoded value for database storage
  *   - Input::get()  — HTML-encoded value (delegates to \Input::get())
- *   - Input::exists() — POST/GET presence check (delegates to \Input::exists())
+ *   - Input::existsPost() / Input::existsGet() — POST/GET presence checks
  *
  * @since v2.23.0
  * @see https://github.com/unibrain1/elanregistry/issues/843
@@ -26,6 +26,9 @@ class Input
      *
      * Use for values that will be stored in the database. Always apply
      * htmlspecialchars() at the HTML output context to prevent XSS.
+     *
+     * The second parameter is a trim flag, NOT a default value. To supply a
+     * default, use `Input::raw('field') ?? 'fallback'`.
      *
      * @param string $item The POST/GET key to retrieve.
      * @param bool   $trim Whether to trim leading/trailing whitespace (default true).
@@ -66,21 +69,34 @@ class Input
     }
 
     /**
-     * Delegates to \Input::exists() — checks whether the named superglobal is non-empty.
+     * Checks whether $_POST is non-empty, or whether a specific key is present in $_POST.
      *
-     * Checks $_POST when $type is 'post', $_GET when $type is 'get'.
+     * With no argument: delegates to \Input::exists('post') — true when $_POST is non-empty.
+     * With a key: uses isset($_POST[$key]) directly, because \Input::exists() has no
+     * key-level API — it only tests superglobal emptiness.
      *
-     * @param string $type 'post' or 'get' (default 'post').
-     * @return bool True when the superglobal is non-empty.
-     * @throws \InvalidArgumentException When $type is not 'post' or 'get'.
+     * @param string $key Optional key to check for. When empty, checks the superglobal itself.
+     * @return bool True when $_POST is non-empty (no key) or contains $key (with key).
+     * @since v2.26.1
      */
-    public static function exists(string $type = 'post'): bool
+    public static function existsPost(string $key = ''): bool
     {
-        if ($type !== 'post' && $type !== 'get') {
-            throw new \InvalidArgumentException(
-                "ElanRegistry\\Input::exists() expects 'post' or 'get', got '{$type}'."
-            );
-        }
-        return \Input::exists($type);
+        return $key !== '' ? isset($_POST[$key]) : \Input::exists('post');
+    }
+
+    /**
+     * Checks whether $_GET is non-empty, or whether a specific key is present in $_GET.
+     *
+     * With no argument: delegates to \Input::exists('get') — true when $_GET is non-empty.
+     * With a key: uses isset($_GET[$key]) directly, because \Input::exists() has no
+     * key-level API — it only tests superglobal emptiness.
+     *
+     * @param string $key Optional key to check for. When empty, checks the superglobal itself.
+     * @return bool True when $_GET is non-empty (no key) or contains $key (with key).
+     * @since v2.26.1
+     */
+    public static function existsGet(string $key = ''): bool
+    {
+        return $key !== '' ? isset($_GET[$key]) : \Input::exists('get');
     }
 }

--- a/usersc/classes/Owner.php
+++ b/usersc/classes/Owner.php
@@ -559,7 +559,7 @@ class Owner
     private function validateRequiredFields(array $fields, array $requiredFields): void
     {
         foreach ($requiredFields as $field) {
-            if (!isset($fields[$field]) || empty(trim($fields[$field]))) {
+            if (!isset($fields[$field]) || trim((string)$fields[$field]) === '') {
                 throw OwnerValidationException::withUserMessage(
                     "Required field '{$field}' is missing or empty",
                     "Required field '{$field}' is missing or empty."
@@ -619,7 +619,7 @@ class Owner
                 case 'state':
                 case 'country':
                     if (!empty($value)) {
-                        $validatedFields[$key] = InputSanitizer::normalize($value, 50);
+                        $validatedFields[$key] = InputSanitizer::normalize($value, 100);
                     }
                     break;
 

--- a/usersc/join.php
+++ b/usersc/join.php
@@ -80,8 +80,8 @@ if ($act == 1 || $settings->no_passwords == 1) {
     $pre = 1;
 }
 
-if (Input::exists()) {
-    $token = $_POST['csrf'];
+if (Input::existsPost()) {
+    $token = Input::get('csrf');
     if (!Token::check($token)) {
         include $abs_us_root.$us_url_root.'usersc/scripts/token_error.php';
     }

--- a/usersc/plugins/ai_prompts/custom_prompts/elanregistry_overrides.md.php
+++ b/usersc/plugins/ai_prompts/custom_prompts/elanregistry_overrides.md.php
@@ -39,6 +39,29 @@ escaping (the UserSpice convention). For anything going to the database, always 
 
 See `docs/development/CODING_STANDARDS.md` — Input Handling and Output Encoding.
 
+### POST/GET presence checks: `existsPost()` / `existsGet()`
+
+The shipped prompts show `Input::exists('post')` / `Input::exists('get')`. In files that
+import `ElanRegistry\Input`, use the typed replacements instead:
+
+```php
+// ✅ CORRECT in ElanRegistry files
+use ElanRegistry\Input;
+
+if (Input::existsPost()) { ... }          // "did a POST request arrive?"
+if (Input::existsGet()) { ... }           // "are there any query params?"
+
+// Key-specific form (isset check on the specific key):
+if (Input::existsPost('csrf')) { ... }    // "is 'csrf' present in $_POST?"
+
+// ❌ WRONG in files with `use ElanRegistry\Input` — calls removed ElanRegistry method
+if (Input::exists('post')) { ... }
+```
+
+`\Input::exists('post')` (the UserSpice upstream) still works in files that do **not**
+import `ElanRegistry\Input`, but any file using the ElanRegistry wrapper must call
+`existsPost()` / `existsGet()` — the `exists()` method was removed from the wrapper in v2.26.1.
+
 ---
 
 ## 2. Server variables: use validated globals, not `$_SERVER` directly


### PR DESCRIPTION
## Summary

Patch release fixing validation edge cases, admin email rendering, and input-class type safety, with expanded e2e smoke coverage for the docs portal.

## Issues Resolved

Closes #867 — refactor: Input class — type-safe existsPost()/existsGet() (PR #1264)
Closes #1230 — fix: N+1 query in owner search (PR #1258)
Closes #1233 — fix: validator alignment — city length caps, default case guard, required-field check, chassis routing (PR #1261)
Closes #1236 — fix: admin contact email renders human-readable car model (PR #1259)
Closes #1252 — test: fix stale e2e paths and add smoke tests for docs portal pages (PR #1265)
Closes #1260 — refactor: remove redundant ChassisValidator call from CarValidator

## Release Notes

See `docs/releases/RELEASE_NOTES_v2.26.1.md` for complete release notes.

## Test Plan

- [x] All 5 issue PRs reviewed and merged into milestone branch
- [x] Pre-commit hooks pass on all changed files
- [x] Unit tests pass — 1111 tests, 4270 assertions (`composer test:quick`)
- [x] Integration tests pass (`composer test:medium`)
- [x] E2E smoke tests pass — 29 tests against elanregistry.org (`npm run test:e2e`)
- [x] Cross-PR security review completed — no cross-integration findings
- [x] Release notes corrected (removed 5 prior-milestone issues carried over in draft)
- [ ] Manual verification of key user flows post-deploy
- [ ] `npm run test:e2e:test` against test.elanregistry.org after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9C2L2Eu6TwxSoZFP7JWca