### PR TITLE
fix: correct cars.year to SMALLINT and drop unused ModifiedBy column

### DIFF
--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -46,8 +46,8 @@ try {
     if (strlen($chassis) > 15) {
         ApiResponse::error('Chassis number must be 15 characters or less', 400)->send();
     }
-    if (strlen($year) > 4) {
-        ApiResponse::error('Year must be 4 characters or less', 400)->send();
+    if (!ctype_digit((string) $year) || (int) $year < 1963 || (int) $year > 1974) {
+        ApiResponse::error('Year must be between 1963 and 1974', 400)->send();
     }
     if (strlen($model) > 30) {
         ApiResponse::error('Model must be 30 characters or less', 400)->send();

--- a/app/api/cars/transfer-request.php
+++ b/app/api/cars/transfer-request.php
@@ -45,12 +45,16 @@ try {
     $engine = trim(Input::raw('engine') ?? '');
     $comments = trim(Input::raw('comments') ?? '');
 
-    // Validate input lengths against DB column widths
+    if (empty($chassis) || empty($year) || empty($model)) {
+        throw new CarTransferException('Chassis, year, and model are required');
+    }
+
+    // Validate input lengths/ranges against DB column widths and domain constraints
     if (strlen($chassis) > 15) {
         throw new CarTransferException('Chassis number must be 15 characters or less');
     }
-    if (strlen($year) > 4) {
-        throw new CarTransferException('Year must be 4 characters or less');
+    if (!ctype_digit((string) $year) || (int) $year < 1963 || (int) $year > 1974) {
+        throw new CarTransferException('Year must be between 1963 and 1974');
     }
     if (strlen($color) > 25) {
         throw new CarTransferException('Color must be 25 characters or less');
@@ -60,10 +64,6 @@ try {
     }
     if (strlen($comments) > 1000) {
         throw new CarTransferException('Transfer explanation must be 1000 characters or less');
-    }
-
-    if (empty($chassis) || empty($year) || empty($model)) {
-        throw new CarTransferException('Chassis, year, and model are required');
     }
 
     // Parse model to get series, variant, type

--- a/database/1-schema.sql
+++ b/database/1-schema.sql
@@ -98,11 +98,10 @@ CREATE TABLE `cars` (
   `mtime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `vericode` varchar(32) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `last_verified` timestamp NULL DEFAULT NULL,
-  `ModifiedBy` varchar(30) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `model` varchar(30) COLLATE utf8mb4_unicode_ci NOT NULL,
   `series` varchar(12) COLLATE utf8mb4_unicode_ci NOT NULL,
   `variant` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `year` varchar(4) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `year` smallint UNSIGNED DEFAULT NULL,
   `type` char(3) COLLATE utf8mb4_unicode_ci NOT NULL,
   `chassis` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL,
   `chassis_override` TINYINT(1) NOT NULL DEFAULT 0,
@@ -134,11 +133,10 @@ CREATE TABLE `cars_hist` (
   `car_id` int(11) UNSIGNED NOT NULL,
   `ctime` timestamp NULL DEFAULT NULL,
   `mtime` timestamp NULL DEFAULT NULL,
-  `ModifiedBy` varchar(30) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `model` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
   `series` varchar(12) COLLATE utf8mb4_unicode_ci NOT NULL,
   `variant` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `year` varchar(4) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `year` smallint UNSIGNED DEFAULT NULL,
   `type` char(3) COLLATE utf8mb4_unicode_ci NOT NULL,
   `chassis` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL,
   `chassis_override` TINYINT(1) NOT NULL DEFAULT 0,
@@ -352,13 +350,13 @@ ALTER TABLE `car_transfer_requests`
 DELIMITER $$
 CREATE TRIGGER `cars_delete` AFTER DELETE ON `cars` FOR EACH ROW BEGIN
     INSERT INTO cars_hist(
-        operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+        operation, car_id, ctime, mtime, model, series, variant,
         year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
         image, user_id, email, fname, lname, join_date, city, state, country,
         lat, lon, website
     )
     VALUES (
-        'DELETE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
+        'DELETE', OLD.id, OLD.ctime, OLD.mtime, OLD.model,
         OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.chassis_override,
         OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
         OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
@@ -373,13 +371,13 @@ DELIMITER ;
 DELIMITER $$
 CREATE TRIGGER `cars_insert` AFTER INSERT ON `cars` FOR EACH ROW BEGIN
     INSERT INTO cars_hist(
-        operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+        operation, car_id, ctime, mtime, model, series, variant,
         year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
         image, user_id, email, fname, lname, join_date, city, state, country,
         lat, lon, website
     )
     VALUES (
-        'INSERT', NEW.id, NEW.ctime, NEW.mtime, NEW.ModifiedBy, NEW.model,
+        'INSERT', NEW.id, NEW.ctime, NEW.mtime, NEW.model,
         NEW.series, NEW.variant, NEW.year, NEW.type, NEW.chassis, NEW.chassis_override,
         NEW.color, NEW.engine, NEW.purchasedate, NEW.solddate, NEW.comments, NEW.image,
         NEW.user_id, NEW.email, NEW.fname, NEW.lname, NEW.join_date, NEW.city,
@@ -395,13 +393,13 @@ DELIMITER $$
 CREATE TRIGGER `cars_update` AFTER UPDATE ON `cars` FOR EACH ROW BEGIN
     IF @disable_triggers IS NULL THEN
         INSERT INTO cars_hist(
-            operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+            operation, car_id, ctime, mtime, model, series, variant,
             year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
             image, user_id, email, fname, lname, join_date, city, state, country,
             lat, lon, website
         )
         VALUES (
-            'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
+            'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.model,
             OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, NEW.chassis_override, -- NEW: records when flag is SET, not the pre-update value
             OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
             OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,

--- a/database/migrations/20260710120000_change_cars_year_and_drop_modifiedby.php
+++ b/database/migrations/20260710120000_change_cars_year_and_drop_modifiedby.php
@@ -34,23 +34,27 @@ final class ChangeCarsYearAndDropModifiedby extends AbstractMigration
 
         $trustFunctionCreatorsSet = $this->enableTrustFunctionCreators();
 
-        // Make cars_hist.year nullable and normalize empty-string sentinel values before
-        // changing the type to SMALLINT UNSIGNED — only needed if the column is still
-        // VARCHAR (i.e., a previous run did not complete this step).
-        $histYearInfo = $this->fetchRow(
-            "SELECT COLUMN_TYPE, IS_NULLABLE
-             FROM information_schema.COLUMNS
-             WHERE TABLE_SCHEMA = DATABASE()
-               AND TABLE_NAME = 'cars_hist'
-               AND COLUMN_NAME = 'year'"
-        );
-        if ($histYearInfo && stripos((string) $histYearInfo['COLUMN_TYPE'], 'varchar') !== false) {
-            if ($histYearInfo['IS_NULLABLE'] === 'NO') {
-                // Make nullable first so we can UPDATE rows to NULL.
-                $this->execute("ALTER TABLE cars_hist MODIFY COLUMN year varchar(4) NULL");
+        // Normalize each table's year column before the type change.
+        // Under NO_ENGINE_SUBSTITUTION, ALTER TABLE MODIFY COLUMN silently coerces
+        // empty strings to 0 rather than NULL — so we must clear sentinels first.
+        // Both tables need the same treatment even though only cars_hist had known
+        // empty-string rows in production; cars.year was NOT NULL so it needs to be
+        // made nullable before the UPDATE can set rows to NULL.
+        foreach (['cars', 'cars_hist'] as $tbl) {
+            $info = $this->fetchRow(
+                "SELECT COLUMN_TYPE, IS_NULLABLE
+                 FROM information_schema.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE()
+                   AND TABLE_NAME = '{$tbl}'
+                   AND COLUMN_NAME = 'year'"
+            );
+            if ($info && stripos((string) $info['COLUMN_TYPE'], 'varchar') !== false) {
+                if ($info['IS_NULLABLE'] === 'NO') {
+                    // Make nullable first so the UPDATE can SET year = NULL.
+                    $this->execute("ALTER TABLE `{$tbl}` MODIFY COLUMN year varchar(4) NULL");
+                }
+                $this->execute("UPDATE `{$tbl}` SET year = NULL WHERE year = '' OR year = '0'");
             }
-            // Normalize legacy sentinel values — empty strings can't cast to SMALLINT UNSIGNED.
-            $this->execute("UPDATE cars_hist SET year = NULL WHERE year = '' OR year = '0'");
         }
 
         // Change year to SMALLINT UNSIGNED NULL on cars and cars_hist — skip whichever

--- a/database/migrations/20260710120000_change_cars_year_and_drop_modifiedby.php
+++ b/database/migrations/20260710120000_change_cars_year_and_drop_modifiedby.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class ChangeCarsYearAndDropModifiedby extends AbstractMigration
+{
+    // up() + down() are used instead of change() because Phinx cannot auto-reverse
+    // a changeColumn() that alters type, and the ModifiedBy column carries no
+    // functional data — dropping it is a one-way schema simplification that we
+    // want to be able to reverse structurally (down() re-adds a nullable column
+    // but does not restore historical ModifiedBy values). The trigger rebuilds
+    // are also not auto-reversible.
+    //
+    // Every DDL step is guarded by an existence/type check so the migration is
+    // idempotent and safe to re-run if a previous attempt was interrupted before
+    // the phinxlog entry was committed.
+    public function up(): void
+    {
+        // Drop triggers first — MySQL will refuse to DROP a column referenced by
+        // a trigger body, so the triggers must go before ModifiedBy is removed.
+        // DROP IF EXISTS makes these idempotent.
+        $this->execute('DROP TRIGGER IF EXISTS cars_insert');
+        $this->execute('DROP TRIGGER IF EXISTS cars_update');
+        $this->execute('DROP TRIGGER IF EXISTS cars_delete');
+
+        // cars_hist contains legacy rows with invalid dates (e.g. '1999-06-00') that
+        // predate strict-mode enforcement. MySQL re-validates the whole table on every
+        // ALTER TABLE, so strict mode would reject those rows even though we are only
+        // changing the year column. Disable it for the session so the ALTER proceeds;
+        // strict mode resumes automatically when the connection closes.
+        $this->execute("SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'");
+
+        $trustFunctionCreatorsSet = $this->enableTrustFunctionCreators();
+
+        // Make cars_hist.year nullable and normalize empty-string sentinel values before
+        // changing the type to SMALLINT UNSIGNED — only needed if the column is still
+        // VARCHAR (i.e., a previous run did not complete this step).
+        $histYearInfo = $this->fetchRow(
+            "SELECT COLUMN_TYPE, IS_NULLABLE
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = 'cars_hist'
+               AND COLUMN_NAME = 'year'"
+        );
+        if ($histYearInfo && stripos((string) $histYearInfo['COLUMN_TYPE'], 'varchar') !== false) {
+            if ($histYearInfo['IS_NULLABLE'] === 'NO') {
+                // Make nullable first so we can UPDATE rows to NULL.
+                $this->execute("ALTER TABLE cars_hist MODIFY COLUMN year varchar(4) NULL");
+            }
+            // Normalize legacy sentinel values — empty strings can't cast to SMALLINT UNSIGNED.
+            $this->execute("UPDATE cars_hist SET year = NULL WHERE year = '' OR year = '0'");
+        }
+
+        // Change year to SMALLINT UNSIGNED NULL on cars and cars_hist — skip whichever
+        // table has already been converted (idempotent re-run support).
+        if (stripos((string) $this->columnType('cars', 'year'), 'varchar') !== false) {
+            $this->table('cars')
+                 ->changeColumn('year', 'smallinteger', ['signed' => false, 'null' => true])
+                 ->update();
+        }
+        if (stripos((string) $this->columnType('cars_hist', 'year'), 'varchar') !== false) {
+            $this->table('cars_hist')
+                 ->changeColumn('year', 'smallinteger', ['signed' => false, 'null' => true])
+                 ->update();
+        }
+
+        // Drop ModifiedBy — skip if already removed.
+        if ($this->table('cars')->hasColumn('ModifiedBy')) {
+            $this->table('cars')->removeColumn('ModifiedBy')->update();
+        }
+        if ($this->table('cars_hist')->hasColumn('ModifiedBy')) {
+            $this->table('cars_hist')->removeColumn('ModifiedBy')->update();
+        }
+
+        // Recreate the three cars triggers without any ModifiedBy references.
+        // Preserved verbatim from the pre-migration bodies except for the
+        // removal of ModifiedBy from the column list and VALUES tuple.
+        $this->execute(<<<'SQL'
+CREATE TRIGGER `cars_delete` AFTER DELETE ON `cars` FOR EACH ROW BEGIN
+    INSERT INTO cars_hist(
+        operation, car_id, ctime, mtime, model, series, variant,
+        year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+        image, user_id, email, fname, lname, join_date, city, state, country,
+        lat, lon, website
+    )
+    VALUES (
+        'DELETE', OLD.id, OLD.ctime, OLD.mtime, OLD.model,
+        OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.chassis_override,
+        OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+        OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
+        OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
+    );
+END
+SQL);
+
+        $this->execute(<<<'SQL'
+CREATE TRIGGER `cars_insert` AFTER INSERT ON `cars` FOR EACH ROW BEGIN
+    INSERT INTO cars_hist(
+        operation, car_id, ctime, mtime, model, series, variant,
+        year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+        image, user_id, email, fname, lname, join_date, city, state, country,
+        lat, lon, website
+    )
+    VALUES (
+        'INSERT', NEW.id, NEW.ctime, NEW.mtime, NEW.model,
+        NEW.series, NEW.variant, NEW.year, NEW.type, NEW.chassis, NEW.chassis_override,
+        NEW.color, NEW.engine, NEW.purchasedate, NEW.solddate, NEW.comments, NEW.image,
+        NEW.user_id, NEW.email, NEW.fname, NEW.lname, NEW.join_date, NEW.city,
+        NEW.state, NEW.country, NEW.lat, NEW.lon, NEW.website
+    );
+END
+SQL);
+
+        $this->execute(<<<'SQL'
+CREATE TRIGGER `cars_update` AFTER UPDATE ON `cars` FOR EACH ROW BEGIN
+    IF @disable_triggers IS NULL THEN
+        INSERT INTO cars_hist(
+            operation, car_id, ctime, mtime, model, series, variant,
+            year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+            image, user_id, email, fname, lname, join_date, city, state, country,
+            lat, lon, website
+        )
+        VALUES (
+            'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.model,
+            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, NEW.chassis_override,
+            OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+            OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
+            OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
+        );
+    END IF;
+END
+SQL);
+
+        $this->resetTrustFunctionCreators($trustFunctionCreatorsSet);
+    }
+
+    // down() reverts schema only. Rows in cars_hist whose year was normalized
+    // from '' or '0' to NULL in up() are restored to '' (empty string) — the
+    // distinction between '' and '0' is lost. The column reverts to NOT NULL varchar(4)
+    // so those rows need a non-NULL value.
+    public function down(): void
+    {
+        // Same legacy-date and trigger-privilege setup as up().
+        $this->execute("SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'");
+        $trustFunctionCreatorsSet = $this->enableTrustFunctionCreators();
+
+        // Drop the ModifiedBy-less triggers before restoring the column.
+        $this->execute('DROP TRIGGER IF EXISTS cars_insert');
+        $this->execute('DROP TRIGGER IF EXISTS cars_update');
+        $this->execute('DROP TRIGGER IF EXISTS cars_delete');
+
+        // Re-add ModifiedBy on both tables — skip if already present (idempotent).
+        // Values cannot be recovered — the column comes back nullable with NULL.
+        if (!$this->table('cars')->hasColumn('ModifiedBy')) {
+            $this->table('cars')
+                 ->addColumn('ModifiedBy', 'string', [
+                     'limit' => 30,
+                     'null'  => true,
+                     'after' => 'last_verified',
+                 ])
+                 ->update();
+        }
+        if (!$this->table('cars_hist')->hasColumn('ModifiedBy')) {
+            $this->table('cars_hist')
+                 ->addColumn('ModifiedBy', 'string', [
+                     'limit' => 30,
+                     'null'  => true,
+                     'after' => 'mtime',
+                 ])
+                 ->update();
+        }
+
+        // Revert year back to varchar(4) NOT NULL on both tables — skip if already reverted.
+        // NULL values must be replaced with '' before the NOT NULL revert, because
+        // up() may have normalized '' to NULL and the original column was NOT NULL.
+        // The distinction between '' and '0' that existed before up() cannot be recovered.
+        if (stripos((string) $this->columnType('cars', 'year'), 'smallint') !== false) {
+            $this->execute("UPDATE cars SET year = '' WHERE year IS NULL");
+            $this->table('cars')
+                 ->changeColumn('year', 'string', ['limit' => 4, 'null' => false, 'default' => ''])
+                 ->update();
+        }
+
+        if (stripos((string) $this->columnType('cars_hist', 'year'), 'smallint') !== false) {
+            $this->execute("UPDATE cars_hist SET year = '' WHERE year IS NULL");
+            $this->table('cars_hist')
+                 ->changeColumn('year', 'string', ['limit' => 4, 'null' => false, 'default' => ''])
+                 ->update();
+        }
+
+        // Recreate the original triggers with ModifiedBy references (verbatim
+        // from database/1-schema.sql at the time this migration was written).
+        $this->execute(<<<'SQL'
+CREATE TRIGGER `cars_delete` AFTER DELETE ON `cars` FOR EACH ROW BEGIN
+    INSERT INTO cars_hist(
+        operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+        year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+        image, user_id, email, fname, lname, join_date, city, state, country,
+        lat, lon, website
+    )
+    VALUES (
+        'DELETE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
+        OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, OLD.chassis_override,
+        OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+        OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
+        OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
+    );
+END
+SQL);
+
+        $this->execute(<<<'SQL'
+CREATE TRIGGER `cars_insert` AFTER INSERT ON `cars` FOR EACH ROW BEGIN
+    INSERT INTO cars_hist(
+        operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+        year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+        image, user_id, email, fname, lname, join_date, city, state, country,
+        lat, lon, website
+    )
+    VALUES (
+        'INSERT', NEW.id, NEW.ctime, NEW.mtime, NEW.ModifiedBy, NEW.model,
+        NEW.series, NEW.variant, NEW.year, NEW.type, NEW.chassis, NEW.chassis_override,
+        NEW.color, NEW.engine, NEW.purchasedate, NEW.solddate, NEW.comments, NEW.image,
+        NEW.user_id, NEW.email, NEW.fname, NEW.lname, NEW.join_date, NEW.city,
+        NEW.state, NEW.country, NEW.lat, NEW.lon, NEW.website
+    );
+END
+SQL);
+
+        $this->execute(<<<'SQL'
+CREATE TRIGGER `cars_update` AFTER UPDATE ON `cars` FOR EACH ROW BEGIN
+    IF @disable_triggers IS NULL THEN
+        INSERT INTO cars_hist(
+            operation, car_id, ctime, mtime, ModifiedBy, model, series, variant,
+            year, type, chassis, chassis_override, color, engine, purchasedate, solddate, comments,
+            image, user_id, email, fname, lname, join_date, city, state, country,
+            lat, lon, website
+        )
+        VALUES (
+            'UPDATE', OLD.id, OLD.ctime, OLD.mtime, OLD.ModifiedBy, OLD.model,
+            OLD.series, OLD.variant, OLD.year, OLD.type, OLD.chassis, NEW.chassis_override,
+            OLD.color, OLD.engine, OLD.purchasedate, OLD.solddate, OLD.comments, OLD.image,
+            OLD.user_id, OLD.email, OLD.fname, OLD.lname, OLD.join_date, OLD.city,
+            OLD.state, OLD.country, OLD.lat, OLD.lon, OLD.website
+        );
+    END IF;
+END
+SQL);
+
+        $this->resetTrustFunctionCreators($trustFunctionCreatorsSet);
+    }
+
+    /**
+     * CREATE TRIGGER requires either SUPER privilege or log_bin_trust_function_creators=1
+     * when binary logging is enabled. Attempt to set it globally; if the migration user
+     * lacks SUPER/SYSTEM_VARIABLES_ADMIN, continue anyway — the variable may already be
+     * set globally (common on managed hosting panels), otherwise the DBA must set it in
+     * MySQL config (log_bin_trust_function_creators=1 in my.cnf).
+     *
+     * @return bool True if this call set the variable (and so should reset it afterward).
+     */
+    private function enableTrustFunctionCreators(): bool
+    {
+        try {
+            $this->execute("SET GLOBAL log_bin_trust_function_creators = 1");
+            return true;
+        } catch (\RuntimeException $e) {
+            // Privilege denied — the variable may already be set globally (common on managed
+            // hosting). If the subsequent CREATE TRIGGER calls fail with a privilege error,
+            // the DBA must add log_bin_trust_function_creators=1 to my.cnf.
+            if (isset($this->output)) {
+                $this->output->writeln(
+                    '<comment>Warning: Could not SET GLOBAL log_bin_trust_function_creators=1 '
+                    . '— continuing. If CREATE TRIGGER fails below, set this variable in my.cnf.</comment>'
+                );
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Resets log_bin_trust_function_creators if this migration run set it — limits the
+     * window of elevated trust to only the trigger creation steps.
+     */
+    private function resetTrustFunctionCreators(bool $wasSet): void
+    {
+        if (!$wasSet) {
+            return;
+        }
+        try {
+            $this->execute("SET GLOBAL log_bin_trust_function_creators = 0");
+        } catch (\Exception $e) {
+            // Non-fatal — DBA can reset manually; triggers are already created/recreated.
+        }
+    }
+
+    /**
+     * Returns the MySQL COLUMN_TYPE (e.g. "varchar(4)", "smallint(5) unsigned") for the
+     * given table/column, or null if the column does not exist.
+     */
+    private function columnType(string $table, string $column): ?string
+    {
+        // $table/$column are always hardcoded literals from call sites in this migration,
+        // never user input — Phinx's fetchRow() does not support parameter binding.
+        $row = $this->fetchRow(sprintf(
+            "SELECT COLUMN_TYPE FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = '%s'
+               AND COLUMN_NAME = '%s'",
+            $table,
+            $column
+        ));
+
+        return $row ? (string) $row['COLUMN_TYPE'] : null;
+    }
+}

--- a/docs/development/DATABASE.md
+++ b/docs/development/DATABASE.md
@@ -62,11 +62,10 @@
 | `ctime`, `mtime` | `timestamp` | Creation and modification times |
 | `vericode` | `varchar(32)` | Verification code |
 | `last_verified` | `timestamp` | Last verification date |
-| `ModifiedBy` | `varchar(30)` | User who last modified the record |
 | `model` | `varchar(30)` | Car model (Elan) |
 | `series` | `varchar(12)` | Car series (S1, S2, S3, S4, +2, Sprint) |
 | `variant` | `varchar(15)` | Car variant |
-| `year` | `varchar(4)` | Manufacturing year |
+| `year` | `SMALLINT UNSIGNED NULL` | Manufacturing year (1963–1974) |
 | `type` | `char(3)` | Vehicle type code |
 | `chassis` | `varchar(15)` | Chassis number (INDEXED) |
 | `chassis_override` | `TINYINT(1) NOT NULL DEFAULT 0` | Flag indicating whether chassis validation was overridden by the user. Set to `1` when validation was overridden; `0` for normal/valid chassis. |
@@ -93,7 +92,7 @@ automatically synchronized from user profiles when user data changes.
 | `operation` | `varchar(32)` | Operation type (INSERT/UPDATE/DELETE) |
 | `car_id` | `int UNSIGNED` | Original car ID |
 | `timestamp` | `timestamp` | Change timestamp |
-| *(All car columns)* | | Mirror of `cars` table structure including `chassis_override` |
+| *(All car columns)* | | Mirror of `cars` table structure including `chassis_override`. `year` is `SMALLINT UNSIGNED NULL` to match cars. |
 
 #### `car_user` - Car sharing relationships
 
@@ -275,7 +274,7 @@ by the Phinx migration
 
 ### Data Access Patterns
 
-**Note**: This database no longer uses views. All data access is performed through direct queries or the application layer using the `getUserWithProfile()` function for combined user and profile data.
+**Note**: This database no longer uses views. All data access is performed through direct queries or the application layer. For combined user and profile data, use `(new Owner($userId))->data()` — `getUserWithProfile()` was removed in v2.26.2 (#1148).
 
 ## System Features
 

--- a/tests/integration/CarActionsTest.php
+++ b/tests/integration/CarActionsTest.php
@@ -40,7 +40,7 @@ final class CarActionsTest extends IntegrationTestCase
             'message' => 'Car added successfully',
             'cardetails' => [
                 'id' => 1,
-                'year' => '1968',
+                'year' => 1968,
                 'model' => 'S4|SE|DHC',
                 'chassis' => '36/7001',
             ]
@@ -81,7 +81,7 @@ final class CarActionsTest extends IntegrationTestCase
             'message' => 'Car updated successfully',
             'cardetails' => [
                 'id' => 1,
-                'year' => '1968',
+                'year' => 1968,
                 'model' => 'S4|SE|DHC',
                 'chassis' => '36/7001',
             ]

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -178,7 +178,7 @@ abstract class IntegrationTestCase extends TestCase
 
         $defaults = [
             'user_id' => $userId,
-            'year' => '1973',
+            'year' => 1973,
             'model' => 'Elan S4',
             'series' => 'S4',
             'variant' => 'SE',

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -117,7 +117,7 @@ class StatisticsApiTest extends IntegrationTestCase
         // Verify production by year data
         $results = $this->db->query(
             "SELECT year, COUNT(*) as count FROM cars
-             WHERE year IS NOT NULL AND year != ''
+             WHERE year IS NOT NULL
              GROUP BY year ORDER BY year"
         )->results();
         $this->assertNotEmpty($results, "Should have production year data");
@@ -162,7 +162,7 @@ class StatisticsApiTest extends IntegrationTestCase
         // Verify color by year data
         $results = $this->db->query(
             "SELECT color, year, COUNT(*) as count FROM cars
-             WHERE color IS NOT NULL AND color != '' AND year IS NOT NULL AND year != ''
+             WHERE color IS NOT NULL AND color != '' AND year IS NOT NULL
              GROUP BY color, year"
         )->results();
         // May be empty but query should work
@@ -199,7 +199,7 @@ class StatisticsApiTest extends IntegrationTestCase
         $result = $this->db->query(
             "SELECT
                 COUNT(*) as total_cars,
-                COUNT(CASE WHEN year IS NOT NULL AND year != '' THEN 1 END) as cars_with_year,
+                COUNT(CASE WHEN year IS NOT NULL THEN 1 END) as cars_with_year,
                 COUNT(CASE WHEN type IS NOT NULL AND type != '' THEN 1 END) as cars_with_type,
                 COUNT(CASE WHEN series IS NOT NULL AND series != '' THEN 1 END) as cars_with_series,
                 COUNT(CASE WHEN color IS NOT NULL AND color != '' THEN 1 END) as cars_with_color

--- a/tests/integration/database/CarsYearSmallintMigrationTest.php
+++ b/tests/integration/database/CarsYearSmallintMigrationTest.php
@@ -1,0 +1,522 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../IntegrationTestCase.php';
+
+use ElanRegistry\Car\Car;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration tests for migration 20260710120000_change_cars_year_and_drop_modifiedby
+ *
+ * Verifies the post-migration state of:
+ * - cars.year and cars_hist.year changed from varchar(4) NOT NULL to SMALLINT UNSIGNED NULL
+ * - ModifiedBy column removed from both cars and cars_hist
+ * - All three cars triggers (cars_insert, cars_update, cars_delete) rebuilt without ModifiedBy
+ * - Trigger INSERT/UPDATE/DELETE behaviour including the @disable_triggers guard on cars_update
+ *
+ * These are schema-level integration tests: they query information_schema to verify
+ * column types and trigger definitions, and exercise the triggers via real DML.
+ */
+#[Group('integration')]
+#[Group('migration')]
+final class CarsYearSmallintMigrationTest extends IntegrationTestCase
+{
+    private int $testUserId = 1;
+
+    /** Car IDs created by individual tests that need early cleanup (e.g. DELETE tests). */
+    private array $localCarIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireDatabase();
+
+        // Verify the migration has been applied by checking that cars.year is SMALLINT.
+        // If the column is still VARCHAR the migration has not run — skip the suite rather
+        // than failing with misleading assertion errors.
+        $yearType = $this->db->query(
+            "SELECT COLUMN_TYPE
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME   = 'cars'
+               AND COLUMN_NAME  = 'year'
+             LIMIT 1"
+        )->first();
+
+        if (!$yearType || stripos((string) $yearType->COLUMN_TYPE, 'smallint') === false) {
+            $this->markTestSkipped(
+                'Migration 20260710120000 has not been applied — cars.year is not SMALLINT UNSIGNED. ' .
+                'Run: composer migrate'
+            );
+        }
+
+        // Mirror the authenticated-user context required by Car::update() / Car::delete().
+        global $user;
+        $user = new User();
+        $user->find($this->testUserId);
+
+        $reflection     = new ReflectionClass($user);
+        $isLoggedInProp = $reflection->getProperty('_isLoggedIn');
+        $isLoggedInProp->setValue($user, true);
+
+        $GLOBALS['user'] = $user;
+
+        $this->localCarIds = [];
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up any cars that were deleted mid-test (so IntegrationTestCase's tearDown
+        // doesn't try to DELETE them again, which would be a no-op but could hide bugs).
+        foreach ($this->localCarIds as $carId) {
+            $this->untrackCarId($carId);
+        }
+
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Schema checks
+    // -------------------------------------------------------------------------
+
+    /**
+     * cars.year must be smallint unsigned nullable after the migration.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_schema_carsYear_isSmallintUnsignedNullable(): void
+    {
+        $row = $this->db->query(
+            "SELECT COLUMN_TYPE, IS_NULLABLE
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME   = 'cars'
+               AND COLUMN_NAME  = 'year'
+             LIMIT 1"
+        )->first();
+
+        $this->assertNotNull($row, 'Column cars.year must exist');
+        $this->assertStringContainsStringIgnoringCase(
+            'smallint',
+            (string) $row->COLUMN_TYPE,
+            'cars.year must be SMALLINT after migration'
+        );
+        $this->assertStringContainsStringIgnoringCase(
+            'unsigned',
+            (string) $row->COLUMN_TYPE,
+            'cars.year must be UNSIGNED after migration'
+        );
+        $this->assertSame(
+            'YES',
+            $row->IS_NULLABLE,
+            'cars.year must be nullable after migration'
+        );
+    }
+
+    /**
+     * cars_hist.year must be smallint unsigned nullable after the migration.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_schema_carsHistYear_isSmallintUnsignedNullable(): void
+    {
+        $row = $this->db->query(
+            "SELECT COLUMN_TYPE, IS_NULLABLE
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME   = 'cars_hist'
+               AND COLUMN_NAME  = 'year'
+             LIMIT 1"
+        )->first();
+
+        $this->assertNotNull($row, 'Column cars_hist.year must exist');
+        $this->assertStringContainsStringIgnoringCase(
+            'smallint',
+            (string) $row->COLUMN_TYPE,
+            'cars_hist.year must be SMALLINT after migration'
+        );
+        $this->assertStringContainsStringIgnoringCase(
+            'unsigned',
+            (string) $row->COLUMN_TYPE,
+            'cars_hist.year must be UNSIGNED after migration'
+        );
+        $this->assertSame(
+            'YES',
+            $row->IS_NULLABLE,
+            'cars_hist.year must be nullable after migration'
+        );
+    }
+
+    /**
+     * The ModifiedBy column must not exist on cars after the migration.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_schema_carsModifiedBy_isAbsent(): void
+    {
+        $result = $this->db->query(
+            "SELECT 1
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME   = 'cars'
+               AND COLUMN_NAME  = 'ModifiedBy'
+             LIMIT 1"
+        );
+
+        $this->assertSame(
+            0,
+            $result->count(),
+            'Column cars.ModifiedBy must not exist after migration'
+        );
+    }
+
+    /**
+     * The ModifiedBy column must not exist on cars_hist after the migration.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_schema_carsHistModifiedBy_isAbsent(): void
+    {
+        $result = $this->db->query(
+            "SELECT 1
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME   = 'cars_hist'
+               AND COLUMN_NAME  = 'ModifiedBy'
+             LIMIT 1"
+        );
+
+        $this->assertSame(
+            0,
+            $result->count(),
+            'Column cars_hist.ModifiedBy must not exist after migration'
+        );
+    }
+
+    /**
+     * All three cars triggers must exist after the migration.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_schema_allThreeCarsTriggersExist(): void
+    {
+        $triggers = $this->db->query(
+            "SELECT TRIGGER_NAME
+             FROM information_schema.TRIGGERS
+             WHERE TRIGGER_SCHEMA = DATABASE()
+               AND EVENT_OBJECT_TABLE = 'cars'
+             ORDER BY TRIGGER_NAME"
+        )->results();
+
+        $this->assertNotNull($triggers, 'information_schema.TRIGGERS query must return results');
+
+        $triggerNames = array_map(
+            static fn(object $t): string => $t->TRIGGER_NAME,
+            $triggers
+        );
+
+        $this->assertContains('cars_delete', $triggerNames, 'cars_delete trigger must exist');
+        $this->assertContains('cars_insert', $triggerNames, 'cars_insert trigger must exist');
+        $this->assertContains('cars_update', $triggerNames, 'cars_update trigger must exist');
+    }
+
+    /**
+     * No trigger's ACTION_STATEMENT must reference ModifiedBy.
+     *
+     * The migration rebuilds all three triggers without the ModifiedBy column; any
+     * remaining reference would cause DML errors on cars (since the column was dropped).
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_triggerBodies_containNoModifiedByReferences(): void
+    {
+        $triggers = $this->db->query(
+            "SELECT TRIGGER_NAME, ACTION_STATEMENT
+             FROM information_schema.TRIGGERS
+             WHERE TRIGGER_SCHEMA = DATABASE()
+               AND EVENT_OBJECT_TABLE = 'cars'
+             ORDER BY TRIGGER_NAME"
+        )->results();
+
+        $this->assertNotNull($triggers, 'information_schema.TRIGGERS query must return results');
+        $this->assertNotEmpty($triggers, 'At least one trigger must exist on the cars table');
+
+        foreach ($triggers as $trigger) {
+            $this->assertStringNotContainsStringIgnoringCase(
+                'ModifiedBy',
+                (string) $trigger->ACTION_STATEMENT,
+                "Trigger {$trigger->TRIGGER_NAME} must not reference ModifiedBy after migration"
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Trigger behaviour: INSERT
+    // -------------------------------------------------------------------------
+
+    /**
+     * Inserting a car must produce one cars_hist row with operation='INSERT' and
+     * the correct integer year value. cars_hist must also not have a ModifiedBy column.
+     *
+     * NOTE: createTestCar() purges stale cars_hist rows for new car IDs after the
+     * INSERT (to avoid pollution from recycled AUTO_INCREMENT values). To observe
+     * the INSERT trigger output we must do a direct raw INSERT on the cars table —
+     * the trigger fires synchronously before createTestCar()'s cleanup DELETE.
+     * We track the car ID manually for tearDown cleanup.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_insertTrigger_createsHistRowWithIntegerYear(): void
+    {
+        $chassis = 'MIGT' . substr(uniqid(), -8);
+
+        // Insert directly so we can read cars_hist before any cleanup sweep.
+        $this->db->query(
+            "INSERT INTO cars (year, model, series, variant, type, chassis, mtime, user_id)
+             VALUES (1966, 'Elan S3', 'S3', 'FHC', '36', ?, NOW(), ?)",
+            [$chassis, $this->testUserId]
+        );
+
+        $carId = (int) $this->db->lastId();
+        $this->assertGreaterThan(0, $carId, 'Direct INSERT must return a valid car ID');
+
+        // Register with IntegrationTestCase so tearDown cleans up.
+        $this->trackCarId($carId);
+        $this->db->insert('car_user', ['userid' => $this->testUserId, 'car_id' => $carId]);
+
+        // The cars_insert trigger must have fired and written to cars_hist.
+        $histQuery = $this->db->query(
+            "SELECT operation, year
+             FROM cars_hist
+             WHERE car_id   = ?
+               AND operation = 'INSERT'
+             ORDER BY timestamp DESC
+             LIMIT 1",
+            [$carId]
+        );
+
+        $this->assertGreaterThan(
+            0,
+            $histQuery->count(),
+            'cars_insert trigger must create a cars_hist row with operation=INSERT'
+        );
+
+        $histRow = $histQuery->first();
+        $this->assertSame(
+            'INSERT',
+            $histRow->operation
+        );
+        $this->assertSame(
+            1966,
+            (int) $histRow->year,
+            'cars_hist.year must store the integer year value inserted into cars'
+        );
+
+        // Confirm ModifiedBy is absent from cars_hist at the schema level (once is enough,
+        // but guard it here as a belt-and-suspenders check inside the trigger test).
+        $modifiedByCheck = $this->db->query(
+            "SELECT 1
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME   = 'cars_hist'
+               AND COLUMN_NAME  = 'ModifiedBy'
+             LIMIT 1"
+        );
+
+        $this->assertSame(
+            0,
+            $modifiedByCheck->count(),
+            'cars_hist must not have a ModifiedBy column after migration'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Trigger behaviour: UPDATE
+    // -------------------------------------------------------------------------
+
+    /**
+     * Updating a car's year must produce one cars_hist row with operation='UPDATE'
+     * containing OLD.year (the pre-update value).
+     *
+     * The cars_update trigger is intentionally asymmetric: it captures OLD values
+     * for most columns but uses NEW.chassis_override. This test exercises the year
+     * path only and verifies the OLD-year snapshot in history.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_updateTrigger_capturesOldYearInHistory(): void
+    {
+        // Create a car with a known year so we can assert the OLD value in history.
+        $carId = $this->createTestCar($this->testUserId, ['year' => 1969]);
+
+        $car = new Car($carId);
+        $result = $car->update([
+            'id'    => $carId,
+            'token' => Token::generate(),
+            'year'  => 1970,
+        ]);
+
+        $this->assertTrue($result, 'Car::update() must return true on success');
+
+        $histQuery = $this->db->query(
+            "SELECT year
+             FROM cars_hist
+             WHERE car_id   = ?
+               AND operation = 'UPDATE'
+             ORDER BY timestamp DESC
+             LIMIT 1",
+            [$carId]
+        );
+
+        $this->assertGreaterThan(
+            0,
+            $histQuery->count(),
+            'cars_update trigger must create a cars_hist row with operation=UPDATE'
+        );
+
+        $histRow = $histQuery->first();
+        $this->assertSame(
+            1969,
+            (int) $histRow->year,
+            'cars_hist must capture OLD.year (pre-update value) in the UPDATE trigger row'
+        );
+
+        // Verify the cars row itself has the NEW year.
+        $carsRow = $this->db->query(
+            'SELECT year FROM cars WHERE id = ?',
+            [$carId]
+        )->first();
+
+        $this->assertSame(
+            1970,
+            (int) $carsRow->year,
+            'cars.year must reflect the updated value after Car::update()'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Trigger behaviour: @disable_triggers guard
+    // -------------------------------------------------------------------------
+
+    /**
+     * Wrapping an UPDATE in SET @disable_triggers = 1 / SET @disable_triggers = NULL
+     * must prevent the cars_update trigger from inserting a cars_hist row.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_disableTriggersGuard_suppressesUpdateHistory(): void
+    {
+        $carId = $this->createTestCar($this->testUserId, ['year' => 1971]);
+
+        // Count UPDATE history rows before the guarded DML.
+        $beforeCount = $this->db->query(
+            "SELECT COUNT(*) AS cnt
+             FROM cars_hist
+             WHERE car_id   = ?
+               AND operation = 'UPDATE'",
+            [$carId]
+        )->first()->cnt;
+
+        // Execute a raw UPDATE wrapped in the disable-triggers guard.
+        $this->db->query("SET @disable_triggers = 1");
+        $this->db->query(
+            "UPDATE cars SET year = 1972, mtime = NOW() WHERE id = ?",
+            [$carId]
+        );
+        $this->db->query("SET @disable_triggers = NULL");
+
+        $afterCount = $this->db->query(
+            "SELECT COUNT(*) AS cnt
+             FROM cars_hist
+             WHERE car_id   = ?
+               AND operation = 'UPDATE'",
+            [$carId]
+        )->first()->cnt;
+
+        $this->assertSame(
+            (int) $beforeCount,
+            (int) $afterCount,
+            '@disable_triggers guard must prevent the cars_update trigger from firing'
+        );
+
+        // Confirm cars.year was actually changed (i.e. the UPDATE ran, only the trigger was suppressed).
+        $carsRow = $this->db->query(
+            'SELECT year FROM cars WHERE id = ?',
+            [$carId]
+        )->first();
+
+        $this->assertSame(
+            1972,
+            (int) $carsRow->year,
+            'Raw UPDATE must still modify cars.year even when the trigger is disabled'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Trigger behaviour: DELETE
+    // -------------------------------------------------------------------------
+
+    /**
+     * Deleting a car must produce a cars_hist row with operation='DELETE' containing
+     * the car's year at the time of deletion.
+     *
+     * The test deletes via Car::delete() (which also purges car_user and calls the
+     * application layer) and then inspects cars_hist directly.
+     */
+    #[Group('integration')]
+    #[Group('migration')]
+    public function test_deleteTrigger_createsHistRowWithOperation(): void
+    {
+        $carId = $this->createTestCar($this->testUserId, ['year' => 1973]);
+
+        // Track locally so tearDown doesn't try to clean up an already-deleted car.
+        $this->localCarIds[] = $carId;
+
+        $car    = new Car($carId);
+        $result = $car->delete('Migration test deletion', Token::generate());
+
+        $this->assertTrue($result, 'Car::delete() must return true on success');
+
+        // cars row must be gone.
+        $carsResult = $this->db->query(
+            'SELECT id FROM cars WHERE id = ?',
+            [$carId]
+        );
+
+        $this->assertSame(
+            0,
+            $carsResult->count(),
+            'cars row must not exist after Car::delete()'
+        );
+
+        // cars_hist must have a DELETE row from the trigger.
+        $histQuery = $this->db->query(
+            "SELECT operation, year
+             FROM cars_hist
+             WHERE car_id   = ?
+               AND operation = 'DELETE'
+             ORDER BY timestamp DESC
+             LIMIT 1",
+            [$carId]
+        );
+
+        $this->assertGreaterThan(
+            0,
+            $histQuery->count(),
+            'cars_delete trigger must create a cars_hist row with operation=DELETE'
+        );
+
+        $histRow = $histQuery->first();
+        $this->assertSame(
+            'DELETE',
+            $histRow->operation
+        );
+        $this->assertSame(
+            1973,
+            (int) $histRow->year,
+            'cars_hist.year must capture the integer year at the time of deletion'
+        );
+    }
+}

--- a/tests/playwright/length-validation.spec.js
+++ b/tests/playwright/length-validation.spec.js
@@ -65,7 +65,7 @@ test.describe('chassis-availability.php — length validation', () => {
     const baseValid = {
         command: 'chassis_check',
         chassis: '123456789012345', // exactly 15 chars (at limit)
-        year: '1973',               // exactly 4 chars (at limit)
+        year: '1973',               // valid in-range year (1963–1974)
         model: 'S4|SE|FHC',         // 9 chars (under 30-char limit, valid format)
     };
 
@@ -95,29 +95,29 @@ test.describe('chassis-availability.php — length validation', () => {
         expect(body.message).toMatch(/chassis.*15/i);
     });
 
-    test('year exactly 4 chars is accepted (at-limit)', async ({ page }) => {
+    test('year in valid range is accepted (1963–1974)', async ({ page }) => {
         const resp = await page.request.post('app/api/cars/chassis-availability.php', {
             data: { ...baseValid, year: '1973', csrf: csrfToken },
         });
         const body = await resp.json();
         expect(body).toHaveProperty('success');
         if (!body.success) {
-            expect(body.message).not.toMatch(/year.*4/i);
+            expect(body.message).not.toMatch(/year/i);
         }
     });
 
-    test('year 5 chars rejected with 400 (over-limit)', async ({ page }) => {
+    test('year out of range rejected with 400 (1975 > max)', async ({ page }) => {
         const resp = await page.request.post('app/api/cars/chassis-availability.php', {
             data: {
                 ...baseValid,
-                year: '19733', // 5 chars — over limit
+                year: '1975', // above the 1963–1974 domain
                 csrf: csrfToken,
             },
         });
         expect(resp.status()).toBe(400);
         const body = await resp.json();
         expect(body).toHaveProperty('success', false);
-        expect(body.message).toMatch(/year.*4/i);
+        expect(body.message).toMatch(/year.*between/i);
     });
 
     test('model exactly 30 chars is accepted (at-limit)', async ({ page }) => {

--- a/tests/playwright/length-validation.spec.js
+++ b/tests/playwright/length-validation.spec.js
@@ -120,6 +120,20 @@ test.describe('chassis-availability.php — length validation', () => {
         expect(body.message).toMatch(/year.*between/i);
     });
 
+    test('year out of range rejected with 400 (1962 < min)', async ({ page }) => {
+        const resp = await page.request.post('app/api/cars/chassis-availability.php', {
+            data: {
+                ...baseValid,
+                year: '1962', // below the 1963–1974 domain
+                csrf: csrfToken,
+            },
+        });
+        expect(resp.status()).toBe(400);
+        const body = await resp.json();
+        expect(body).toHaveProperty('success', false);
+        expect(body.message).toMatch(/year.*between/i);
+    });
+
     test('model exactly 30 chars is accepted (at-limit)', async ({ page }) => {
         // 26 A's + |B|C = exactly 30 chars, valid 3-part format
         const model30 = 'A'.repeat(26) + '|B|C';
@@ -300,6 +314,24 @@ test.describe('transfer-request.php — length validation', () => {
             data: {
                 ...baseValid,
                 year: '1975', // above the 1963–1974 domain
+                csrf: csrfToken,
+            },
+        });
+        const body = await resp.json();
+        if (body.message && /too many/i.test(body.message)) {
+            test.skip(true, 'Rate limited — skipping; run in a fresh session or wait for the rate-limit window to reset');
+            return;
+        }
+        expect(resp.status()).toBe(400);
+        expect(body).toHaveProperty('success', false);
+        expect(body.message).toMatch(/year.*between/i);
+    });
+
+    test('year out of range rejected with 400 (1962 < min)', async ({ page }) => {
+        const resp = await page.request.post('app/api/cars/transfer-request.php', {
+            data: {
+                ...baseValid,
+                year: '1962', // below the 1963–1974 domain
                 csrf: csrfToken,
             },
         });

--- a/tests/playwright/length-validation.spec.js
+++ b/tests/playwright/length-validation.spec.js
@@ -176,7 +176,7 @@ test.describe('transfer-request.php — length validation', () => {
     // end with "No car found" — but length checks fire before the DB lookup.
     const baseValid = {
         chassis: '123456789012345',             // 15 chars (at limit)
-        year: '1973',                           // 4 chars (at limit)
+        year: '1973',                           // valid in-range year (1963–1974)
         color: '0123456789012345678901234',      // 25 chars (at limit)
         engine: '123456789012345',              // 15 chars (at limit)
         comments: 'A'.repeat(1000),             // 1000 chars (at limit)
@@ -295,11 +295,11 @@ test.describe('transfer-request.php — length validation', () => {
         expect(body.message).toMatch(/chassis.*15/i);
     });
 
-    test('year 5 chars rejected with 400 (over-limit)', async ({ page }) => {
+    test('year out of range rejected with 400 (1975 > max)', async ({ page }) => {
         const resp = await page.request.post('app/api/cars/transfer-request.php', {
             data: {
                 ...baseValid,
-                year: '19733', // 5 chars
+                year: '1975', // above the 1963–1974 domain
                 csrf: csrfToken,
             },
         });
@@ -310,7 +310,7 @@ test.describe('transfer-request.php — length validation', () => {
         }
         expect(resp.status()).toBe(400);
         expect(body).toHaveProperty('success', false);
-        expect(body.message).toMatch(/year.*4/i);
+        expect(body.message).toMatch(/year.*between/i);
     });
 
     test('color 26 chars rejected with 400 (over-limit)', async ({ page }) => {

--- a/tests/unit/cars/CarCrudTest.php
+++ b/tests/unit/cars/CarCrudTest.php
@@ -61,7 +61,7 @@ final class CarCrudTest extends TestCase
         $carData = [
             'token' => Token::generate(),
             'user_id' => $this->testUserId,
-            'year' => '1973',
+            'year' => 1973,
             'model' => 'Elan S4',
             'series' => 'S4',
             'variant' => 'SE',
@@ -77,7 +77,7 @@ final class CarCrudTest extends TestCase
         $result = $car->create($carData);
 
         $this->assertTrue($result);
-        $this->assertEquals('1973', $car->data()->year);
+        $this->assertEquals(1973, (int) $car->data()->year);
         $this->assertEquals('S4', $car->data()->series);
         $this->assertEquals('SE', $car->data()->variant);
         $this->assertEquals('FHC', $car->data()->type);
@@ -101,7 +101,7 @@ final class CarCrudTest extends TestCase
         $carData = [
             'token' => Token::generate(),
             'user_id' => $this->testUserId,
-            'year' => '1973',
+            'year' => 1973,
             'model' => 'Elan',
             'series' => 'S4',
             'variant' => 'SE',
@@ -128,7 +128,7 @@ final class CarCrudTest extends TestCase
         $updateData = [
             'id' => $this->testCarId,
             'token' => Token::generate(),
-            'year' => '1974',
+            'year' => 1974,
             'series' => 'S4',
             'variant' => 'SE',
             'type' => 'DHC',
@@ -145,7 +145,7 @@ final class CarCrudTest extends TestCase
         
         $this->assertTrue($result);
         $this->assertEquals($this->testCarId, $car->data()->id);
-        $this->assertEquals('1974', $car->data()->year);
+        $this->assertEquals(1974, (int) $car->data()->year);
         $this->assertEquals('Blue', $car->data()->color);
         $this->assertEquals('DEF456', $car->data()->engine);
         $this->assertEquals('2021-01-01', $car->data()->purchasedate);
@@ -161,7 +161,7 @@ final class CarCrudTest extends TestCase
         $carData = [
             'token' => Token::generate(),
             'user_id' => $this->testUserId,
-            'year' => '1969',
+            'year' => 1969,
             'model' => 'Elan S2',
             'series' => 'S2',
             'variant' => 'Standard',
@@ -173,7 +173,7 @@ final class CarCrudTest extends TestCase
         $result = $car->create($carData);
         
         $this->assertTrue($result);
-        $this->assertEquals('1969', $car->data()->year);
+        $this->assertEquals(1969, (int) $car->data()->year);
         $this->assertEquals('1234', $car->data()->chassis);
         $this->assertEquals('S2', $car->data()->series);
     }
@@ -187,7 +187,7 @@ final class CarCrudTest extends TestCase
         $carData = [
             'token' => Token::generate(),
             'user_id' => $this->testUserId,
-            'year' => '1969',
+            'year' => 1969,
             'model' => 'Elan S2',
             'series' => 'S2',
             'variant' => 'Race',
@@ -359,7 +359,7 @@ final class CarCrudTest extends TestCase
         $updateData = [
             'id' => $this->testCarId,
             'token' => 'invalid-csrf-token-12345',
-            'year' => '1974',
+            'year' => 1974,
             'color' => 'Blue'
         ];
 
@@ -377,7 +377,7 @@ final class CarCrudTest extends TestCase
         $updateData = [
             'id' => -1,
             'token' => Token::generate(),
-            'year' => '1974',
+            'year' => 1974,
             'color' => 'Blue'
         ];
 
@@ -478,7 +478,7 @@ final class CarCrudTest extends TestCase
         $carData = [
             'token'            => Token::generate(),
             'user_id'          => $this->testUserId,
-            'year'             => '1973',
+            'year'             => 1973,
             'model'            => 'Elan S4',
             'series'           => 'S4',
             'variant'          => 'SE',

--- a/tests/unit/cars/services/CarDataTablesServiceTest.php
+++ b/tests/unit/cars/services/CarDataTablesServiceTest.php
@@ -55,6 +55,12 @@ final class CarDataTablesServiceTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testValidateColumnNameRejectsRemovedModifiedByColumn(): void
+    {
+        $result = $this->service->validateColumnName('ModifiedBy', 'cars');
+        $this->assertFalse($result);
+    }
+
     // ============================================================
     // getDataTablesData tests
     // ============================================================

--- a/usersc/classes/Car/CarDataTablesService.php
+++ b/usersc/classes/Car/CarDataTablesService.php
@@ -30,7 +30,7 @@ class CarDataTablesService
     /** @var array<string, array<string>> Allowed columns per table */
     private const ALLOWED_COLUMNS = [
         'cars' => [
-            'id', 'ctime', 'mtime', 'vericode', 'last_verified', 'ModifiedBy',
+            'id', 'ctime', 'mtime', 'vericode', 'last_verified',
             'model', 'series', 'variant', 'year', 'type', 'chassis', 'color', 'engine',
             'purchasedate', 'solddate', 'comments', 'image', 'user_id', 'email', 'fname',
             'lname', 'join_date', 'city', 'state', 'country', 'lat', 'lon', 'website'

--- a/usersc/classes/StatisticsDataService.php
+++ b/usersc/classes/StatisticsDataService.php
@@ -179,12 +179,12 @@ class StatisticsDataService {
         return $this->executeQuery(
             "SELECT
                 CASE
-                    WHEN year BETWEEN '1963' AND '1967' THEN 'Early Production (1963-1967)'
-                    WHEN year BETWEEN '1968' AND '1974' THEN 'Late Production (1968-1974)'
+                    WHEN year BETWEEN 1963 AND 1967 THEN 'Early Production (1963-1967)'
+                    WHEN year BETWEEN 1968 AND 1974 THEN 'Late Production (1968-1974)'
                 END as period,
                 COUNT(*) as count
              FROM cars
-             WHERE year BETWEEN '1963' AND '1974'
+             WHERE year BETWEEN 1963 AND 1974
              GROUP BY period"
         );
     }
@@ -222,7 +222,7 @@ class StatisticsDataService {
     /**
      * Get map pin data for the world map
      *
-     * @return array<int, object{id: int, year: string, series: string, chassis: string,
+     * @return array<int, object{id: int, year: int|null, series: string, chassis: string,
      *                           variant: string, image: string, city: string, state: string,
      *                           country: string, owner: string, lat: float, lon: float}> Cars with coordinates
      */


### PR DESCRIPTION
## Summary

- **Migration** (`20260710120000`): `cars.year` and `cars_hist.year` changed from `varchar(4) NOT NULL` to `SMALLINT UNSIGNED NULL`; `ModifiedBy` dropped from both tables; all three cars triggers (`cars_insert`, `cars_update`, `cars_delete`) rebuilt without `ModifiedBy` references. Migration is fully idempotent — each DDL step is guarded by an existence/type check via `information_schema`.
- **`database/1-schema.sql`** updated for fresh-install parity (same schema, same triggers).
- **Year validation** in `chassis-availability.php` and `transfer-request.php` upgraded from a loose 4-char length check to a strict numeric range check (`1963–1974`); empty check moved before range check in `transfer-request.php`.
- **`StatisticsDataService`**: `BETWEEN '1963' AND '1974'` string literals corrected to numeric `BETWEEN 1963 AND 1974`.
- **`CarDataTablesService`**: `ModifiedBy` removed from `ALLOWED_COLUMNS` SQL injection allowlist.
- **Tests**: 10 new migration integration tests (`CarsYearSmallintMigrationTest`); year fixtures updated from string to int throughout; Playwright length-validation year tests updated to test range instead of character length.

## Migration notes

- The migration handles legacy `cars_hist.year = ''` rows (normalised to NULL before the type change) and the `1999-06-00` invalid-date rows in `cars_hist.purchasedate` (addressed via `SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'`).
- Requires `log_bin_trust_function_creators=1` to create triggers when binary logging is enabled. The migration attempts `SET GLOBAL` automatically; if the migration user lacks `SUPER/SYSTEM_VARIABLES_ADMIN`, the DBA must pre-set this in `my.cnf`.
- All three environments (dev/test/prod) share the same starting schema. The v2.26.2 auto-deploy hook runs `phinx migrate` on deploy.

## Test plan

- `composer migrate:rollback && composer migrate` — round-trip verified locally
- `composer test:medium` — 1137 unit + 48 integration tests passing, 2 pre-existing skips
- Pre-commit hook: PHPStan clean, phpcs 0 errors

Closes #1161

https://claude.ai/code/session_013nDQ1LjGgFXQ9ARKvJgCva