### PR TITLE
fix: contact-owner page exposes owner's last name, contradicting the privacy policy (#1322)

### DIFF
--- a/app/api/contact/send-owner-email.php
+++ b/app/api/contact/send-owner-email.php
@@ -178,15 +178,13 @@ if (!$fromEmailValid) {
 $replyOpts = $fromEmailValid ? ['replyTo' => $fromEmail, 'reply_name' => $fromName] : [];
 
 $result = email($toEmail, $subject, $body, $replyOpts);
-$safeFromLog = preg_replace('/[\r\n\t]/', '', $fromEmail);
-$safeToLog   = preg_replace('/[\r\n\t]/', '', $toEmail);
 
 if ($result !== true) {
     ApiResponse::serverError()
-        ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "send-owner-email.php SEND FAILED from $safeFromLog to $safeToLog")
+        ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "send-owner-email.php SEND FAILED from $fromEmail to $toEmail")
         ->send();
 }
 
 ApiResponse::success('Your message has been sent.')
-    ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_ELAN_REGISTRY, "send-owner-email.php sent from $safeFromLog to $safeToLog")
+    ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_ELAN_REGISTRY, "send-owner-email.php sent from $fromEmail to $toEmail")
     ->send();

--- a/app/api/contact/send-owner-email.php
+++ b/app/api/contact/send-owner-email.php
@@ -178,13 +178,15 @@ if (!$fromEmailValid) {
 $replyOpts = $fromEmailValid ? ['replyTo' => $fromEmail, 'reply_name' => $fromName] : [];
 
 $result = email($toEmail, $subject, $body, $replyOpts);
+$safeFromLog = preg_replace('/[\r\n\t]/', '', $fromEmail);
+$safeToLog   = preg_replace('/[\r\n\t]/', '', $toEmail);
 
 if ($result !== true) {
     ApiResponse::serverError()
-        ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "send-owner-email.php SEND FAILED from $fromEmail to $toEmail")
+        ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "send-owner-email.php SEND FAILED from $safeFromLog to $safeToLog")
         ->send();
 }
 
 ApiResponse::success('Your message has been sent.')
-    ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_ELAN_REGISTRY, "send-owner-email.php sent from $fromEmail to $toEmail")
+    ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_ELAN_REGISTRY, "send-owner-email.php sent from $safeFromLog to $safeToLog")
     ->send();

--- a/app/api/contact/send-owner-email.php
+++ b/app/api/contact/send-owner-email.php
@@ -111,9 +111,16 @@ $toData   = $toOwner->data();
 $fromData = $fromOwner->data();
 
 $toEmail   = preg_replace('/[\r\n\t]/', '', $toData->email);
-$toName    = $toData->fname . ' ' . $toData->lname;
-$fromEmail = $fromData->email;
-$fromName  = $fromData->fname . ' ' . $fromData->lname;
+$toName    = $toData->fname;                                                       // first name only — flows to HTML template, not headers
+$fromEmail = preg_replace('/[\r\n\t]/', '', $fromData->email);
+$fromName  = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));     // strip header-injection chars — reply_name is a display-name header value
+
+if (!filter_var($toEmail, FILTER_VALIDATE_EMAIL)) {
+    ApiResponse::serverError()
+        ->withLogging($logUserId ?? 0, LogCategories::LOG_CATEGORY_EMAIL_ERROR,
+            'send-owner-email.php: invalid recipient email for to_user_id=' . $toUserId)
+        ->send();
+}
 
 try {
     $car = new Car($carId);

--- a/app/api/contact/send-owner-email.php
+++ b/app/api/contact/send-owner-email.php
@@ -111,7 +111,7 @@ $toData   = $toOwner->data();
 $fromData = $fromOwner->data();
 
 $toEmail   = preg_replace('/[\r\n\t]/', '', $toData->email);
-$toName    = $toData->fname;                                                       // first name only — flows to HTML template, not headers
+$toName    = (string)($toData->fname ?? '');                                        // first name only — flows to HTML template, not headers
 $fromEmail = preg_replace('/[\r\n\t]/', '', $fromData->email);
 $fromName  = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));     // strip header-injection chars — reply_name is a display-name header value
 

--- a/app/owner/contact/owner.php
+++ b/app/owner/contact/owner.php
@@ -41,7 +41,6 @@ $from = [
 $to = [
     'id'    => $ownerData->id,
     'fname' => $ownerData->fname,
-    'lname' => $ownerData->lname,
 ];
 ?>
 
@@ -69,7 +68,7 @@ $to = [
                         <h5 class="text-primary"><i class="fas fa-user"></i> To</h5>
                         <div class="bg-light p-3 rounded">
                             <div class="mb-2">
-                                <strong><?= OwnerView::displayName((object)$to) ?></strong>
+                                <strong><?= htmlspecialchars($to['fname'] ?? '', ENT_QUOTES, 'UTF-8') ?></strong>
                             </div>
                         </div>
                     </div>

--- a/tests/integration/OwnerEmailSecurityTest.php
+++ b/tests/integration/OwnerEmailSecurityTest.php
@@ -172,7 +172,7 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
         $toData        = $toOwnerResult->first();
 
         // Replicate send-owner-email.php:114
-        $toName = $toData->fname;
+        $toName = (string)($toData->fname ?? '');
 
         $this->assertSame('Bob', $toName, '$toName must equal fname only');
         $this->assertStringNotContainsString('Jones', $toName, '$toName must not include lname');

--- a/tests/integration/OwnerEmailSecurityTest.php
+++ b/tests/integration/OwnerEmailSecurityTest.php
@@ -128,7 +128,9 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
             'email' => 'alice_fromname@example.com',
         ]);
 
-        // Replicate the Owner data load from send-owner-email.php:91-101
+        // Raw SQL intentionally bypasses Owner::data() to isolate the string-derivation
+        // logic under test. Owner::data() is tested separately; we're pinning what
+        // send-owner-email.php does with the data it receives, not how it loads it.
         $fromOwnerResult = $this->db->query('SELECT fname, lname, email FROM users WHERE id = ?', [$fromUserId]);
         $fromData        = $fromOwnerResult->first();
 
@@ -167,7 +169,9 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
             'email' => 'bob_toname@example.com',
         ]);
 
-        // Replicate the Owner data load from send-owner-email.php:91-101
+        // Raw SQL intentionally bypasses Owner::data() to isolate the string-derivation
+        // logic under test. Owner::data() is tested separately; we're pinning what
+        // send-owner-email.php does with the data it receives, not how it loads it.
         $toOwnerResult = $this->db->query('SELECT fname, lname, email FROM users WHERE id = ?', [$toUserId]);
         $toData        = $toOwnerResult->first();
 

--- a/tests/integration/OwnerEmailSecurityTest.php
+++ b/tests/integration/OwnerEmailSecurityTest.php
@@ -102,6 +102,83 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
     }
 
     /**
+     * Privacy + injection fix (issue #1322, Bug B): $fromName uses only fname.
+     *
+     * ROOT CAUSE
+     * ----------
+     * Before the fix, $fromName was $fromData->fname . ' ' . $fromData->lname,
+     * exposing the sender's surname in reply-to headers and the email template,
+     * and bypassing the CR/LF strip that was already applied to $toEmail.
+     *
+     * TESTING GAP
+     * -----------
+     * No test verified which name fields flow into email headers or the
+     * reply_name parameter, so the regression was invisible to CI.
+     *
+     * PREVENTION
+     * ----------
+     * This test pins the contract: $fromName is derived from $fromData->fname
+     * alone, stripped of CR/LF/tab, and must not contain lname.
+     */
+    public function testFromNameIsFirstNameOnly(): void
+    {
+        $fromUserId = $this->createTestUser([
+            'fname' => 'Alice',
+            'lname' => 'Smith',
+            'email' => 'alice_fromname@example.com',
+        ]);
+
+        // Replicate the Owner data load from send-owner-email.php:91-101
+        $fromOwnerResult = $this->db->query('SELECT fname, lname, email FROM users WHERE id = ?', [$fromUserId]);
+        $fromData        = $fromOwnerResult->first();
+
+        // Replicate send-owner-email.php:116
+        $fromName = preg_replace('/[\r\n\t]/', '', $fromData->fname);
+
+        $this->assertSame('Alice', $fromName, '$fromName must equal fname only');
+        $this->assertStringNotContainsString('Smith', $fromName, '$fromName must not include lname');
+        $this->assertStringNotContainsString("\r", $fromName, 'CR must be stripped');
+        $this->assertStringNotContainsString("\n", $fromName, 'LF must be stripped');
+        $this->assertStringNotContainsString("\t", $fromName, 'tab must be stripped');
+    }
+
+    /**
+     * Privacy fix (issue #1322, Bug B): $toName uses only fname.
+     *
+     * ROOT CAUSE
+     * ----------
+     * Before the fix, $toName was $toData->fname . ' ' . $toData->lname,
+     * leaking the recipient's surname into the email template greeting.
+     *
+     * TESTING GAP
+     * -----------
+     * Same gap as $fromName — no test verified the $toName derivation.
+     *
+     * PREVENTION
+     * ----------
+     * This test pins the contract: $toName is derived from $toData->fname
+     * alone and must not contain lname.
+     */
+    public function testToNameIsFirstNameOnly(): void
+    {
+        $toUserId = $this->createTestUser([
+            'fname' => 'Bob',
+            'lname' => 'Jones',
+            'email' => 'bob_toname@example.com',
+        ]);
+
+        // Replicate the Owner data load from send-owner-email.php:91-101
+        $toOwnerResult = $this->db->query('SELECT fname, lname, email FROM users WHERE id = ?', [$toUserId]);
+        $toData        = $toOwnerResult->first();
+
+        // Replicate send-owner-email.php:114
+        $toName = $toData->fname;
+
+        $this->assertSame('Bob', $toName, '$toName must equal fname only');
+        $this->assertStringNotContainsString('Jones', $toName, '$toName must not include lname');
+    }
+
+    /**
      * IDOR guard: to_user_id must match the car's actual owner.
      *
      * Replicates the DB query and comparison from send-owner-email.php:76-87.

--- a/tests/unit/security/EmailHeaderSanitizationTest.php
+++ b/tests/unit/security/EmailHeaderSanitizationTest.php
@@ -172,20 +172,37 @@ final class EmailHeaderSanitizationTest extends TestCase
      * Unlike $fromName (which flows into reply_name — a MIME display-name header),
      * $toName is used only in the HTML template greeting where htmlspecialchars()
      * handles XSS. SMTP header injection is not a risk for body-only values, so
-     * stripping is unnecessary. This test documents the intentional asymmetry so
-     * future refactors don't add preg_replace here by mistake.
+     * stripping is unnecessary. The (string)(... ?? '') null guard matches $fromName
+     * for defensive consistency, but no preg_replace is applied. This test documents
+     * the intentional asymmetry so future refactors don't add preg_replace here.
      */
     public function testToName_IsAssignedDirectly_WithoutPregreplace(): void
     {
         $toData = (object)['fname' => "Bob\r\nInjection", 'lname' => 'Jones'];
 
-        // The contract: $toName is $toData->fname verbatim (no stripping)
-        $toName = $toData->fname;
+        // The contract: (string)($toData->fname ?? '') — null guard only, no stripping
+        $toName = (string)($toData->fname ?? '');
 
         // The value is the raw fname — control chars are present (intentional)
         $this->assertSame("Bob\r\nInjection", $toName);
         // Template safety comes from htmlspecialchars() at render time, not pre-stripping
         $this->assertStringNotContainsString('Jones', $toName);
+    }
+
+    /**
+     * Null fname (DEFAULT NULL column) produces an empty string without TypeError.
+     *
+     * Without the (string)(... ?? '') guard, $toName would be null, and
+     * htmlspecialchars($to, ENT_QUOTES, 'UTF-8') in the email template would throw
+     * a TypeError in PHP 8.1+, causing the ob_start() catch to suppress the error
+     * and return a 500 to the sender.
+     */
+    public function testToName_NullFname_YieldsEmptyString(): void
+    {
+        $toData = (object)['fname' => null, 'lname' => 'Jones'];
+        $toName = (string)($toData->fname ?? '');
+
+        $this->assertSame('', $toName);
     }
 
     // ------------------------------------------------------------------
@@ -275,9 +292,9 @@ final class EmailHeaderSanitizationTest extends TestCase
 
         // Replicate send-owner-email.php:113-116 verbatim
         $toEmail   = preg_replace('/[\r\n\t]/', '', $toData->email);
-        $toName    = $toData->fname;
+        $toName    = (string)($toData->fname ?? '');
         $fromEmail = preg_replace('/[\r\n\t]/', '', $fromData->email);
-        $fromName  = preg_replace('/[\r\n\t]/', '', $fromData->fname);
+        $fromName  = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));
 
         $this->assertSame('bob@example.com',   $toEmail);
         $this->assertSame('Bob',               $toName);

--- a/tests/unit/security/EmailHeaderSanitizationTest.php
+++ b/tests/unit/security/EmailHeaderSanitizationTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Unit tests for email header field sanitization — issue #1322 (Bug B).
+ *
+ * ROOT CAUSE
+ * ----------
+ * Before the fix, $fromName was built as:
+ *   $fromName = $fromData->fname . ' ' . $fromData->lname;
+ * This introduced two vulnerabilities:
+ *   1. lname was included, leaking the sender's full surname into reply-to headers
+ *      and the email template, violating the first-name-only privacy contract.
+ *   2. $fromName was not passed through preg_replace('/[\r\n\t]/', '', ...), so a
+ *      CR/LF sequence in the database fname or lname value could inject additional
+ *      MIME headers via PHPMailer's addReplyTo() call.
+ *
+ * TESTING GAP
+ * -----------
+ * No test verified which name fields flow into email headers or the reply_name
+ * parameter, nor that those values are stripped of control characters before use.
+ * The fix was therefore untested, making regression possible on future refactors.
+ *
+ * PREVENTION
+ * ----------
+ * These tests pin the exact string-derivation contract from send-owner-email.php
+ * lines 113-116 so that any future change to $toName or $fromName construction
+ * is caught immediately without requiring an end-to-end email send.
+ */
+#[Group('fast')]
+final class EmailHeaderSanitizationTest extends TestCase
+{
+    // ------------------------------------------------------------------
+    // $fromName — derived from $fromData->fname with CR/LF stripping
+    // Replicates send-owner-email.php:116
+    // ------------------------------------------------------------------
+
+    /**
+     * \r\n in fname must be stripped before the value reaches addReplyTo().
+     *
+     * A malicious or corrupted fname such as "Alice\r\nBcc: attacker@evil.com"
+     * would inject an extra MIME header if passed unsanitized. The sanitization
+     * removes the line-break characters so the value is collapsed into a single
+     * line — the injected text no longer begins on its own line and cannot be
+     * interpreted as a separate header by a MIME parser.
+     */
+    public function testFromName_CrLfInFname_IsStripped(): void
+    {
+        $fromData = (object)['fname' => "Alice\r\nBcc: attacker@evil.com", 'lname' => 'Smith'];
+        $fromName = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));
+
+        // The line-break characters are gone — the value is now a single line
+        $this->assertStringNotContainsString("\r", $fromName);
+        $this->assertStringNotContainsString("\n", $fromName);
+        // The resulting collapsed string cannot be parsed as a separate MIME header
+        $this->assertSame('AliceBcc: attacker@evil.com', $fromName);
+    }
+
+    /**
+     * Bare \r (carriage-return only) is also stripped — covers legacy mailers
+     * that treat \r alone as a line terminator.
+     */
+    public function testFromName_CrAloneInFname_IsStripped(): void
+    {
+        $fromData = (object)['fname' => "Alice\rSmith", 'lname' => 'Last'];
+        $fromName = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));
+
+        $this->assertStringNotContainsString("\r", $fromName);
+        $this->assertSame('AliceSmith', $fromName);
+    }
+
+    /**
+     * \t (tab) in fname is stripped — tabs are also illegal in MIME header values.
+     */
+    public function testFromName_TabInFname_IsStripped(): void
+    {
+        $fromData = (object)['fname' => "Alice\tTab", 'lname' => 'Last'];
+        $fromName = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));
+
+        $this->assertStringNotContainsString("\t", $fromName);
+        $this->assertSame('AliceTab', $fromName);
+    }
+
+    /**
+     * $fromName must not include lname — only fname flows into reply_name.
+     *
+     * The pre-fix code appended lname, leaking the sender's surname into
+     * PHPMailer's addReplyTo() and the email template 'from' variable.
+     */
+    public function testFromName_DoesNotContainLname(): void
+    {
+        $fromData = (object)['fname' => 'Alice', 'lname' => 'Smith'];
+        $fromName = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));
+
+        $this->assertSame('Alice', $fromName);
+        $this->assertStringNotContainsString('Smith', $fromName);
+    }
+
+    /**
+     * A clean fname with no control characters is preserved unchanged.
+     */
+    public function testFromName_CleanFname_IsPreservedUnchanged(): void
+    {
+        $fromData = (object)['fname' => 'Alice', 'lname' => 'Smith'];
+        $fromName = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));
+
+        $this->assertSame('Alice', $fromName);
+    }
+
+    /**
+     * Empty fname sanitizes to an empty string without error.
+     */
+    public function testFromName_EmptyFname_YieldsEmptyString(): void
+    {
+        $fromData = (object)['fname' => '', 'lname' => 'Smith'];
+        $fromName = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));
+
+        $this->assertSame('', $fromName);
+    }
+
+    /**
+     * Null fname (DEFAULT NULL column) sanitizes to an empty string without PHP deprecation.
+     *
+     * In PHP 8.2+ preg_replace() on a null subject would trigger a deprecation notice.
+     * The (string)(...?? '') cast ensures a safe empty-string fallback.
+     */
+    public function testFromName_NullFname_YieldsEmptyString(): void
+    {
+        $fromData = (object)['fname' => null, 'lname' => 'Smith'];
+        $fromName = preg_replace('/[\r\n\t]/', '', (string)($fromData->fname ?? ''));
+
+        $this->assertSame('', $fromName);
+    }
+
+    // ------------------------------------------------------------------
+    // $toName — derived from $toData->fname only (no stripping needed for
+    // template display, but the contract is first-name-only).
+    // Replicates send-owner-email.php:114
+    // ------------------------------------------------------------------
+
+    /**
+     * $toName must not include lname — the recipient's surname must not appear
+     * in the email template greeting, preserving the privacy contract.
+     */
+    public function testToName_DoesNotContainLname(): void
+    {
+        $toData = (object)['fname' => 'Bob', 'lname' => 'Jones'];
+        $toName = $toData->fname;
+
+        $this->assertSame('Bob', $toName);
+        $this->assertStringNotContainsString('Jones', $toName);
+    }
+
+    /**
+     * $toName is exactly fname with no transformation.
+     */
+    public function testToName_IsFnameVerbatim(): void
+    {
+        $toData = (object)['fname' => 'Élodie', 'lname' => 'Dupont'];
+        $toName = $toData->fname;
+
+        $this->assertSame('Élodie', $toName);
+    }
+
+    /**
+     * $toName intentionally does NOT receive preg_replace stripping.
+     *
+     * Unlike $fromName (which flows into reply_name — a MIME display-name header),
+     * $toName is used only in the HTML template greeting where htmlspecialchars()
+     * handles XSS. SMTP header injection is not a risk for body-only values, so
+     * stripping is unnecessary. This test documents the intentional asymmetry so
+     * future refactors don't add preg_replace here by mistake.
+     */
+    public function testToName_IsAssignedDirectly_WithoutPregreplace(): void
+    {
+        $toData = (object)['fname' => "Bob\r\nInjection", 'lname' => 'Jones'];
+
+        // The contract: $toName is $toData->fname verbatim (no stripping)
+        $toName = $toData->fname;
+
+        // The value is the raw fname — control chars are present (intentional)
+        $this->assertSame("Bob\r\nInjection", $toName);
+        // Template safety comes from htmlspecialchars() at render time, not pre-stripping
+        $this->assertStringNotContainsString('Jones', $toName);
+    }
+
+    // ------------------------------------------------------------------
+    // $fromEmail — preg_replace stripping (regression guard)
+    // Replicates send-owner-email.php:115
+    // ------------------------------------------------------------------
+
+    /**
+     * $fromEmail CR/LF is stripped — added by the fix alongside the $toEmail
+     * stripping that already existed. Regression guard: don't drop this call.
+     *
+     * Stripping the line-break collapses the value to a single line so it
+     * cannot be interpreted as a separate MIME header by the mailer.
+     */
+    public function testFromEmail_CrLfInEmail_IsStripped(): void
+    {
+        $fromData  = (object)['email' => "alice@example.com\r\nBcc: attacker@evil.com"];
+        $fromEmail = preg_replace('/[\r\n\t]/', '', $fromData->email);
+
+        $this->assertStringNotContainsString("\r", $fromEmail);
+        $this->assertStringNotContainsString("\n", $fromEmail);
+        // Value is now a single collapsed line — not a parseable injected header
+        $this->assertSame('alice@example.comBcc: attacker@evil.com', $fromEmail);
+    }
+
+    /**
+     * A clean fromEmail passes through unchanged.
+     */
+    public function testFromEmail_CleanEmail_IsPreservedUnchanged(): void
+    {
+        $fromData  = (object)['email' => 'alice@example.com'];
+        $fromEmail = preg_replace('/[\r\n\t]/', '', $fromData->email);
+
+        $this->assertSame('alice@example.com', $fromEmail);
+    }
+
+    // ------------------------------------------------------------------
+    // $toEmail — regression guard: existing stripping must not be broken
+    // Replicates send-owner-email.php:113
+    // ------------------------------------------------------------------
+
+    /**
+     * $toEmail CR/LF stripping existed before the fix and must remain intact.
+     *
+     * This is a regression guard to ensure the existing sanitization is not
+     * accidentally removed during future refactors of the name-field lines.
+     * The strip collapses the injection attempt to a single line that a MIME
+     * parser cannot interpret as a separate header.
+     */
+    public function testToEmail_CrLfInEmail_IsStripped(): void
+    {
+        $toData  = (object)['email' => "bob@example.com\r\nX-Injected: header"];
+        $toEmail = preg_replace('/[\r\n\t]/', '', $toData->email);
+
+        $this->assertStringNotContainsString("\r", $toEmail);
+        $this->assertStringNotContainsString("\n", $toEmail);
+        // Value is now a single collapsed line — not a parseable injected header
+        $this->assertSame('bob@example.comX-Injected: header', $toEmail);
+    }
+
+    /**
+     * A clean toEmail is preserved without modification.
+     */
+    public function testToEmail_CleanEmail_IsPreservedUnchanged(): void
+    {
+        $toData  = (object)['email' => 'bob@example.com'];
+        $toEmail = preg_replace('/[\r\n\t]/', '', $toData->email);
+
+        $this->assertSame('bob@example.com', $toEmail);
+    }
+
+    // ------------------------------------------------------------------
+    // All four fields together — combined contract snapshot
+    // ------------------------------------------------------------------
+
+    /**
+     * Snapshot: all four header-related assignments produce correct values
+     * for a typical clean dataset.
+     *
+     * This makes it obvious at a glance when any of the four derivations
+     * is changed, without requiring four separate failures to be investigated.
+     */
+    public function testAllHeaderFields_CleanInput_CorrectDerivation(): void
+    {
+        $toData   = (object)['fname' => 'Bob',   'lname' => 'Jones',  'email' => 'bob@example.com'];
+        $fromData = (object)['fname' => 'Alice', 'lname' => 'Smith',  'email' => 'alice@example.com'];
+
+        // Replicate send-owner-email.php:113-116 verbatim
+        $toEmail   = preg_replace('/[\r\n\t]/', '', $toData->email);
+        $toName    = $toData->fname;
+        $fromEmail = preg_replace('/[\r\n\t]/', '', $fromData->email);
+        $fromName  = preg_replace('/[\r\n\t]/', '', $fromData->fname);
+
+        $this->assertSame('bob@example.com',   $toEmail);
+        $this->assertSame('Bob',               $toName);
+        $this->assertSame('alice@example.com', $fromEmail);
+        $this->assertSame('Alice',             $fromName);
+
+        // Confirm surnames are absent from the name fields
+        $this->assertStringNotContainsString('Jones', $toName);
+        $this->assertStringNotContainsString('Smith', $fromName);
+    }
+}


### PR DESCRIPTION
## Summary

- **Privacy fix**: Contact-owner page showed the car owner's full name (first + last) to the contacting member via `OwnerView::displayName()`. Now shows first name only, consistent with the published privacy policy.
- **Email header injection fix**: `$fromName` and `$fromEmail` were not CR/LF-stripped before flowing into PHPMailer's `addReplyTo()` via `reply_name`. Both are now explicitly stripped. `$toName` correctly remains unstripped (body-only, escaped by `htmlspecialchars()` at render).
- **Recipient email guard**: Added `filter_var($toEmail, FILTER_VALIDATE_EMAIL)` check before delivery — bad recipient email now logs a specific error rather than a generic "SEND FAILED".
- **Structural privacy guard**: Removed `lname` from the `$to` array in `owner.php` — the surname can no longer be accidentally re-introduced via a template change.

## Bug Escape Analysis

**Root cause**: `OwnerView::displayName()` always returns `fname lname`, and no context-aware filtering existed. The email header path lacked the same CR/LF stripping already applied to `$toEmail`.

**Testing gap**: No test verified which name fields flow into email headers or the `reply_name` parameter. No test verified the contact page "To" display showed only first name.

**Prevention**: 15 unit tests in `EmailHeaderSanitizationTest` pin the exact string-derivation contracts for all four header-related variables. 2 integration tests in `OwnerEmailSecurityTest` verify the DB-to-variable path using real rows.

## Test plan

- [ ] All 1156 unit tests pass (verified locally)
- [ ] PHPStan clean on all changed files
- [ ] PHP coding standards pass
- [ ] Contact-owner page shows only first name of car owner in the "To" box
- [ ] Contact-owner email arrives with sender's first name only in "Message From" and reply instruction
- [ ] Email Reply-To header set correctly (verify in email client)

Closes #1322

https://claude.ai/code/session_01FMCNygrZ9jdR2b7H3Nj6cB