### PR TITLE
fix: update FK migration for prod — column types, 13 indexes, 3 FKs (#1272)

### DIFF
--- a/database/migrations/20260709202522_add_foreign_key_constraints.php
+++ b/database/migrations/20260709202522_add_foreign_key_constraints.php
@@ -16,7 +16,8 @@ final class AddForeignKeyConstraints extends AbstractMigration
     //
     // This migration was already applied to dev and test before #1272 was filed.
     // The column type fixes, 13 indexes, and 2 additional FK additions below
-    // only execute on prod, which has never had this migration applied.
+    // were absent on prod, which had never had this migration applied at that
+    // point. Phinx runs up() on any environment where the migration is pending.
     public function up(): void
     {
         // Fix column types on car_transfer_requests before adding FK constraints.
@@ -66,6 +67,23 @@ final class AddForeignKeyConstraints extends AbstractMigration
                  'constraint' => 'fk_cars_user_id',
              ])
              ->update();
+
+        // Guard: fk_transfer_created_by and fk_transfer_requested_by CASCADE on
+        // DELETE. If any row references a non-existent user MySQL will reject the
+        // FK addition with an opaque error. Fail early with a clear message so
+        // the operator knows to run the pre-deployment orphan check from the
+        // v2.26.2 release notes before migrating.
+        $orphans = $this->fetchRow(
+            "SELECT COUNT(*) AS n FROM car_transfer_requests
+              WHERE created_by NOT IN (SELECT id FROM users)
+                 OR requested_by_user_id NOT IN (SELECT id FROM users)"
+        );
+        if ((int) $orphans['n'] > 0) {
+            throw new \RuntimeException(
+                "Cannot add FK constraints: {$orphans['n']} orphaned row(s) in car_transfer_requests. " .
+                "Run pre-deployment orphan check from the v2.26.2 release notes before migrating."
+            );
+        }
 
         // Three FKs on car_transfer_requests — fk_transfer_created_by and
         // fk_transfer_requested_by were in 1-schema.sql but missing from the

--- a/database/migrations/20260709202522_add_foreign_key_constraints.php
+++ b/database/migrations/20260709202522_add_foreign_key_constraints.php
@@ -11,15 +11,52 @@ final class AddForeignKeyConstraints extends AbstractMigration
     // directly and reversed via Phinx's dropForeignKey on rollback.
     //
     // up() + down() are used instead of change() because the expires_at fix
-    // (changeColumn) is not auto-reversible by Phinx — and should not be
-    // reversed anyway: '0000-00-00 00:00:00' is invalid in MySQL 8 strict mode.
+    // is not auto-reversible by Phinx — and should not be reversed anyway:
+    // '0000-00-00 00:00:00' is invalid in MySQL 8 strict mode.
+    //
+    // This migration was already applied to dev and test before #1272 was filed.
+    // The column type fixes, 13 indexes, and 2 additional FK additions below
+    // only execute on prod, which has never had this migration applied.
     public function up(): void
     {
-        // car_transfer_requests.expires_at was created with DEFAULT '0000-00-00 00:00:00',
-        // a MySQL 5.x workaround. MySQL 8 strict mode rejects this default on any
-        // ALTER TABLE that touches the table. Fix it before adding the FK.
+        // Fix column types on car_transfer_requests before adding FK constraints.
+        //
+        // On prod: id and existing_car_id are signed INT; MySQL 8.0.16+ enforces
+        // signedness matching on FK columns, so existing_car_id must be UNSIGNED
+        // before fk_transfer_existing_car (existing_car_id → cars.id UNSIGNED) can
+        // be added. id is promoted to UNSIGNED to match dev/test and 1-schema.sql.
+        //
+        // request_date is nullable on prod — NOT NULL aligns with dev/test intent.
+        //
+        // expires_at had DEFAULT '0000-00-00 00:00:00' on prod (MySQL 5.x workaround).
+        // MySQL 8 strict mode rejects that default on any ALTER TABLE touching the
+        // table, so it is fixed in this same statement before any index/FK work.
+        $this->execute(
+            "ALTER TABLE `car_transfer_requests`
+             MODIFY COLUMN `id`               int UNSIGNED NOT NULL AUTO_INCREMENT,
+             MODIFY COLUMN `existing_car_id`  int UNSIGNED NOT NULL,
+             MODIFY COLUMN `request_date`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+             MODIFY COLUMN `expires_at`       timestamp NULL DEFAULT NULL"
+        );
+
+        // Add all 13 non-primary indexes present on dev/test but absent on prod.
+        // Indexes are added before FKs so MySQL can use them for FK enforcement.
+        // The UNIQUE KEY on security_token is the highest operational risk —
+        // without it, duplicate transfer tokens can exist on prod.
         $this->table('car_transfer_requests')
-             ->changeColumn('expires_at', 'timestamp', ['null' => true, 'default' => null])
+             ->addIndex('security_token',                        ['unique' => true, 'name' => 'security_token'])
+             ->addIndex('existing_car_id',                       ['name' => 'existing_car_id'])
+             ->addIndex('requested_by_user_id',                  ['name' => 'requested_by_user_id'])
+             ->addIndex('status',                                ['name' => 'status'])
+             ->addIndex('request_date',                          ['name' => 'request_date'])
+             ->addIndex('expires_at',                            ['name' => 'expires_at'])
+             ->addIndex('submitted_chassis',                     ['name' => 'submitted_chassis'])
+             ->addIndex('submitted_type',                        ['name' => 'submitted_type'])
+             ->addIndex('created_by',                            ['name' => 'fk_transfer_created_by'])
+             ->addIndex(['existing_car_id', 'status'],           ['name' => 'idx_car_pending_transfers'])
+             ->addIndex(['requested_by_user_id', 'status'],      ['name' => 'idx_user_transfer_requests'])
+             ->addIndex(['status', 'expires_at'],                ['name' => 'idx_expired_requests'])
+             ->addIndex(['submitted_type', 'submitted_chassis'],  ['name' => 'idx_submitted_chassis_type'])
              ->update();
 
         $this->table('cars')
@@ -30,26 +67,67 @@ final class AddForeignKeyConstraints extends AbstractMigration
              ])
              ->update();
 
+        // Three FKs on car_transfer_requests — fk_transfer_created_by and
+        // fk_transfer_requested_by were in 1-schema.sql but missing from the
+        // original migration (#1272). Added here so prod matches dev/test.
         $this->table('car_transfer_requests')
              ->addForeignKey('existing_car_id', 'cars', 'id', [
                  'delete'     => 'CASCADE',
                  'update'     => 'NO_ACTION',
                  'constraint' => 'fk_transfer_existing_car',
              ])
+             ->addForeignKey('created_by', 'users', 'id', [
+                 'delete'     => 'CASCADE',
+                 'update'     => 'NO_ACTION',
+                 'constraint' => 'fk_transfer_created_by',
+             ])
+             ->addForeignKey('requested_by_user_id', 'users', 'id', [
+                 'delete'     => 'CASCADE',
+                 'update'     => 'NO_ACTION',
+                 'constraint' => 'fk_transfer_requested_by',
+             ])
              ->update();
     }
 
     public function down(): void
     {
+        // Drop FKs before indexes — MySQL rejects dropping an index that
+        // supports an active FK constraint.
         $this->table('car_transfer_requests')
              ->dropForeignKey('existing_car_id')
+             ->dropForeignKey('created_by')
+             ->dropForeignKey('requested_by_user_id')
              ->update();
 
         $this->table('cars')
              ->dropForeignKey('user_id')
              ->update();
 
+        // Remove all 13 indexes added in up().
+        $this->table('car_transfer_requests')
+             ->removeIndexByName('security_token')
+             ->removeIndexByName('existing_car_id')
+             ->removeIndexByName('requested_by_user_id')
+             ->removeIndexByName('status')
+             ->removeIndexByName('request_date')
+             ->removeIndexByName('expires_at')
+             ->removeIndexByName('submitted_chassis')
+             ->removeIndexByName('submitted_type')
+             ->removeIndexByName('fk_transfer_created_by')
+             ->removeIndexByName('idx_car_pending_transfers')
+             ->removeIndexByName('idx_user_transfer_requests')
+             ->removeIndexByName('idx_expired_requests')
+             ->removeIndexByName('idx_submitted_chassis_type')
+             ->update();
+
+        // Revert column types to pre-migration (prod) state.
         // expires_at is intentionally left as NULL DEFAULT NULL — zero-date
         // defaults are invalid in MySQL 8 strict mode and should not be restored.
+        $this->execute(
+            "ALTER TABLE `car_transfer_requests`
+             MODIFY COLUMN `id`              int NOT NULL AUTO_INCREMENT,
+             MODIFY COLUMN `existing_car_id` int NOT NULL,
+             MODIFY COLUMN `request_date`    timestamp NULL DEFAULT CURRENT_TIMESTAMP"
+        );
     }
 }

--- a/database/migrations/20260709202522_add_foreign_key_constraints.php
+++ b/database/migrations/20260709202522_add_foreign_key_constraints.php
@@ -20,6 +20,28 @@ final class AddForeignKeyConstraints extends AbstractMigration
     // point. Phinx runs up() on any environment where the migration is pending.
     public function up(): void
     {
+        // Guard: check for orphaned rows before any DDL. DDL triggers an implicit
+        // commit in MySQL — if a guard placed after DDL throws, those schema changes
+        // are permanent and a re-run will fail on duplicate indexes/FKs. This SELECT
+        // is read-only, so failure here leaves the schema untouched.
+        //
+        // Covers all three FKs being added to car_transfer_requests:
+        //   fk_transfer_existing_car  → cars.id
+        //   fk_transfer_created_by    → users.id
+        //   fk_transfer_requested_by  → users.id
+        $orphans = $this->fetchRow(
+            "SELECT COUNT(*) AS n FROM car_transfer_requests
+              WHERE existing_car_id NOT IN (SELECT id FROM cars)
+                 OR created_by NOT IN (SELECT id FROM users)
+                 OR requested_by_user_id NOT IN (SELECT id FROM users)"
+        );
+        if ((int) $orphans['n'] > 0) {
+            throw new \RuntimeException(
+                "Cannot add FK constraints: {$orphans['n']} orphaned row(s) in car_transfer_requests. " .
+                "Run pre-deployment orphan check from the v2.26.2 release notes before migrating."
+            );
+        }
+
         // Fix column types on car_transfer_requests before adding FK constraints.
         //
         // On prod: id and existing_car_id are signed INT; MySQL 8.0.16+ enforces
@@ -67,23 +89,6 @@ final class AddForeignKeyConstraints extends AbstractMigration
                  'constraint' => 'fk_cars_user_id',
              ])
              ->update();
-
-        // Guard: fk_transfer_created_by and fk_transfer_requested_by CASCADE on
-        // DELETE. If any row references a non-existent user MySQL will reject the
-        // FK addition with an opaque error. Fail early with a clear message so
-        // the operator knows to run the pre-deployment orphan check from the
-        // v2.26.2 release notes before migrating.
-        $orphans = $this->fetchRow(
-            "SELECT COUNT(*) AS n FROM car_transfer_requests
-              WHERE created_by NOT IN (SELECT id FROM users)
-                 OR requested_by_user_id NOT IN (SELECT id FROM users)"
-        );
-        if ((int) $orphans['n'] > 0) {
-            throw new \RuntimeException(
-                "Cannot add FK constraints: {$orphans['n']} orphaned row(s) in car_transfer_requests. " .
-                "Run pre-deployment orphan check from the v2.26.2 release notes before migrating."
-            );
-        }
 
         // Three FKs on car_transfer_requests — fk_transfer_created_by and
         // fk_transfer_requested_by were in 1-schema.sql but missing from the

--- a/docs/releases/RELEASE_NOTES_v2.26.2.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.2.md
@@ -50,6 +50,7 @@ None — all changes in this release are internal infrastructure and refactoring
 ### Improvements
 
 - **Year sorting** ([#1161](https://github.com/unibrain1/elanregistry/issues/1161)): `cars.year` stored as `SMALLINT` instead of `VARCHAR` — corrects sort order in any admin views that order by year.
+- **Transfer token uniqueness enforced on prod** ([#1272](https://github.com/unibrain1/elanregistry/issues/1272)): Fixes the FK migration so it no longer fails on prod due to column signedness mismatches. Adds `UNIQUE KEY security_token` and 12 other missing indexes, plus two FK constraints (`fk_transfer_created_by`, `fk_transfer_requested_by`) that were in the schema but not the migration.
 
 ## Issues Resolved
 
@@ -62,3 +63,4 @@ None — all changes in this release are internal infrastructure and refactoring
 - [#1247](https://github.com/unibrain1/elanregistry/issues/1247) — refactor: narrow CarRepository::insert() and ::update() to car-specific method signatures *(consolidated into #1168)*
 - [#1169](https://github.com/unibrain1/elanregistry/issues/1169) — refactor: introduce TransferStatus backed enum for car_transfer_requests status values
 - [#1254](https://github.com/unibrain1/elanregistry/issues/1254) — chore: add composer install and phinx migrate to deployment hooks; single self-configuring hook replaces prod/test variants; swap ElanRegistryAutoloader for vendor/autoload.php
+- [#1272](https://github.com/unibrain1/elanregistry/issues/1272) — fix: update AddForeignKeyConstraints migration to handle prod column type mismatches and add 13 missing indexes


### PR DESCRIPTION
## Summary

- Fixes `AddForeignKeyConstraints` migration to run cleanly on prod, where `car_transfer_requests.id` and `existing_car_id` are signed `INT` (MySQL 8.0.16+ rejects the `existing_car_id → cars.id UNSIGNED` FK without signedness alignment)
- Adds all 13 non-primary indexes missing on prod, including `UNIQUE KEY security_token` (highest operational risk — no token uniqueness enforcement on prod until this lands)
- Adds `fk_transfer_created_by` and `fk_transfer_requested_by` FK constraints that were in `1-schema.sql` and on dev/test but missing from the original migration and from prod (required to meet the AC's "3 FK constraints" target)

## What changed

**`database/migrations/20260709202522_add_foreign_key_constraints.php`**

`up()`:
1. Single combined `ALTER TABLE` at the top: promotes `id`/`existing_car_id` to `UNSIGNED`, makes `request_date` `NOT NULL`, clears the zero-date `expires_at` default
2. Adds all 13 non-primary indexes (indexes before FKs so MySQL can use them for constraint enforcement)
3. Adds 3 FKs on `car_transfer_requests` + 1 FK on `cars`

`down()`: drops FKs → drops 13 indexes → reverts column types (correct MySQL ordering)

## Pre-deployment check (run on prod before pushing v2.26.2)

```sql
-- Must return 0 — orphaned rows block FK additions
SELECT COUNT(*) FROM car_transfer_requests WHERE existing_car_id NOT IN (SELECT id FROM cars);
SELECT COUNT(*) FROM car_transfer_requests WHERE created_by NOT IN (SELECT id FROM users) OR requested_by_user_id NOT IN (SELECT id FROM users);
```

## Test plan

- [x] `composer migrate:rollback` + `composer migrate` — clean round-trip on dev
- [x] 48/48 integration tests passing
- [x] Security review — 0 findings
- [ ] Post-deployment: `SHOW CREATE TABLE car_transfer_requests\G` confirms UNSIGNED ids, 13 indexes, 3 FK constraints

Closes #1272

https://claude.ai/code/session_013nDQ1LjGgFXQ9ARKvJgCva