### PR TITLE
v2.26.3 — User Deletion Hook & Stability Fixes

### DIFF
--- a/database/migrations/20260719120000_drop_cars_user_id_fk.php
+++ b/database/migrations/20260719120000_drop_cars_user_id_fk.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class DropCarsUserIdFk extends AbstractMigration
+{
+    // The fk_cars_user_id foreign key (cars.user_id → users.id ON DELETE SET NULL)
+    // was present on some environments but absent from the canonical schema. When
+    // present, MySQL's FK cascade fires during DELETE FROM users (inside deleteUsers())
+    // and sets cars.user_id = NULL before the after_user_deletion.php hook runs —
+    // so the hook finds 0 cars for the deleted user and skips the noowner reassignment.
+    //
+    // This migration drops the FK constraint if it exists. The accompanying index
+    // (also named fk_cars_user_id) is retained for query performance.
+    //
+    // up() + down() are used instead of change() because DROP FOREIGN KEY is not
+    // auto-reversible by Phinx. down() intentionally does NOT restore ON DELETE SET NULL
+    // since that behaviour was the bug.
+    //
+    // DDL note: ALTER TABLE issues an implicit commit in MySQL. This migration
+    // cannot be wrapped in a transaction.
+
+    public function up(): void
+    {
+        $fkExists = $this->fetchRow(
+            "SELECT CONSTRAINT_NAME
+             FROM information_schema.REFERENTIAL_CONSTRAINTS
+             WHERE CONSTRAINT_SCHEMA = DATABASE()
+               AND CONSTRAINT_NAME = 'fk_cars_user_id'"
+        );
+
+        if ($fkExists) {
+            $this->execute("ALTER TABLE `cars` DROP FOREIGN KEY `fk_cars_user_id`");
+        }
+    }
+
+    public function down(): void
+    {
+        // Intentionally empty. ON DELETE SET NULL caused the user deletion hook to
+        // miss cars (the cascade fired before the hook ran). Re-adding the FK on
+        // rollback would restore the bug. The index (fk_cars_user_id on user_id)
+        // was never dropped and remains in place.
+    }
+}

--- a/docs/pdf-viewer.php
+++ b/docs/pdf-viewer.php
@@ -17,6 +17,7 @@ $nav_section = (($_GET['subdir'] ?? '') === 'stories') ? 'stories' : 'reference'
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 use ElanRegistry\Documentation\DocumentPortalTemplate;
+use ElanRegistry\LogCategories;
 
 if (!securePage($php_self)) {
     die();

--- a/docs/releases/RELEASE_NOTES_v2.26.3.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.3.md
@@ -1,0 +1,31 @@
+# Elan Registry v2.26.3 Release Notes
+
+**Release Date:** TBD
+**Type:** Patch Release — User Deletion Hook & Stability Fixes
+
+> **Note:** v2.26.2 was released but never deployed to production due to instability.
+> v2.26.3 supersedes it and is the recommended upgrade from v2.26.1.
+
+## Required Actions After Deployment
+
+1. Run database migrations to drop the legacy `fk_cars_user_id` FK constraint if present:
+   ```
+   composer migrate
+   ```
+   *(No-op on environments that already dropped it.)*
+
+## User-Facing Changes
+
+None.
+
+## Admin-Facing Changes
+
+### Improvements
+
+- **User Deletion — Owner Details Preserved** (TBD): Deleting an owner now correctly updates all denormalized car fields (name, email, city, etc.) to show the noowner placeholder, matching the behavior of the admin manual reassign tool.
+
+## Issues Resolved
+
+- TBD — User deletion hook: use Car::transfer() to update denormalized owner fields
+- TBD — PDF viewer page: missing LogCategories import causes fatal error on first load
+- TBD — Defensive migration: drop fk_cars_user_id FK if present (ON DELETE SET NULL race condition)

--- a/docs/releases/RELEASE_NOTES_v2.26.3.md
+++ b/docs/releases/RELEASE_NOTES_v2.26.3.md
@@ -1,18 +1,20 @@
 # Elan Registry v2.26.3 Release Notes
 
-**Release Date:** TBD
+**Release Date:** July 19, 2026
 **Type:** Patch Release — User Deletion Hook & Stability Fixes
 
-> **Note:** v2.26.2 was released but never deployed to production due to instability.
-> v2.26.3 supersedes it and is the recommended upgrade from v2.26.1.
+> **Note:** v2.26.2 was released but never deployed to production due to
+> instability discovered during testing. v2.26.3 supersedes it and is the
+> recommended upgrade from v2.26.1.
 
 ## Required Actions After Deployment
 
-1. Run database migrations to drop the legacy `fk_cars_user_id` FK constraint if present:
+1. Run database migrations:
    ```
    composer migrate
    ```
-   *(No-op on environments that already dropped it.)*
+   Drops the `fk_cars_user_id` FK constraint if present. No-op on environments
+   where the constraint does not exist (including production).
 
 ## User-Facing Changes
 
@@ -22,10 +24,16 @@ None.
 
 ### Improvements
 
-- **User Deletion — Owner Details Preserved** (TBD): Deleting an owner now correctly updates all denormalized car fields (name, email, city, etc.) to show the noowner placeholder, matching the behavior of the admin manual reassign tool.
+- **User Deletion — Owner Details Preserved**: Deleting an owner now correctly
+  updates all denormalized car fields (name, email, city, state, country, etc.)
+  to show the noowner placeholder, matching the behavior of the admin manual
+  reassign tool. Previously only `user_id` was updated, leaving stale owner
+  details visible on the car page.
 
 ## Issues Resolved
 
-- TBD — User deletion hook: use Car::transfer() to update denormalized owner fields
-- TBD — PDF viewer page: missing LogCategories import causes fatal error on first load
-- TBD — Defensive migration: drop fk_cars_user_id FK if present (ON DELETE SET NULL race condition)
+All fixes were committed directly to the milestone branch (no linked GitHub issues).
+
+- `fix: use Car::transfer() in deletion hook to update denormalized owner fields`
+- `fix: add missing LogCategories import to pdf-viewer.php` (fatal error on first page load)
+- `fix: drop fk_cars_user_id FK if present (ON DELETE SET NULL race condition)`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -529,12 +529,6 @@ parameters:
 			path: app/views/email/_transfer_response.php
 
 		-
-			message: '#^Access to constant LOG_CATEGORY_SECURITY on an unknown class LogCategories\.$#'
-			identifier: class.notFound
-			count: 4
-			path: docs/pdf-viewer.php
-
-		-
 			message: '#^Variable \$settings might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/usersc/scripts/after_user_deletion.php
+++ b/usersc/scripts/after_user_deletion.php
@@ -73,7 +73,10 @@ if ($noOwnerQuery->count() > 0) {
             throw new \RuntimeException("Failed to delete profile for user $id: " . $db->errorString());
         }
         // Transfer each car using the same code path as the admin reassign UI — updates
-        // user_id and all denormalized owner fields (email, fname, lname, city, etc.)
+        // user_id and all denormalized owner fields (email, fname, lname, city, etc.).
+        // Car::transfer() requires $user->isLoggedIn(); this hook is only ever invoked
+        // from admin-authenticated contexts (deleteUsers() callers). A future self-service
+        // GDPR-deletion path would need a different reassignment strategy here.
         foreach ($userCars as $carObj) {
             $car = new \ElanRegistry\Car\Car((int) $carObj->id);
             $car->transfer(

--- a/usersc/scripts/after_user_deletion.php
+++ b/usersc/scripts/after_user_deletion.php
@@ -54,7 +54,7 @@ if ($noOwnerQuery->count() > 0) {
     $userCars = $repo->findByOwner($id);
     $carCount = count($userCars);
 
-    $committed = $inTransaction(function () use ($db, $repo, $id, $noOwnerUserId): void {
+    $committed = $inTransaction(function () use ($db, $id, $noOwnerUserId, $userCars): void {
         // Expire any non-terminal transfer requests the user initiated — prevents orphaned
         // requester FK references and ensures the current car owner sees a clean audit trail.
         $db->query(
@@ -72,8 +72,16 @@ if ($noOwnerQuery->count() > 0) {
         if ($db->error()) {
             throw new \RuntimeException("Failed to delete profile for user $id: " . $db->errorString());
         }
-        // Update primary car ownership (this triggers cars_hist via database trigger)
-        $repo->reassignCarsByUser($id, $noOwnerUserId);
+        // Transfer each car using the same code path as the admin reassign UI — updates
+        // user_id and all denormalized owner fields (email, fname, lname, city, etc.)
+        foreach ($userCars as $carObj) {
+            $car = new \ElanRegistry\Car\Car((int) $carObj->id);
+            $car->transfer(
+                $noOwnerUserId,
+                "Account deleted — reassigned to noowner (ID: $noOwnerUserId)",
+                'NEWOWNER'
+            );
+        }
     });
 
     if (!$committed) {


### PR DESCRIPTION
## Summary

Patch release superseding the unstable v2.26.2. Fixes the user deletion hook to correctly update all denormalized car owner fields (not just `user_id`), resolves a fatal error on the PDF viewer page, and adds a defensive migration to drop an accidental FK constraint that caused the hook to silently skip car reassignment on affected environments.

## Changes

Three fixes committed directly to the milestone branch (no linked GitHub issues — these were discovered and fixed during v2.26.2 testing):

- `fix: use Car::transfer() in deletion hook to update denormalized owner fields` — `reassignCarsByUser()` only updated `user_id`; `Car::transfer()` matches the admin reassign code path and updates all 9 denormalized owner fields atomically
- `fix: add missing LogCategories import to pdf-viewer.php` — fatal error on first page load
- `fix: drop fk_cars_user_id FK if present (ON DELETE SET NULL race condition)` — FK cascade fired before the hook ran, causing hook to find 0 cars and skip reassignment; migration is a no-op on environments where the FK is absent

## Release Notes

See `docs/releases/RELEASE_NOTES_v2.26.3.md` for complete release notes.

## Test Plan

- [x] All three fixes manually verified on test server
- [x] PHPStan clean on all changed PHP files
- [x] Migration dry-run passes locally (no-op; FK absent on local/prod)
- [x] Security review: 0 Critical/High findings
- [x] Code review: 0 Blocking findings; transaction nesting independently verified correct
- [ ] Deploy to test server and run user deletion flow end-to-end
- [ ] Confirm car details show noowner after deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)