### PR TITLE
chore: migrate fix_script_runs to utf8mb4 and enforce completed_at NOT NULL

### DIFF
--- a/database/1-schema.sql
+++ b/database/1-schema.sql
@@ -85,9 +85,9 @@ CREATE TABLE `car_models` (
 -- -----------------------------------------------------------------------------
 CREATE TABLE `fix_script_runs` (
   `id` int(11) NOT NULL,
-  `script_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `script_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `completed_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- -----------------------------------------------------------------------------
 -- Table: cars (Primary vehicle registry)

--- a/database/migrations/20260710200000_fix_script_runs_charset_and_nullability.php
+++ b/database/migrations/20260710200000_fix_script_runs_charset_and_nullability.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class FixScriptRunsCharsetAndNullability extends AbstractMigration
+{
+    // CONVERT TO CHARACTER SET updates the table default and all text column
+    // charsets in a single DDL statement. DDL triggers an implicit commit in
+    // MySQL and cannot be wrapped in a transaction.
+    //
+    // up() + down() are used instead of change() because raw SQL is not
+    // auto-reversible. Row-count guards verify no data is silently lost during
+    // the charset conversion (utf8mb4 is a superset of utf8mb3, so no row
+    // loss is expected, but a mismatch would indicate a MySQL-level anomaly).
+    public function up(): void
+    {
+        $before = (int) $this->fetchRow("SELECT COUNT(*) AS n FROM `fix_script_runs`")['n'];
+
+        $this->execute(
+            "ALTER TABLE `fix_script_runs`
+             CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+        );
+        $this->execute(
+            "ALTER TABLE `fix_script_runs`
+             MODIFY COLUMN `completed_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        );
+
+        $after = (int) $this->fetchRow("SELECT COUNT(*) AS n FROM `fix_script_runs`")['n'];
+        if ($before !== $after) {
+            throw new \RuntimeException(
+                "fix_script_runs row count changed during charset conversion: {$before} → {$after}. " .
+                "Investigate immediately — utf8mb3 → utf8mb4 conversion should preserve all rows."
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        $before = (int) $this->fetchRow("SELECT COUNT(*) AS n FROM `fix_script_runs`")['n'];
+
+        $this->execute(
+            "ALTER TABLE `fix_script_runs`
+             MODIFY COLUMN `completed_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP"
+        );
+        $this->execute(
+            "ALTER TABLE `fix_script_runs`
+             CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"
+        );
+
+        $after = (int) $this->fetchRow("SELECT COUNT(*) AS n FROM `fix_script_runs`")['n'];
+        if ($before !== $after) {
+            throw new \RuntimeException(
+                "fix_script_runs row count changed during charset reversion: {$before} → {$after}. " .
+                "Investigate immediately — utf8mb4 → utf8mb3 conversion should preserve all rows."
+            );
+        }
+    }
+}

--- a/docs/releases/RELEASE_NOTES_v2.26.2.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.2.md
@@ -53,6 +53,7 @@ None — all changes in this release are internal infrastructure and refactoring
 - **Transfer token uniqueness enforced on prod** ([#1272](https://github.com/unibrain1/elanregistry/issues/1272)): Fixes the FK migration so it no longer fails on prod due to column signedness mismatches. Adds `UNIQUE KEY security_token` and 12 other missing indexes, plus two FK constraints (`fk_transfer_created_by`, `fk_transfer_requested_by`) that were in the schema but not the migration.
 - **`logs` table crash safety** ([#1273](https://github.com/unibrain1/elanregistry/issues/1273)): Converted the `logs` table from MyISAM to InnoDB on dev and prod (test was already InnoDB). Restores crash recovery, row-level locking, and transaction support for audit log writes.
 - **User deletion car reassignment** ([#1279](https://github.com/unibrain1/elanregistry/issues/1279)): Fixed regression introduced by the v2.26.2 FK migration — `ON DELETE SET NULL` was firing before the hook could reassign cars to noowner, leaving `cars.user_id = NULL`. Also tightened error handling in the deletion hook (catch `\Throwable`, error-check the noowner lookup and profiles DELETE).
+- **`fix_script_runs` charset alignment** ([#1274](https://github.com/unibrain1/elanregistry/issues/1274)): Migrated `fix_script_runs` from deprecated `utf8mb3`/`utf8mb3_unicode_ci` to `utf8mb4`/`utf8mb4_unicode_ci` on dev and test (prod already correct). Ensures all environments share a consistent, future-proof charset and `completed_at NOT NULL` nullability.
 
 ## Issues Resolved
 
@@ -68,3 +69,4 @@ None — all changes in this release are internal infrastructure and refactoring
 - [#1272](https://github.com/unibrain1/elanregistry/issues/1272) — fix: update AddForeignKeyConstraints migration to handle prod column type mismatches and add 13 missing indexes
 - [#1273](https://github.com/unibrain1/elanregistry/issues/1273) — chore: migrate logs table from MyISAM to InnoDB on dev and prod
 - [#1279](https://github.com/unibrain1/elanregistry/issues/1279) — bug: fix FK ON DELETE SET NULL regression in after_user_deletion.php; add error checks for noowner query and profiles DELETE; catch \Throwable in transaction
+- [#1274](https://github.com/unibrain1/elanregistry/issues/1274) — chore: migrate fix_script_runs to utf8mb4 charset and enforce completed_at NOT NULL on all environments


### PR DESCRIPTION
## Summary

- Adds a Phinx migration (`20260710200000`) that converts `fix_script_runs` from deprecated `utf8mb3`/`utf8mb3_unicode_ci` to `utf8mb4`/`utf8mb4_unicode_ci` on dev and test (prod already correct)
- Modifies `completed_at` to `NOT NULL DEFAULT CURRENT_TIMESTAMP` on all environments (prod had `NULL`; dev/test already `NOT NULL`)
- Updates `database/1-schema.sql` so fresh installs start with the correct charset
- Includes row-count guards in both `up()` and `down()` to surface any silent data loss

## Test plan

- [x] `composer migrate:dry-run` — picks up migration, prints correct DDL
- [x] `composer migrate` — applied on dev; `SHOW CREATE TABLE` confirms `utf8mb4` and `NOT NULL`
- [x] `composer migrate:rollback` then `composer migrate` — round-trip clean
- [x] `composer test:medium` — 48 integration tests pass

## Post-deployment prod smoke

```sql
SELECT COUNT(*) AS row_count FROM fix_script_runs;
SHOW CREATE TABLE fix_script_runs\G
-- Expect: DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-- Expect: completed_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
```

Closes #1274

https://claude.ai/code/session_013nDQ1LjGgFXQ9ARKvJgCva