### PR TITLE
chore: migrate logs table from MyISAM to InnoDB (#1273)

### DIFF
--- a/database/migrations/20260710181528_migrate_logs_to_innodb.php
+++ b/database/migrations/20260710181528_migrate_logs_to_innodb.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class MigrateLogsToInnodb extends AbstractMigration
+{
+    // Engine change (MyISAM → InnoDB) requires raw SQL — Phinx's Table API
+    // has no first-class support for altering an existing table's ENGINE.
+    // DDL triggers an implicit commit in MySQL, so the ALTER cannot be
+    // wrapped in a transaction; MyISAM → InnoDB conversion is atomic at the
+    // MySQL level and preserves all rows.
+    //
+    // up() + down() are used instead of change() because raw SQL is not
+    // auto-reversible. The pre-flight row count is captured and re-verified
+    // after the swap so a silent data loss is surfaced immediately.
+    public function up(): void
+    {
+        $before = (int) $this->fetchRow("SELECT COUNT(*) AS n FROM `logs`")['n'];
+
+        $this->execute("ALTER TABLE `logs` ENGINE=InnoDB");
+
+        $after = (int) $this->fetchRow("SELECT COUNT(*) AS n FROM `logs`")['n'];
+        if ($before !== $after) {
+            throw new \RuntimeException(
+                "logs row count changed during engine conversion: {$before} → {$after}. " .
+                "Investigate immediately — MyISAM → InnoDB conversion should preserve all rows."
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        $before = (int) $this->fetchRow("SELECT COUNT(*) AS n FROM `logs`")['n'];
+
+        $this->execute("ALTER TABLE `logs` ENGINE=MyISAM");
+
+        $after = (int) $this->fetchRow("SELECT COUNT(*) AS n FROM `logs`")['n'];
+        if ($before !== $after) {
+            throw new \RuntimeException(
+                "logs row count changed during engine conversion: {$before} → {$after}. " .
+                "Investigate immediately — InnoDB → MyISAM conversion should preserve all rows."
+            );
+        }
+    }
+}

--- a/docs/releases/RELEASE_NOTES_v2.26.2.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.2.md
@@ -51,6 +51,8 @@ None — all changes in this release are internal infrastructure and refactoring
 
 - **Year sorting** ([#1161](https://github.com/unibrain1/elanregistry/issues/1161)): `cars.year` stored as `SMALLINT` instead of `VARCHAR` — corrects sort order in any admin views that order by year.
 - **Transfer token uniqueness enforced on prod** ([#1272](https://github.com/unibrain1/elanregistry/issues/1272)): Fixes the FK migration so it no longer fails on prod due to column signedness mismatches. Adds `UNIQUE KEY security_token` and 12 other missing indexes, plus two FK constraints (`fk_transfer_created_by`, `fk_transfer_requested_by`) that were in the schema but not the migration.
+- **`logs` table crash safety** ([#1273](https://github.com/unibrain1/elanregistry/issues/1273)): Converted the `logs` table from MyISAM to InnoDB on dev and prod (test was already InnoDB). Restores crash recovery, row-level locking, and transaction support for audit log writes.
+- **User deletion car reassignment** ([#1279](https://github.com/unibrain1/elanregistry/issues/1279)): Fixed regression introduced by the v2.26.2 FK migration — `ON DELETE SET NULL` was firing before the hook could reassign cars to noowner, leaving `cars.user_id = NULL`. Also tightened error handling in the deletion hook (catch `\Throwable`, error-check the noowner lookup and profiles DELETE).
 
 ## Issues Resolved
 
@@ -64,3 +66,5 @@ None — all changes in this release are internal infrastructure and refactoring
 - [#1169](https://github.com/unibrain1/elanregistry/issues/1169) — refactor: introduce TransferStatus backed enum for car_transfer_requests status values
 - [#1254](https://github.com/unibrain1/elanregistry/issues/1254) — chore: add composer install and phinx migrate to deployment hooks; single self-configuring hook replaces prod/test variants; swap ElanRegistryAutoloader for vendor/autoload.php
 - [#1272](https://github.com/unibrain1/elanregistry/issues/1272) — fix: update AddForeignKeyConstraints migration to handle prod column type mismatches and add 13 missing indexes
+- [#1273](https://github.com/unibrain1/elanregistry/issues/1273) — chore: migrate logs table from MyISAM to InnoDB on dev and prod
+- [#1279](https://github.com/unibrain1/elanregistry/issues/1279) — bug: fix FK ON DELETE SET NULL regression in after_user_deletion.php; add error checks for noowner query and profiles DELETE; catch \Throwable in transaction


### PR DESCRIPTION
## Summary

- Converts `logs` from MyISAM to InnoDB to restore crash recovery, row-level locking, and transaction support for audit log writes
- Dev and prod were MyISAM; test was already InnoDB — this aligns all three environments
- Uses `up()`/`down()` with raw SQL (`$this->execute`) — Phinx's Table API has no `ENGINE` support
- Pre/post row-count guard raises `RuntimeException` on any silent data loss; round-trip verified on dev (22,094 rows preserved both directions)

## Test plan

- [x] `composer migrate:rollback` — reverts to MyISAM cleanly (verified locally)
- [x] `composer migrate` — re-applies to InnoDB cleanly (verified locally)
- [x] Row count preserved: 22,094 rows in both directions
- [ ] Post-deployment prod smoke: `SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_NAME = 'logs'` → `InnoDB`

Closes #1273

https://claude.ai/code/session_013nDQ1LjGgFXQ9ARKvJgCva