### PR TITLE
refactor: introduce TransferStatus backed enum (#1169)

### DIFF
--- a/app/admin/includes/process-transfer-approve.php
+++ b/app/admin/includes/process-transfer-approve.php
@@ -9,6 +9,7 @@ use ElanRegistry\Exceptions\CarTransferException;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Owner;
 use ElanRegistry\Transfer\CarTransferRepository;
+use ElanRegistry\Transfer\TransferStatus;
 use ElanRegistry\Transfer\TransferEmailService;
 
 /**
@@ -66,7 +67,7 @@ try {
     $db->beginTransaction();
 
     // 1. Claim the request atomically — TOCTOU gate
-    if (!$repo->updateStatus((int)$transferId, 'completed', "Approved by admin user {$user->data()->id}")) {
+    if (!$repo->updateStatus((int)$transferId, TransferStatus::Completed, "Approved by admin user {$user->data()->id}")) {
         throw new CarTransferException(
             "updateStatus returned false for transfer #{$transferId} — request already processed (TOCTOU)",
             0,

--- a/app/admin/includes/process-transfer-deny.php
+++ b/app/admin/includes/process-transfer-deny.php
@@ -6,6 +6,7 @@ use ElanRegistry\ApiResponse;
 use ElanRegistry\Exceptions\CarTransferException;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Transfer\CarTransferRepository;
+use ElanRegistry\Transfer\TransferStatus;
 use ElanRegistry\Transfer\TransferEmailService;
 
 /**
@@ -43,8 +44,10 @@ try {
             ->send();
     }
 
-    // Update transfer request status to denied
-    if (!$repo->updateStatus((int)$transferId, 'denied', "Denied by admin user {$user->data()->id}")) {
+    // Update transfer request status to denied.
+    // No transaction needed — this is the only write in the denial flow.
+    // If a second write is added here in future, wrap both in beginTransaction()/rollBack().
+    if (!$repo->updateStatus((int)$transferId, TransferStatus::Denied, "Denied by admin user {$user->data()->id}")) {
         throw new CarTransferException(
             "updateStatus returned false for transfer #{$transferId} — request already processed (TOCTOU)",
             0,

--- a/app/admin/includes/process-transfer-deny.php
+++ b/app/admin/includes/process-transfer-deny.php
@@ -46,7 +46,6 @@ try {
 
     // Update transfer request status to denied.
     // No transaction needed — this is the only write in the denial flow.
-    // If a second write is added here in future, wrap both in beginTransaction()/rollBack().
     if (!$repo->updateStatus((int)$transferId, TransferStatus::Denied, "Denied by admin user {$user->data()->id}")) {
         throw new CarTransferException(
             "updateStatus returned false for transfer #{$transferId} — request already processed (TOCTOU)",

--- a/app/admin/includes/tab-car_mgmt.php
+++ b/app/admin/includes/tab-car_mgmt.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use ElanRegistry\Car\Car;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Transfer\CarTransferRepository;
+use ElanRegistry\Transfer\TransferStatus;
 
 /**
  * tab-car_mgmt.php
@@ -43,9 +44,9 @@ try {
     $transferStats['pending']   = count($pendingTransfers);
 
     foreach ($repo->getTodayStatusCounts() as $stat) {
-        if ($stat->status === 'completed') {
+        if ($stat->status === TransferStatus::Completed->value) {
             $transferStats['completed_today'] = (int)$stat->count;
-        } elseif ($stat->status === 'denied') {
+        } elseif ($stat->status === TransferStatus::Denied->value) {
             $transferStats['denied_today'] = (int)$stat->count;
         }
     }

--- a/docs/releases/RELEASE_NOTES_v2.26.2.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.2.md
@@ -54,6 +54,7 @@ None — all changes in this release are internal infrastructure and refactoring
 - **`logs` table crash safety** ([#1273](https://github.com/unibrain1/elanregistry/issues/1273)): Converted the `logs` table from MyISAM to InnoDB on dev and prod (test was already InnoDB). Restores crash recovery, row-level locking, and transaction support for audit log writes.
 - **User deletion car reassignment** ([#1279](https://github.com/unibrain1/elanregistry/issues/1279)): Fixed regression introduced by the v2.26.2 FK migration — `ON DELETE SET NULL` was firing before the hook could reassign cars to noowner, leaving `cars.user_id = NULL`. Also tightened error handling in the deletion hook (catch `\Throwable`, error-check the noowner lookup and profiles DELETE).
 - **`fix_script_runs` charset alignment** ([#1274](https://github.com/unibrain1/elanregistry/issues/1274)): Migrated `fix_script_runs` from deprecated `utf8mb3`/`utf8mb3_unicode_ci` to `utf8mb4`/`utf8mb4_unicode_ci` on dev and test (prod already correct). Ensures all environments share a consistent, future-proof charset and `completed_at NOT NULL` nullability.
+- **`TransferStatus` backed enum** ([#1169](https://github.com/unibrain1/elanregistry/issues/1169)): Replaced bare-string status constants in `CarTransferRepository` with a PHP 8.1 `TransferStatus` enum. `updateStatus()` now requires a typed `TransferStatus` value — invalid statuses are caught at compile time rather than at runtime. The `isTerminal()` method replaces the `TERMINAL_STATUSES` constant array.
 
 ## Issues Resolved
 

--- a/tests/integration/transfer/CarTransferRepositoryIntegrationTest.php
+++ b/tests/integration/transfer/CarTransferRepositoryIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../IntegrationTestCase.php';
 
 use ElanRegistry\Transfer\CarTransferRepository;
+use ElanRegistry\Transfer\TransferStatus;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -146,7 +147,7 @@ final class CarTransferRepositoryIntegrationTest extends IntegrationTestCase
         $this->assertNotNull($pending, 'findPendingById() must find a pending row');
         $this->assertSame((string) $id, (string) $pending->id);
 
-        $this->assertTrue($this->repo->updateStatus($id, 'denied', 'Test denial'));
+        $this->assertTrue($this->repo->updateStatus($id, TransferStatus::Denied, 'Test denial'));
 
         $this->assertNull(
             $this->repo->findPendingById($id),
@@ -164,7 +165,7 @@ final class CarTransferRepositoryIntegrationTest extends IntegrationTestCase
         $carId       = $this->createTestCar($ownerId);
 
         $id = $this->createTransferRequest($carId, $requesterId);
-        $this->assertTrue($this->repo->updateStatus($id, 'denied', 'Audit note'));
+        $this->assertTrue($this->repo->updateStatus($id, TransferStatus::Denied, 'Audit note'));
 
         $row = $this->db->query(
             "SELECT status, admin_notes FROM car_transfer_requests WHERE id = ?",
@@ -221,7 +222,7 @@ final class CarTransferRepositoryIntegrationTest extends IntegrationTestCase
         $id = $this->createTransferRequest($carId, $requesterId);
         $this->assertTrue($this->repo->hasPendingForCar($carId, $requesterId), 'Precondition: must be pending before status change');
 
-        $this->repo->updateStatus($id, 'denied', 'Test');
+        $this->repo->updateStatus($id, TransferStatus::Denied, 'Test');
 
         $this->assertFalse(
             $this->repo->hasPendingForCar($carId, $requesterId),
@@ -239,7 +240,7 @@ final class CarTransferRepositoryIntegrationTest extends IntegrationTestCase
         $carId       = $this->createTestCar($ownerId);
 
         $id = $this->createTransferRequest($carId, $requesterId);
-        $this->repo->updateStatus($id, 'denied', 'Test denial');
+        $this->repo->updateStatus($id, TransferStatus::Denied, 'Test denial');
 
         $counts = $this->repo->getTodayStatusCounts();
 

--- a/tests/integration/transfer/CarTransferWorkflowTest.php
+++ b/tests/integration/transfer/CarTransferWorkflowTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../IntegrationTestCase.php';
 
+use ElanRegistry\Transfer\TransferStatus;
+
 /**
  * Integration tests for car transfer workflow
  *
@@ -457,7 +459,7 @@ class CarTransferWorkflowTest extends IntegrationTestCase
         // Because the WHERE clause includes AND status = 'pending', no row matches,
         // and the method returns false — the correct TOCTOU signal.
         $repo   = new \ElanRegistry\Transfer\CarTransferRepository($this->db);
-        $result = $repo->updateStatus($requestId, 'completed', 'Second admin');
+        $result = $repo->updateStatus($requestId, TransferStatus::Completed, 'Second admin');
 
         $this->assertFalse($result, 'updateStatus() must return false when the row is already in a terminal status (TOCTOU gate)');
     }
@@ -504,7 +506,7 @@ class CarTransferWorkflowTest extends IntegrationTestCase
         $this->db->beginTransaction();
 
         // Step 1: claim the request (TOCTOU gate succeeds).
-        $claimed = $repo->updateStatus($requestId, 'completed', 'Admin claim');
+        $claimed = $repo->updateStatus($requestId, TransferStatus::Completed, 'Admin claim');
         $this->assertTrue($claimed, 'Precondition: initial claim must succeed');
 
         // Step 2: simulate a failed car transfer by rolling back the outer transaction

--- a/tests/unit/transfer/CarTransferRepositoryTest.php
+++ b/tests/unit/transfer/CarTransferRepositoryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use ElanRegistry\Transfer\CarTransferRepository;
+use ElanRegistry\Transfer\TransferStatus;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -82,7 +83,7 @@ final class CarTransferRepositoryTest extends TestCase
         // Mock query() always returns empty results, so rows-affected = 0.
         // That rows-affected=0 → false path is the correct behavior (no row matched).
         // True/False with real rows is verified by the integration tests.
-        $result = $this->repo->updateStatus($id, 'denied', 'Test denial');
+        $result = $this->repo->updateStatus($id, TransferStatus::Denied, 'Test denial');
         $this->assertIsBool($result);
     }
 
@@ -96,11 +97,5 @@ final class CarTransferRepositoryTest extends TestCase
     {
         $result = $this->repo->getPendingWithCarAndUsers();
         $this->assertIsArray($result);
-    }
-
-    public function testUpdateStatusThrowsOnInvalidStatus(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->repo->updateStatus(1, 'bogus_status', 'Test');
     }
 }

--- a/tests/unit/transfer/TransferStatusTest.php
+++ b/tests/unit/transfer/TransferStatusTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use ElanRegistry\Transfer\TransferStatus;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Unit tests for TransferStatus backed enum.
+ *
+ * Covers isTerminal() for all five cases, including the reserved Approved case
+ * which is non-terminal even though no production code currently transitions to it.
+ */
+#[Group('fast')]
+#[Group('transfer')]
+final class TransferStatusTest extends TestCase
+{
+    public function testPendingIsNotTerminal(): void
+    {
+        $this->assertFalse(TransferStatus::Pending->isTerminal());
+    }
+
+    public function testApprovedIsNotTerminal(): void
+    {
+        $this->assertFalse(TransferStatus::Approved->isTerminal());
+    }
+
+    public function testCompletedIsTerminal(): void
+    {
+        $this->assertTrue(TransferStatus::Completed->isTerminal());
+    }
+
+    public function testDeniedIsTerminal(): void
+    {
+        $this->assertTrue(TransferStatus::Denied->isTerminal());
+    }
+
+    public function testExpiredIsTerminal(): void
+    {
+        $this->assertTrue(TransferStatus::Expired->isTerminal());
+    }
+
+    public function testBackingValuesMatchDatabaseEnumStrings(): void
+    {
+        $this->assertSame('pending',   TransferStatus::Pending->value);
+        $this->assertSame('approved',  TransferStatus::Approved->value);
+        $this->assertSame('completed', TransferStatus::Completed->value);
+        $this->assertSame('denied',    TransferStatus::Denied->value);
+        $this->assertSame('expired',   TransferStatus::Expired->value);
+    }
+}

--- a/usersc/classes/Transfer/CarTransferRepository.php
+++ b/usersc/classes/Transfer/CarTransferRepository.php
@@ -218,6 +218,10 @@ class CarTransferRepository
      * TOCTOU case where another admin processed the request first. Throws on DB error
      * so callers can distinguish "already processed" from "infrastructure failure".
      *
+     * Note: terminal transitions include `AND status = 'pending'` in the WHERE clause
+     * as a TOCTOU guard. Non-terminal transitions (Pending, Approved) do not — callers
+     * are responsible for ensuring the row is in an expected state before calling.
+     *
      * @param int $id Transfer request ID
      * @param TransferStatus $status New status
      * @param string $adminNotes Admin notes to record

--- a/usersc/classes/Transfer/CarTransferRepository.php
+++ b/usersc/classes/Transfer/CarTransferRepository.php
@@ -19,11 +19,6 @@ use ElanRegistry\LogCategories;
  */
 class CarTransferRepository
 {
-    private const VALID_STATUSES = ['pending', 'completed', 'denied', 'expired'];
-
-    /** Terminal statuses that record a completion timestamp. */
-    private const TERMINAL_STATUSES = ['completed', 'denied', 'expired'];
-
     /**
      * Production always receives DB::getInstance(); declared as object so test
      * doubles (which implement query() only) can be injected without a type error.
@@ -216,42 +211,37 @@ class CarTransferRepository
     /**
      * Update the status, admin notes, and completion date of a transfer request.
      *
-     * Terminal statuses (completed, denied, expired) also record completed_date = NOW().
-     * Non-terminal statuses (pending) leave completed_date unchanged.
+     * Terminal statuses (Completed, Denied, Expired) also record completed_date = NOW().
+     * Non-terminal statuses (Pending, Approved) leave completed_date unchanged.
      *
      * Returns false only when the query succeeds but no row was matched — the expected
      * TOCTOU case where another admin processed the request first. Throws on DB error
      * so callers can distinguish "already processed" from "infrastructure failure".
      *
      * @param int $id Transfer request ID
-     * @param string $status New status value
+     * @param TransferStatus $status New status
      * @param string $adminNotes Admin notes to record
-     * @return bool True if exactly one row was updated; false if no row matched (already processed)
-     * @throws \InvalidArgumentException if $status is not one of: pending, completed, denied, expired
+     * @return bool True if one or more rows were updated; false if no row matched (already processed)
      * @throws \RuntimeException on database error
      */
-    public function updateStatus(int $id, string $status, string $adminNotes): bool
+    public function updateStatus(int $id, TransferStatus $status, string $adminNotes): bool
     {
-        if (!in_array($status, self::VALID_STATUSES, true)) {
-            throw new \InvalidArgumentException("Invalid transfer status: '$status'");
-        }
-
-        if (in_array($status, self::TERMINAL_STATUSES, true)) {
+        if ($status->isTerminal()) {
             // AND status = 'pending' is the atomic TOCTOU gate: a second admin's
             // UPDATE will match 0 rows (already terminal) and return false.
             $result = $this->db->query(
                 "UPDATE car_transfer_requests SET status = ?, admin_notes = ?, completed_date = NOW() WHERE id = ? AND status = 'pending'",
-                [$status, $adminNotes, $id]
+                [$status->value, $adminNotes, $id]
             );
         } else {
             $result = $this->db->query(
                 "UPDATE car_transfer_requests SET status = ?, admin_notes = ? WHERE id = ?",
-                [$status, $adminNotes, $id]
+                [$status->value, $adminNotes, $id]
             );
         }
 
         if ($this->db->error()) {
-            logger(0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, "CarTransferRepository::updateStatus failed for id=$id status=$status: " . $this->db->errorString());
+            logger(0, LogCategories::LOG_CATEGORY_DATABASE_ERROR, "CarTransferRepository::updateStatus failed for id=$id status={$status->value}: " . $this->db->errorString());
             throw new \RuntimeException('Database error updating transfer request status');
         }
         return $result->count() > 0;

--- a/usersc/classes/Transfer/TransferStatus.php
+++ b/usersc/classes/Transfer/TransferStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElanRegistry\Transfer;
+
+enum TransferStatus: string
+{
+    case Pending   = 'pending';
+    case Approved  = 'approved'; // Reserved — DB enum includes this; no code transitions to it, but isTerminal() classifies it as non-terminal so future transitions are safe to add
+    case Completed = 'completed';
+    case Denied    = 'denied';
+    case Expired   = 'expired';
+
+    public function isTerminal(): bool
+    {
+        return match($this) {
+            self::Pending, self::Approved             => false,
+            self::Completed, self::Denied, self::Expired => true,
+        };
+    }
+}

--- a/usersc/classes/Transfer/TransferStatus.php
+++ b/usersc/classes/Transfer/TransferStatus.php
@@ -7,7 +7,7 @@ namespace ElanRegistry\Transfer;
 enum TransferStatus: string
 {
     case Pending   = 'pending';
-    case Approved  = 'approved'; // Reserved — DB enum includes this; no code transitions to it, but isTerminal() classifies it as non-terminal so future transitions are safe to add
+    case Approved  = 'approved'; // Included to match DB enum; non-terminal so DB rows with this value are safe to read without ValueError
     case Completed = 'completed';
     case Denied    = 'denied';
     case Expired   = 'expired';


### PR DESCRIPTION
## Summary

- Adds `TransferStatus` PHP 8.1 backed enum (`Pending`, `Approved`, `Completed`, `Denied`, `Expired`) in `ElanRegistry\Transfer` namespace
- `CarTransferRepository::updateStatus()` signature changed from `string $status` to `TransferStatus $status` — invalid statuses now caught at compile time, `\InvalidArgumentException` guard removed
- `isTerminal()` method on enum replaces `TERMINAL_STATUSES` constant array; uses exhaustive `match` arms (no `default`) so adding a future case without updating `isTerminal()` throws `UnhandledMatchError`
- `Approved` case included to match DB schema (`enum('pending','approved','denied','completed','expired')`) even though no code currently transitions to it — prevents `ValueError` if a DB row with that value is ever read
- All callers updated: `process-transfer-approve.php`, `process-transfer-deny.php`, `tab-car_mgmt.php`
- All test files updated; `testUpdateStatusThrowsOnInvalidStatus()` removed (type system now makes it impossible); `TransferStatusTest.php` added to cover all 5 `isTerminal()` cases

## Test plan

- [ ] `composer test:medium` passes (unit + integration)
- [ ] `composer check:php` clean on changed files
- [ ] Manual: approve a pending transfer — car ownership changes, status shows completed
- [ ] Manual: deny a pending transfer — status shows denied, car ownership unchanged

## Pre-push review

- Security review: 0 findings (enum backing value is a compile-time constant, not user-tainted; TOCTOU gate preserved; auth guards intact)
- Code review: clean
- Type design: 8/10 average (exhaustive `match` added based on reviewer feedback)
- Test coverage: `TransferStatusTest.php` added covering all 5 cases including reserved `Approved` non-terminal case

https://claude.ai/code/session_013nDQ1LjGgFXQ9ARKvJgCva