### PR TITLE
security: block dev config files, disable TRACE, add Permissions-Policy (#1242)

### DIFF
--- a/.claude/commands/release-milestone.md
+++ b/.claude/commands/release-milestone.md
@@ -238,14 +238,14 @@ Release:
 Next Steps — Deploy:
 
   1. Deploy to TEST server (recommended first):
-     git push test main
      git push test v<version>
+     git push test main
 
   2. Validate on test server
 
   3. Deploy to PRODUCTION when ready:
-     git push prod main
      git push prod v<version>
+     git push prod main
 
 Links:
 - GitHub Release: <release URL>

--- a/.deployignore
+++ b/.deployignore
@@ -34,6 +34,7 @@ scripts/
 eslint.config.mjs
 phpstan.neon
 phpstan-baseline.neon
+phpstan-bootstrap.php
 .markdownlint.json
 .markdownlintignore
 .semgrepignore

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,6 +21,9 @@ name: Claude Code Review
 #                             accuracy, and deployment readiness.
 #
 # Drafts and [skip-review] / [WIP] titles are skipped in both modes.
+# No paths filter — runs on every file type so config, SQL, and template
+# changes are reviewed alongside PHP/JS. Gating is handled by the job-level
+# if: conditions, not by path filtering.
 #
 # Posting mechanism (v1 action):
 #   Claude must explicitly post via `gh pr comment` — the action does not
@@ -31,16 +34,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, labeled]
-    paths:
-      - "**.php"
-      - "**.js"
-      - "**.css"
-      - "tests/**"
-      - "usersc/**"
-      - "scripts/**"
-      - "docs/development/**"
-      - ".github/workflows/**"
-  # Note: `paths` filter above applies only to pull_request events.
   # issue_comment events are not filtered by paths — the job's `if:`
   # condition and author_association check handle gating.
   issue_comment:

--- a/.htaccess
+++ b/.htaccess
@@ -16,6 +16,7 @@ ErrorDocument 504 /error/500.php
 Header always set X-Frame-Options "SAMEORIGIN"
 Header always set X-Content-Type-Options "nosniff"
 Header always set Referrer-Policy "strict-origin-when-cross-origin"
+Header always set Permissions-Policy "geolocation=(), camera=(), microphone=(), payment=()"
 
 # Deny access to sensitive files
 <Files "*.env*">
@@ -42,11 +43,37 @@ Header always set Referrer-Policy "strict-origin-when-cross-origin"
     Require all denied
 </Files>
 
+<FilesMatch "^phpunit.*\.xml$">
+    Require all denied
+</FilesMatch>
+
+<Files "phpstan.neon">
+    Require all denied
+</Files>
+
+<Files "phpstan-baseline.neon">
+    Require all denied
+</Files>
+
+<Files "phpstan-bootstrap.php">
+    Require all denied
+</Files>
+
+<FilesMatch "^package(-lock)?\.json$">
+    Require all denied
+</FilesMatch>
+
+# Disable HTTP TRACE (XST prevention)
+<LimitExcept GET POST HEAD OPTIONS>
+    Require all denied
+</LimitExcept>
+
 # Block access to sensitive directories using RewriteRule
 RewriteEngine On
 
 # Block access to backup directories
 RewriteRule ^@backup/ - [F,L]
+RewriteRule ^db-backups/ - [F,L]
 
 # Block access to node_modules
 RewriteRule ^node_modules/ - [F,L]

--- a/docs/releases/RELEASE_NOTES_v2.27.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.27.0.md
@@ -17,6 +17,7 @@ None.
 
 ### Improvements
 
+- **Server Hardening** ([#1242](https://github.com/unibrain1/elanregistry/issues/1242)): Blocked web access to PHPUnit config, PHPStan config, and npm manifests; disabled HTTP TRACE; added Permissions-Policy header opting out of geolocation, camera, microphone, and payment APIs.
 - **Backup Authorization** ([#1308](https://github.com/unibrain1/elanregistry/issues/1308)): Backup and restore operations now require Administrator role; editor accounts are explicitly rejected.
 - **Admin Script CSRF Hardening** ([#1308](https://github.com/unibrain1/elanregistry/issues/1308)): Destructive admin maintenance scripts now require POST + CSRF token; the fix-script template has been updated so future scripts inherit this pattern.
 


### PR DESCRIPTION
## Summary

- Adds `Permissions-Policy` header opting out of geolocation, camera, microphone, and payment APIs
- Blocks web access to `phpunit*.xml`, `phpstan.neon`, `phpstan-baseline.neon`, `phpstan-bootstrap.php`, and `package*.json` via `<FilesMatch>`/`<Files>` rules
- Disables HTTP TRACE via `<LimitExcept GET POST HEAD OPTIONS>` to prevent XST attacks
- Blocks `db-backups/` directory (server-generated SQL dumps that persist across deployments)
- Adds `phpstan-bootstrap.php` to `.deployignore` (was the only PHPStan file reaching production — now scrubbed on deploy)
- Fixes `release-milestone` deploy order: push tag before `main`

## Test plan

- [ ] `GET /phpunit.xml` returns 403
- [ ] `GET /phpunit-unit.xml` returns 403
- [ ] `TRACE /` returns 405 or 403
- [ ] `Permissions-Policy` header present on all responses
- [ ] `GET /phpstan-baseline.neon` returns 403
- [ ] `GET /package.json` returns 403
- [ ] Existing GET/POST functionality unaffected

Closes #1242

https://claude.ai/code/session_01FMCNygrZ9jdR2b7H3Nj6cB