### PR TITLE
fix: remove active/permissions from Owner allowlist (#1232)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.27.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.27.0.md
@@ -17,6 +17,7 @@ None.
 
 ### Improvements
 
+- **Owner Privilege Escalation Guard** ([#1232](https://github.com/unibrain1/elanregistry/issues/1232)): Removed `active` and `permissions` from `Owner::extractUserFields()` allowlist; changed the `validateAndSanitizeFields()` default case to drop unknown fields instead of passing them through. Prevents any future endpoint from accidentally writing these privilege-controlling columns via the general profile-update path.
 - **Server Hardening** ([#1242](https://github.com/unibrain1/elanregistry/issues/1242)): Blocked web access to PHPUnit config, PHPStan config, and npm manifests; disabled HTTP TRACE; added Permissions-Policy header opting out of geolocation, camera, microphone, and payment APIs.
 - **CSP Tightening** ([#1326](https://github.com/unibrain1/elanregistry/issues/1326)): Added `form-action 'self'` to the Content Security Policy (closing a form-hijacking gap that `default-src` doesn't cover); removed `unsafe-eval` from `script-src` after verifying no custom JS uses `eval()` or `new Function()`.
 - **Backup Authorization** ([#1308](https://github.com/unibrain1/elanregistry/issues/1308)): Backup and restore operations now require Administrator role; editor accounts are explicitly rejected.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -583,12 +583,6 @@ parameters:
 			path: usersc/account.php
 
 		-
-			message: '#^Function randomstring not found\.$#'
-			identifier: function.notFound
-			count: 1
-			path: usersc/classes/Owner.php
-
-		-
 			message: '#^File ends with a trailing whitespace\. This may cause problems when running the code in the web browser\. Remove the closing \?\> mark or remove the whitespace\.$#'
 			identifier: whitespace.fileEnd
 			count: 1
@@ -718,12 +712,6 @@ parameters:
 			message: '#^Function pluginActive not found\.$#'
 			identifier: function.notFound
 			count: 1
-			path: usersc/join.php
-
-		-
-			message: '#^Function randomstring not found\.$#'
-			identifier: function.notFound
-			count: 2
 			path: usersc/join.php
 
 		-
@@ -1084,12 +1072,6 @@ parameters:
 			message: '#^Function passwordResetKillSessions not found\.$#'
 			identifier: function.notFound
 			count: 1
-			path: usersc/user_settings.php
-
-		-
-			message: '#^Function randomstring not found\.$#'
-			identifier: function.notFound
-			count: 2
 			path: usersc/user_settings.php
 
 		-

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -40,4 +40,12 @@ $user = null;
 /** @var mixed $db */
 $db   = null;
 
+// UserSpice helper functions (defined in users/helpers/us_helpers.php, excluded from scan)
+if (!function_exists('randomstring')) {
+    function randomstring(int $len): string
+    {
+        return '';
+    }
+}
+
 require_once __DIR__ . '/usersc/includes/config.php';

--- a/tests/integration/OwnerIntegrationTest.php
+++ b/tests/integration/OwnerIntegrationTest.php
@@ -378,4 +378,123 @@ class OwnerIntegrationTest extends IntegrationTestCase
             ['fname', 'lname', 'email']
         );
     }
+
+    // -------------------------------------------------------------------------
+    // Privilege-escalation guard (#1232)
+    // active/permissions must never pass through validateAndSanitizeFields or
+    // extractUserFields — they are not profile fields and must not be writable
+    // via the general Owner::update() path.
+    // -------------------------------------------------------------------------
+
+    public function testActiveFieldIsDroppedByValidation(): void
+    {
+        $result = $this->callValidateAndSanitize(['active' => '0']);
+        $this->assertArrayNotHasKey('active', $result,
+            'active must be silently dropped by validateAndSanitizeFields');
+    }
+
+    public function testPermissionsFieldIsDroppedByValidation(): void
+    {
+        $result = $this->callValidateAndSanitize(['permissions' => '3']);
+        $this->assertArrayNotHasKey('permissions', $result,
+            'permissions must be silently dropped by validateAndSanitizeFields');
+    }
+
+    public function testUnknownFieldIsDroppedByValidation(): void
+    {
+        $result = $this->callValidateAndSanitize(['totally_unknown_field' => 'injected']);
+        $this->assertArrayNotHasKey('totally_unknown_field', $result,
+            'Unknown fields must be silently dropped by the default case');
+    }
+
+    public function testActiveAndPermissionsDoNotReachDbViaUpdate(): void
+    {
+        $userId = $this->createTestUser();
+        $this->db->insert('profiles', [
+            'user_id' => $userId,
+            'city' => 'BeforeCity', 'state' => '', 'country' => '',
+            'lat' => 0.0, 'lon' => 0.0,
+        ]);
+        try {
+            $before = $this->db->query("SELECT active, permissions FROM users WHERE id = ?", [$userId])
+                ->first();
+            $csrf = \Token::generate();
+            $owner = new Owner($userId);
+            $owner->update([
+                'id'          => $userId,
+                'csrf'        => $csrf,
+                'active'      => '0',
+                'permissions' => '3',
+                'city'        => 'AfterCity',
+            ]);
+            $after = $this->db->query("SELECT active, permissions FROM users WHERE id = ?", [$userId])
+                ->first();
+            // Confirm the update ran (city changed) so the privilege assertions aren't vacuously true
+            $this->assertSame('AfterCity', $owner->data()->city,
+                'Owner::update() must persist legitimate fields');
+            $this->assertSame((string) $before->active, (string) $after->active,
+                'Owner::update() must not modify the active column');
+            $this->assertSame((string) $before->permissions, (string) $after->permissions,
+                'Owner::update() must not modify the permissions column');
+        } finally {
+            $this->db->query("DELETE FROM profiles WHERE user_id = ?", [$userId]);
+        }
+    }
+
+    public function testActiveEscalationDoesNotReachDbViaUpdate(): void
+    {
+        // Deactivated-user escalation: attacker passes active=1 to re-activate their account
+        $userId = $this->createTestUser();
+        $this->db->query("UPDATE users SET active = 0 WHERE id = ?", [$userId]);
+        $this->db->insert('profiles', [
+            'user_id' => $userId,
+            'city' => 'BeforeCity', 'state' => '', 'country' => '',
+            'lat' => 0.0, 'lon' => 0.0,
+        ]);
+        try {
+            $csrf = \Token::generate();
+            $owner = new Owner($userId);
+            $owner->update([
+                'id'     => $userId,
+                'csrf'   => $csrf,
+                'active' => '1',
+                'city'   => 'AfterCity',
+            ]);
+            $after = $this->db->query("SELECT active FROM users WHERE id = ?", [$userId])->first();
+            $this->assertSame('AfterCity', $owner->data()->city,
+                'Owner::update() must persist legitimate fields');
+            $this->assertSame('0', (string) $after->active,
+                'Owner::update() must not allow escalation of active from 0 to 1');
+        } finally {
+            $this->db->query("DELETE FROM profiles WHERE user_id = ?", [$userId]);
+        }
+    }
+
+    public function testUsernameFieldIsDroppedByValidation(): void
+    {
+        $result = $this->callValidateAndSanitize(['username' => 'hacker']);
+        $this->assertArrayNotHasKey('username', $result,
+            'username must be silently dropped by validateAndSanitizeFields');
+    }
+
+    public function testExtractUserFieldsExcludesDangerousColumns(): void
+    {
+        $owner = new Owner();
+        $method = new \ReflectionMethod($owner, 'extractUserFields');
+        /** @var array<string, mixed> */
+        $result = $method->invoke($owner, [
+            'fname'       => 'Alice',
+            'active'      => '1',
+            'permissions' => '3',
+            'username'    => 'hacker',
+            'password'    => 'hash',
+        ]);
+        $this->assertArrayHasKey('fname', $result, 'fname must be allowed through extractUserFields');
+        $this->assertArrayNotHasKey('active', $result,
+            'active must be excluded from the extractUserFields allowlist');
+        $this->assertArrayNotHasKey('permissions', $result,
+            'permissions must be excluded from the extractUserFields allowlist');
+        $this->assertArrayNotHasKey('username', $result,
+            'username must be excluded from the extractUserFields allowlist');
+    }
 }

--- a/usersc/classes/Owner.php
+++ b/usersc/classes/Owner.php
@@ -156,7 +156,7 @@ class Owner
 
             // Create user record
             $userFields['join_date'] = date(AppConstants::DATETIME_FORMAT);
-            $userFields['vericode'] = randomstring(15);
+            $userFields['vericode'] = randomString(15);
 
             if (!$this->_db->insert($this->userTableName, $userFields)) {
                 throw OwnerCreationException::withUserMessage(

--- a/usersc/classes/Owner.php
+++ b/usersc/classes/Owner.php
@@ -712,10 +712,9 @@ class Owner
                     break;
 
                 default:
-                    // Pass through other fields without validation (for flexibility)
-                    if (!empty($value)) {
-                        $validatedFields[$key] = $value;
-                    }
+                    // Unknown fields are silently dropped — security control to prevent
+                    // privilege-escalating columns (active, permissions) from reaching the DB.
+                    // To support a new field, add an explicit validated case above.
                     break;
             }
         }
@@ -724,14 +723,17 @@ class Owner
     }
 
     /**
-     * Extract user table fields from input array
+     * Extract user table fields from input array.
+     *
+     * Privilege-controlling columns (active, permissions) are intentionally
+     * absent — they must never be writable via the general Owner::update() path.
      *
      * @param array $fields Input fields array
      * @return array Fields that belong to users table
      */
     private function extractUserFields(array $fields): array
     {
-        $userFieldNames = ['fname', 'lname', 'email', 'username', 'password', 'active', 'permissions'];
+        $userFieldNames = ['fname', 'lname', 'email', 'password'];
         return array_intersect_key($fields, array_flip($userFieldNames));
     }
 


### PR DESCRIPTION
## Summary

- Removes `active` and `permissions` from `Owner::extractUserFields()` allowlist — these privilege-controlling columns must never be writable via the general profile-update path
- Changes `validateAndSanitizeFields()` default case from passthrough to **drop**: unknown fields are now silently discarded instead of forwarded, preventing any future endpoint from accidentally writing arbitrary user-table columns
- Removes the dead `username` entry from the same allowlist (no explicit sanitizer case for it; would have been dropped before reaching `extractUserFields()` anyway)
- Adds 7 integration tests: sanitizer-level drop assertions for `active`, `permissions`, `username`, and unknown fields; round-trip `Owner::update()` test confirming the DB columns don't change (both deactivation and escalation directions); and a direct `extractUserFields()` allowlist test via reflection

## Current status

The existing call site (`process-owner-update.php`) is already safe — it builds `$updateFields` from an explicit POST allowlist that excludes these fields. This is a defense-in-depth fix to harden the class interface itself so no future endpoint can accidentally introduce the vulnerability.

## Bug escape analysis

**Root cause:** Class design — `extractUserFields()` listed `active`/`permissions` as writable user-table fields, and `validateAndSanitizeFields()` had a default passthrough that forwarded any non-empty unrecognized field. No individual code path was currently exploitable, but the combination was latent.

**Testing gap:** No test verified that privilege-controlling columns were excluded from the update path. The existing integration tests only confirmed that specific profile fields persisted correctly — they didn't assert that fields *absent from the sanitizer* also couldn't reach the DB.

**Preventive tests added:** `testActiveFieldIsDroppedByValidation`, `testPermissionsFieldIsDroppedByValidation`, `testActiveAndPermissionsDoNotReachDbViaUpdate` (deactivation direction), `testActiveEscalationDoesNotReachDbViaUpdate` (escalation direction), `testExtractUserFieldsExcludesDangerousColumns`.

## Test plan

- [x] PHPStan: `vendor/bin/phpstan analyse usersc/classes/Owner.php` — no errors
- [x] Unit tests: 1141 tests, all pass
- [x] Pre-commit hooks: coding standards + PHPStan + unit tests — all pass
- [x] Security review: 0 Critical, 0 High findings
- [ ] Integration tests require MAMP running: `vendor/bin/phpunit tests/integration/OwnerIntegrationTest.php`

Closes #1232

https://claude.ai/code/session_01FMCNygrZ9jdR2b7H3Nj6cB