### PR TITLE
ci: remove paths filter from Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,16 +31,10 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, labeled]
-    paths:
-      - "**.php"
-      - "**.js"
-      - "**.css"
-      - "tests/**"
-      - "usersc/**"
-      - "scripts/**"
-      - "docs/development/**"
-      - ".github/workflows/**"
-  # Note: `paths` filter above applies only to pull_request events.
+    # No paths filter: workflow-only PRs (e.g. CI config changes) must also
+    # trigger Claude review so the claude-code-action@v1 OIDC token validation
+    # runs against the default-branch workflow file. A paths filter that
+    # excludes .github/workflows/** causes validation to fail on those PRs.
   # issue_comment events are not filtered by paths — the job's `if:`
   # condition and author_association check handle gating.
   issue_comment:


### PR DESCRIPTION
## Summary

- Removes the `paths:` filter from the `pull_request` trigger in `.github/workflows/claude-code-review.yml`
- Adds a comment explaining *why* there is no paths filter

## Why

`claude-code-action@v1` validates that the workflow file on the PR branch matches `main` exactly before it mints an OIDC token. When a PR's only changes are to CI config files (e.g., `.github/workflows/**`) and those files are excluded by the `paths:` filter, the `pull_request` event is never fired on `main`'s copy of the workflow — causing validation to fail with:

```
Warning: Skipping action due to workflow validation: Workflow validation failed...
```

This broke Claude Code Review on every issue PR in milestone/v2.27.0 after the workflow was updated on the milestone branch but before it was merged to main.

## Impact

- Claude Code Review now triggers on all PR types, including CI-only changes
- No application code changes

## Test plan

- [ ] Open a test PR (or re-push existing PR #1330) and verify `Claude Code Review / pr-to-milestone-review` runs successfully without the OIDC validation failure

https://claude.ai/code/session_01FMCNygrZ9jdR2b7H3Nj6cB