### PR TITLE
chore: update repo slug references after migration to elan-registry/registry

### DIFF
--- a/.claude/commands/address-pr-comments.md
+++ b/.claude/commands/address-pr-comments.md
@@ -26,7 +26,7 @@ If no argument provided, find the open PR for the current branch:
 
 ```bash
 gh pr list --head "$(git branch --show-current)" --state open \
-  --json number,title,url --repo unibrain1/elanregistry
+  --json number,title,url --repo elan-registry/registry
 ```
 
 If no PR found, stop and tell the user to run `/commit-push-pr` first.
@@ -34,14 +34,14 @@ If no PR found, stop and tell the user to run `/commit-push-pr` first.
 ## Step 2: Fetch Review Comments
 
 ```bash
-gh pr view <pr-number> --repo unibrain1/elanregistry \
+gh pr view <pr-number> --repo elan-registry/registry \
   --json reviews,comments
 ```
 
 Also fetch inline code review comments:
 
 ```bash
-gh api "repos/unibrain1/elanregistry/pulls/<pr-number>/comments" \
+gh api "repos/elan-registry/registry/pulls/<pr-number>/comments" \
   --jq '.[] | {path, line, body, user: .user.login}'
 ```
 
@@ -50,16 +50,16 @@ gh api "repos/unibrain1/elanregistry/pulls/<pr-number>/comments" \
 Get the PR's head SHA and all check runs:
 
 ```bash
-HEAD_SHA=$(gh pr view <pr-number> --repo unibrain1/elanregistry \
+HEAD_SHA=$(gh pr view <pr-number> --repo elan-registry/registry \
   --json headRefOid --jq .headRefOid)
-gh api "repos/unibrain1/elanregistry/commits/${HEAD_SHA}/check-runs" \
+gh api "repos/elan-registry/registry/commits/${HEAD_SHA}/check-runs" \
   --jq '.check_runs[] | {name, conclusion, id, output: .output.summary}'
 ```
 
 For any failed check runs, fetch their annotations:
 
 ```bash
-gh api "repos/unibrain1/elanregistry/check-runs/<run-id>/annotations" \
+gh api "repos/elan-registry/registry/check-runs/<run-id>/annotations" \
   --jq '.[] | {path, start_line, message, annotation_level}'
 ```
 
@@ -121,7 +121,7 @@ git push origin "$(git branch --show-current)"
 Wait up to 5 minutes for checks to re-run. Poll every 60 seconds:
 
 ```bash
-gh pr checks <pr-number> --repo unibrain1/elanregistry
+gh pr checks <pr-number> --repo elan-registry/registry
 ```
 
 If any check still fails after the fix, report the failure and stop — do not

--- a/.claude/commands/architecture-update.md
+++ b/.claude/commands/architecture-update.md
@@ -266,6 +266,6 @@ document:
 - Note which task groups completed and if any required a re-run.
 - Note any lint errors that were found and how they were resolved.
 - Note the commit hash from the wiki repo push.
-- Confirm the changes are live at `https://github.com/unibrain1/elanregistry/wiki`.
+- Confirm the changes are live at `https://github.com/elan-registry/registry/wiki`.
 - If the document was split, provide the exact wiki page titles created so
   they are consistent with the filenames used.

--- a/.claude/commands/finish-issue.md
+++ b/.claude/commands/finish-issue.md
@@ -59,7 +59,7 @@ if they want to proceed or retarget the PR.
 Check if the PR is a draft:
 
 ```bash
-gh pr view <pr-number> --json isDraft --repo unibrain1/elanregistry -q .isDraft
+gh pr view <pr-number> --json isDraft --repo elan-registry/registry -q .isDraft
 ```
 
 **If the PR is a draft:**
@@ -71,7 +71,7 @@ gh pr view <pr-number> --json isDraft --repo unibrain1/elanregistry -q .isDraft
    gh workflow run claude-code-review.yml \
      --ref main \
      --field pr_number=<pr-number> \
-     --repo unibrain1/elanregistry
+     --repo elan-registry/registry
    ```
 
 2. Wait for the workflow run to complete. Poll every 30 seconds:
@@ -79,8 +79,8 @@ gh pr view <pr-number> --json isDraft --repo unibrain1/elanregistry -q .isDraft
    ```bash
    # Get the most recent run of claude-code-review.yml
    gh run list --workflow=claude-code-review.yml --limit=1 \
-     --repo unibrain1/elanregistry --json databaseId,status,conclusion
-   gh run watch <run-id> --repo unibrain1/elanregistry
+     --repo elan-registry/registry --json databaseId,status,conclusion
+   gh run watch <run-id> --repo elan-registry/registry
    ```
 
 3. Report the review result. If the review posted **Blocking** findings, stop
@@ -90,7 +90,7 @@ gh pr view <pr-number> --json isDraft --repo unibrain1/elanregistry -q .isDraft
    is the moment watchers are notified — immediately followed by merge:
 
    ```bash
-   gh pr ready <pr-number> --repo unibrain1/elanregistry
+   gh pr ready <pr-number> --repo elan-registry/registry
    ```
 
 **If the PR is already ready (not a draft):** skip to Step 3 — the Claude
@@ -208,9 +208,9 @@ List remaining open issues in the milestone. Use the direct API (`gh issue list 
 ```bash
 # Get milestone number from the milestone branch name, then query API directly
 MILESTONE_TITLE=$(git branch --show-current | sed 's|.*milestone/||' || echo "<milestone title>")
-MILESTONE_NUM=$(gh api "repos/unibrain1/elanregistry/milestones" \
+MILESTONE_NUM=$(gh api "repos/elan-registry/registry/milestones" \
   --jq ".[] | select(.title | startswith(\"${MILESTONE_TITLE}\")) | .number")
-gh api "repos/unibrain1/elanregistry/issues?milestone=${MILESTONE_NUM}&state=open&per_page=20" \
+gh api "repos/elan-registry/registry/issues?milestone=${MILESTONE_NUM}&state=open&per_page=20" \
   --jq '.[] | {number, title}'
 ```
 

--- a/.claude/commands/finish-milestone.md
+++ b/.claude/commands/finish-milestone.md
@@ -44,7 +44,7 @@ Set each task to `in_progress` when you begin it and `completed` on success.
 Use the direct API (`gh issue list --milestone` can silently return empty results — the milestone number is already recorded from Step 1):
 
 ```bash
-gh api "repos/unibrain1/elanregistry/issues?milestone=<MILESTONE_NUM>&state=open&per_page=20" \
+gh api "repos/elan-registry/registry/issues?milestone=<MILESTONE_NUM>&state=open&per_page=20" \
   --jq '.[] | {number, title}'
 ```
 

--- a/.claude/commands/found.md
+++ b/.claude/commands/found.md
@@ -68,7 +68,7 @@ No new issue needed. Add a "Found in passing" item to the plan and PR body.
 
 ```bash
 gh issue create \
-  --repo unibrain1/elanregistry \
+  --repo elan-registry/registry \
   --title "CONCISE_TITLE" \
   --body "Pre-existing issue found while working on #CURRENT_ISSUE.\n\nDESCRIPTION" \
   --label "bug,triage" \
@@ -81,7 +81,7 @@ gh issue create \
 
 ```bash
 gh issue create \
-  --repo unibrain1/elanregistry \
+  --repo elan-registry/registry \
   --title "CONCISE_TITLE" \
   --body "Pre-existing issue found while working on #CURRENT_ISSUE.\n\nDESCRIPTION" \
   --label "triage"

--- a/.claude/commands/release-milestone.md
+++ b/.claude/commands/release-milestone.md
@@ -176,7 +176,7 @@ git tag -a v<version> -m "Release v<version>: <milestone title>
 
 <Key highlights from release notes>
 
-Full release notes: https://github.com/unibrain1/elanregistry/releases/tag/v<version>"
+Full release notes: https://github.com/elan-registry/registry/releases/tag/v<version>"
 ```
 
 Verify:
@@ -216,7 +216,7 @@ rm /tmp/release-notes-v<version>.md
 ### Step 15: Close the GitHub milestone
 
 ```bash
-gh api repos/unibrain1/elanregistry/milestones/<milestone_number> \
+gh api repos/elan-registry/registry/milestones/<milestone_number> \
   -X PATCH -f state=closed
 ```
 

--- a/.claude/commands/start-milestone.md
+++ b/.claude/commands/start-milestone.md
@@ -23,14 +23,14 @@ release notes, and recommending an issue order.
 ### Step 1: Validate the milestone exists on GitHub
 
 ```bash
-gh api repos/unibrain1/elanregistry/milestones \
+gh api repos/elan-registry/registry/milestones \
   --jq '.[] | select(.title | startswith("'"$ARGUMENTS"'"))'
 ```
 
 If not found, stop and report the error. Show available open milestones:
 
 ```bash
-gh api repos/unibrain1/elanregistry/milestones --jq '.[].title'
+gh api repos/elan-registry/registry/milestones --jq '.[].title'
 ```
 
 Record the full milestone title and milestone number for later steps.
@@ -100,7 +100,7 @@ gh issue list --milestone "<full milestone title>" --state open \
 when issues exist. Always verify with the direct API call:
 
 ```bash
-gh api "repos/unibrain1/elanregistry/issues?milestone=<NUMBER>&state=open&per_page=50" \
+gh api "repos/elan-registry/registry/issues?milestone=<NUMBER>&state=open&per_page=50" \
   --jq '.[] | {number, title, labels: [.labels[].name], body}'
 ```
 
@@ -164,7 +164,7 @@ After displaying the review, ask two questions in sequence:
 If the user provides issue numbers to close, close each one on GitHub:
 
 ```bash
-gh issue close NNN --repo unibrain1/elanregistry \
+gh issue close NNN --repo elan-registry/registry \
   --comment "Closing as low-value / make-work during milestone planning. Can be reopened if prioritized."
 ```
 
@@ -185,7 +185,7 @@ For each accepted consolidation group:
 3. **Close the secondary issue(s)** with a linking comment:
 
 ```bash
-gh issue close NNN --repo unibrain1/elanregistry \
+gh issue close NNN --repo elan-registry/registry \
   --comment "Consolidated into #PRIMARY — scope merged there."
 ```
 
@@ -224,7 +224,7 @@ Create a draft release notes file at
 - Write a brief summary based on the milestone description
 - Populate the "Issues Resolved" section with all open issues from the
   milestone (linked to GitHub using
-  `https://github.com/unibrain1/elanregistry/issues/NNN`)
+  `https://github.com/elan-registry/registry/issues/NNN`)
 - Leave deployment instructions and verification sections as template
   placeholders — these will be filled in as issues are completed
 - Remove the "Template Instructions" section below the `---` divider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,9 @@ working with code in this repository.
 
 **Core understanding:**
 
-- [GitHub Wiki: Architecture Guide](https://github.com/unibrain1/elanregistry/wiki/Elan-Registry-Architecture-and-Database-Design) - System architecture and patterns
+- [GitHub Wiki: Architecture Guide](https://github.com/elan-registry/registry/wiki/Elan-Registry-Architecture-and-Database-Design) - System architecture and patterns
 - `docs/development/DATABASE.md` - Database schema and relationships
-- [GitHub Wiki: UserSpice Integration Guide](https://github.com/unibrain1/elanregistry/wiki/Customization-and-Integration-Patterns) - UserSpice integration
+- [GitHub Wiki: UserSpice Integration Guide](https://github.com/elan-registry/registry/wiki/Customization-and-Integration-Patterns) - UserSpice integration
 
 **UserSpice context (AI Prompts plugin):** Before any UserSpice task, read the
 shipped prompts starting at:
@@ -44,7 +44,7 @@ authentication, with custom car registry functionality. Cloudflare provides
 edge caching and CDN for global users (US, EU, AU).
 
 > **For complete architecture, see the
-> [GitHub Wiki: Architecture Guide](https://github.com/unibrain1/elanregistry/wiki/Elan-Registry-Architecture-and-Database-Design)**
+> [GitHub Wiki: Architecture Guide](https://github.com/elan-registry/registry/wiki/Elan-Registry-Architecture-and-Database-Design)**
 
 **Directory Structure:**
 
@@ -70,7 +70,7 @@ edge caching and CDN for global users (US, EU, AU).
 **Key Integration Points:**
 
 - **Page Security**: All protected pages require `securePage($php_self)` check.
-  See [GitHub Wiki: UserSpice Integration Guide](https://github.com/unibrain1/elanregistry/wiki/Customization-and-Integration-Patterns).
+  See [GitHub Wiki: UserSpice Integration Guide](https://github.com/elan-registry/registry/wiki/Customization-and-Integration-Patterns).
 - **Role Hierarchy**: Two privileged roles — `admin` and `editor`. Most admin
   pages are admin-only; some tools (e.g. data repair, image management) grant
   access to both. Always check the issue scope before defaulting to admin-only.
@@ -320,7 +320,7 @@ See [DEPLOYMENT.md](docs/development/DEPLOYMENT.md) for complete procedures. **C
 
 ## GitHub Repository
 
-- **GitHub owner/repo:** `unibrain1/elanregistry` (not `jimboone/elan-registry`)
+- **GitHub owner/repo:** `elan-registry/registry` (not `jimboone/elan-registry`)
 - Use `gh` CLI for GitHub operations — the MCP GitHub tools require the correct
   owner/repo pair above
 - Milestone descriptions should state the goal, not list issue numbers
@@ -328,16 +328,16 @@ See [DEPLOYMENT.md](docs/development/DEPLOYMENT.md) for complete procedures. **C
 
 **gh CLI gotchas:**
 
-- `gh milestone list` does not exist — use `gh api repos/unibrain1/elanregistry/milestones` instead
+- `gh milestone list` does not exist — use `gh api repos/elan-registry/registry/milestones` instead
 - `gh issue list --milestone` can silently return empty even with open issues — always use
-  `gh api repos/unibrain1/elanregistry/issues?milestone=<number>&state=open` for reliable results
+  `gh api repos/elan-registry/registry/issues?milestone=<number>&state=open` for reliable results
 
 ## GitHub Wiki
 
 The wiki is a **separate git repository** at the permanent path:
 
 ```text
-/Users/jimboone/Developer/Web/elan-registry-wiki
+/Users/jimboone/Documents/Developer/Web/ElanRegistryWiki
 ```
 
 **CRITICAL:** ALWAYS use this exact path. NEVER clone to `/tmp/`, a worktree,
@@ -347,8 +347,8 @@ only place to use.
 To update the live wiki after editing files in `wiki/` on a branch:
 
 ```bash
-cp wiki/<file>.md /Users/jimboone/Developer/Web/elan-registry-wiki/
-cd /Users/jimboone/Developer/Web/elan-registry-wiki
+cp wiki/<file>.md /Users/jimboone/Documents/Developer/Web/ElanRegistryWiki/
+cd /Users/jimboone/Documents/Developer/Web/ElanRegistryWiki
 git add <file>.md
 git commit -m "docs: <description>"
 git push

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ PHP 8.2+ · MySQL 8.0+ · UserSpice 6 · Bootstrap 5.3 · Cloudflare
 ### Quick Start
 
 ```bash
-git clone https://github.com/unibrain1/elanregistry.git
+git clone https://github.com/elan-registry/registry.git
 composer install
 npm install
 ./scripts/setup-git-hooks.sh   # installs pre-commit quality checks
@@ -41,7 +41,7 @@ cp .env.example .env            # then fill in credentials
 composer test:quick             # verify environment
 ```
 
-For full installation steps, see the [Registry Installation Guide](https://github.com/unibrain1/elanregistry/wiki/Registry-Installation).
+For full installation steps, see the [Registry Installation Guide](https://github.com/elan-registry/registry/wiki/Registry-Installation).
 
 See [ENVIRONMENT.md](docs/development/ENVIRONMENT.md) for full `.env` configuration.
 
@@ -50,7 +50,7 @@ See [ENVIRONMENT.md](docs/development/ENVIRONMENT.md) for full `.env` configurat
 | Audience | Where |
 | --- | --- |
 | Development conventions, workflow, AI context | [`CLAUDE.md`](CLAUDE.md) |
-| Architecture, database design, class patterns | [GitHub Wiki](https://github.com/unibrain1/elanregistry/wiki) |
+| Architecture, database design, class patterns | [GitHub Wiki](https://github.com/elan-registry/registry/wiki) |
 | Technical reference docs | [`docs/development/`](docs/development/) |
 | End-user guides | [`docs/guides/`](docs/guides/) |
 | Reference pages (paint colors, chassis ID) | [`docs/reference/`](docs/reference/) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,5 +111,5 @@ in the relevant PHP file. No build step required.
 - `/usersc/plugins/*/README.md` — Individual plugin documentation
 - Third-party docs in `/vendor/` and `/node_modules/`
 
-[arch-wiki]: https://github.com/unibrain1/elanregistry/wiki/Elan-Registry-Architecture-and-Database-Design
-[us-wiki]: https://github.com/unibrain1/elanregistry/wiki/Customization-and-Integration-Patterns
+[arch-wiki]: https://github.com/elan-registry/registry/wiki/Elan-Registry-Architecture-and-Database-Design
+[us-wiki]: https://github.com/elan-registry/registry/wiki/Customization-and-Integration-Patterns

--- a/docs/development/DEPLOYMENT.md
+++ b/docs/development/DEPLOYMENT.md
@@ -37,7 +37,7 @@ git push origin main && git push origin --tags
 ### Remote Configuration Reference
 
 ```bash
-origin git@github.com:unibrain1/elanregistry.git    # GitHub repository
+origin git@github.com:elan-registry/registry.git    # GitHub repository
 test   [test-server-path]                            # Test/staging server
 prod   a2hosting:/home/unibrain/git/elanregistry.git # LIVE PRODUCTION SERVER
 ```
@@ -201,7 +201,7 @@ Pre-commit hooks validate PHP coding standards, markdown formatting, and run fas
 git commit --no-verify           # Bypass (emergency only)
 ```
 
-**See the [Development Workflow](https://github.com/unibrain1/elanregistry/wiki/Development-Workflow) wiki page** for hook details and `scripts/README.md` for troubleshooting.
+**See the [Development Workflow](https://github.com/elan-registry/registry/wiki/Development-Workflow) wiki page** for hook details and `scripts/README.md` for troubleshooting.
 
 ## 📋 Complete Production Deployment Process
 
@@ -375,5 +375,5 @@ If deployment fails:
 **📖 Related Documentation:**
 
 - [CLAUDE.md](../../CLAUDE.md) - Essential development guidance
-- [Development Workflow](https://github.com/unibrain1/elanregistry/wiki/Development-Workflow) - Development processes (wiki)
+- [Development Workflow](https://github.com/elan-registry/registry/wiki/Development-Workflow) - Development processes (wiki)
 - [ENVIRONMENT.md](ENVIRONMENT.md) - Environment setup and configuration

--- a/package.json
+++ b/package.json
@@ -38,16 +38,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/unibrain1/elanregistry.git"
+    "url": "git+https://github.com/elan-registry/registry.git"
   },
   "keywords": [],
   "author": "",
   "license": "AGPL-3.0-only",
   "type": "commonjs",
   "bugs": {
-    "url": "https://github.com/unibrain1/elanregistry/issues"
+    "url": "https://github.com/elan-registry/registry/issues"
   },
-  "homepage": "https://github.com/unibrain1/elanregistry#readme",
+  "homepage": "https://github.com/elan-registry/registry#readme",
   "dependencies": {
     "chart.js": "4.5.1",
     "datatables.net-bs5": "2.3.8",


### PR DESCRIPTION
## Summary

- Bulk replace `unibrain1/elanregistry` → `elan-registry/registry` across all Claude commands, CLAUDE.md, package.json, README, and deployment docs
- Follows the completed repo transfer and rename (Phases 2–3 of the GitHub org migration plan)

## Files changed

- `.claude/commands/` — 7 files (API paths, `--repo` flags, wiki URLs)
- `CLAUDE.md` — 4 wiki links + owner/repo reference
- `README.md` — clone URL + wiki links
- `docs/development/DEPLOYMENT.md` — origin remote URL + wiki links
- `docs/README.md` — 2 wiki links
- `package.json` — `repository.url`, `bugs.url`, `homepage`

## Test plan

- [ ] Verify no `unibrain1/elanregistry` references remain in changed files
- [ ] Confirm Claude commands resolve correctly against new repo slug

https://claude.ai/code/session_01AdLmBwcNRtRGw7TYoMCamr