### PR TITLE
refactor: add CarValidator::parseModel() to centralize pipe-split model string parsing

### DIFF
--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -61,7 +61,9 @@ try {
     try {
         [, , $type] = CarValidator::parseModel($model);
     } catch (CarValidationException $e) {
-        ApiResponse::error('Invalid model format', 400)->send();
+        ApiResponse::error('Invalid model format', 400)
+            ->withLogging($logUserId, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'chassis-availability: invalid model string from user ' . $logUserId . ': ' . $model)
+            ->send();
     }
 
     $db = DB::getInstance();
@@ -91,7 +93,7 @@ try {
         ->withLogging(
             $logUserId,
             LogCategories::LOG_CATEGORY_SYSTEM_ERROR,
-            'Chassis check error: ' . $e->getMessage()
+            'Chassis check error [' . get_class($e) . ']: ' . $e->getMessage()
         )
         ->send();
 }

--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -59,7 +59,7 @@ try {
     }
 
     try {
-        [, , $type] = CarValidator::parseModel($model);
+        [, , $type] = CarValidator::parseModel($model); // $series/$variant not needed for this query
     } catch (CarValidationException $e) {
         ApiResponse::error('Invalid model format', 400)
             ->withLogging($logUserId, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'chassis-availability: invalid model string from user ' . $logUserId . ': ' . $model)

--- a/app/api/cars/chassis-availability.php
+++ b/app/api/cars/chassis-availability.php
@@ -17,6 +17,8 @@ require_once '../../../users/init.php';
 use ElanRegistry\ApiResponse;
 use ElanRegistry\Input;
 use ElanRegistry\LogCategories;
+use ElanRegistry\Car\CarValidator;
+use ElanRegistry\Exceptions\CarValidationException;
 
 if (!Input::existsPost()) {
     ApiResponse::error('No data received', 400)->send();
@@ -56,12 +58,11 @@ try {
         ApiResponse::error('Model must be 30 characters or less', 400)->send();
     }
 
-    $modelParts = explode('|', $model);
-    if (count($modelParts) !== 3) {
+    try {
+        [, , $type] = CarValidator::parseModel($model);
+    } catch (CarValidationException $e) {
         ApiResponse::error('Invalid model format', 400)->send();
     }
-
-    list($series, $variant, $type) = $modelParts;
 
     $db = DB::getInstance();
     $carQ = $db->query(

--- a/app/api/cars/save.php
+++ b/app/api/cars/save.php
@@ -443,7 +443,7 @@ function updateYear(array &$cardetails, array &$errors): void
  */
 function updateModel(array &$cardetails, array &$errors): void
 {
-    global $successes;
+    global $successes, $user;
 
     $model = Input::raw('model');
     if ($model !== null && $model !== '') {
@@ -452,6 +452,7 @@ function updateModel(array &$cardetails, array &$errors): void
             [$cardetails['series'], $cardetails['variant'], $cardetails['type']] = CarValidator::parseModel($cardetails['model']);
         } catch (CarValidationException $e) {
             $errors[] = 'Invalid model format — please select a model from the dropdown';
+            logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'updateModel: invalid model string: "' . htmlspecialchars($model, ENT_QUOTES, 'UTF-8') . '": ' . $e->getMessage());
             return;
         }
 

--- a/app/api/cars/save.php
+++ b/app/api/cars/save.php
@@ -452,7 +452,7 @@ function updateModel(array &$cardetails, array &$errors): void
             [$cardetails['series'], $cardetails['variant'], $cardetails['type']] = CarValidator::parseModel($cardetails['model']);
         } catch (CarValidationException $e) {
             $errors[] = 'Invalid model format — please select a model from the dropdown';
-            logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'updateModel: invalid model string: "' . htmlspecialchars($model, ENT_QUOTES, 'UTF-8') . '": ' . $e->getMessage());
+            logger((int)$user->data()->id, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'updateModel: invalid model string: "' . $model . '": ' . $e->getMessage());
             return;
         }
 

--- a/app/api/cars/save.php
+++ b/app/api/cars/save.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use ElanRegistry\ApiResponse;
 use ElanRegistry\Car\Car;
 use ElanRegistry\Car\CarImageProcessor;
+use ElanRegistry\Car\CarValidator;
 use ElanRegistry\ChassisValidator;
 use ElanRegistry\Exceptions\CarConcurrentModificationException;
 use ElanRegistry\Exceptions\CarDatabaseException;
@@ -447,12 +448,12 @@ function updateModel(array &$cardetails, array &$errors): void
     $model = Input::raw('model');
     if ($model !== null && $model !== '') {
         $cardetails['model'] = $model;
-        $modelParts = explode('|', $cardetails['model']);
-        if (count($modelParts) !== 3) {
+        try {
+            [$cardetails['series'], $cardetails['variant'], $cardetails['type']] = CarValidator::parseModel($cardetails['model']);
+        } catch (CarValidationException $e) {
             $errors[] = 'Invalid model format — please select a model from the dropdown';
             return;
         }
-        [$cardetails['series'], $cardetails['variant'], $cardetails['type']] = $modelParts;
 
         $successes[] = 'Model: ' . htmlspecialchars($model, ENT_QUOTES, 'UTF-8');
     } else {
@@ -1107,30 +1108,23 @@ function getMimeType(string $file): string
  *
  * @param array $file File upload array from $_FILES
  * @param int $maxSize Maximum file size in bytes (default 5MB)
- * @return bool Always returns true if validation passes
  * @throws ImageProcessingException If validation fails
  */
-function validateFileUpload(array $file, int $maxSize = 5242880): bool // Default 5MB
+function validateFileUpload(array $file, int $maxSize = 5242880): void // Default 5MB
 {
-    // Check for upload errors
     if ($file['error'] !== UPLOAD_ERR_OK) {
         throw new ImageProcessingException("File upload error: " . $file['error']);
     }
 
-    // Check file size (default 5MB limit)
     if ($file['size'] > $maxSize) {
         throw new ImageProcessingException("File too large. Maximum size: " . ($maxSize / 1024 / 1024) . "MB");
     }
 
-    // Verify the file was actually uploaded via HTTP POST
     if (!is_uploaded_file($file['tmp_name'])) {
         throw new ImageProcessingException("Invalid file upload");
     }
 
-    // Additional security: Check for minimum file size (avoid empty files)
     if ($file['size'] < 100) {
         throw new ImageProcessingException("File too small - minimum 100 bytes required");
     }
-
-    return true;
 }

--- a/app/api/cars/transfer-request.php
+++ b/app/api/cars/transfer-request.php
@@ -75,7 +75,7 @@ try {
     try {
         [$series, $variant, $type] = CarValidator::parseModel($model);
     } catch (CarValidationException $e) {
-        throw new CarTransferException('Invalid model format');
+        throw new CarTransferException('Invalid model format: ' . $model, 0, $e);
     }
 
     // Validate model-derived field lengths against DB column widths

--- a/app/api/cars/transfer-request.php
+++ b/app/api/cars/transfer-request.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use ElanRegistry\ApiResponse;
 use ElanRegistry\Exceptions\CarTransferException;
 use ElanRegistry\Input;
+use ElanRegistry\Car\CarValidator;
+use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Transfer\CarTransferRepository;
 use ElanRegistry\Transfer\TransferEmailService;
@@ -70,14 +72,11 @@ try {
     }
 
     // Parse model to get series, variant, type
-    $modelParts = explode('|', $model);
-    if (count($modelParts) !== 3) {
+    try {
+        [$series, $variant, $type] = CarValidator::parseModel($model);
+    } catch (CarValidationException $e) {
         throw new CarTransferException('Invalid model format');
     }
-
-    $series = $modelParts[0];
-    $variant = $modelParts[1];
-    $type = $modelParts[2];
 
     // Validate model-derived field lengths against DB column widths
     if (strlen($model) > 30) {
@@ -131,7 +130,7 @@ try {
 
     $fields = [
         'existing_car_id' => $existingCar->id,
-        'requested_by_user_id' => $user->data()->id,
+        'requested_by_user_id' => $userData->id,
         'security_token' => $securityToken,
         'expires_at' => $expiresAt,
         'submitted_model' => $model,
@@ -149,12 +148,12 @@ try {
         'submitted_city' => $userData->city ?? '',
         'submitted_state' => $userData->state ?? '',
         'submitted_country' => $userData->country ?? '',
-        'created_by' => $user->data()->id,
+        'created_by' => $userData->id,
     ];
 
     $transferRequestId = $repo->create($fields);
 
-    logger($user->data()->id, LogCategories::LOG_CATEGORY_CAR_TRANSFER, "Transfer request created for car ID {$existingCar->id}, chassis {$chassis}, transfer request ID: {$transferRequestId}");
+    logger($userData->id, LogCategories::LOG_CATEGORY_CAR_TRANSFER, "Transfer request created for car ID {$existingCar->id}, chassis {$chassis}, transfer request ID: {$transferRequestId}");
 
     // Send email notifications with timeout protection
     try {
@@ -167,29 +166,29 @@ try {
         try {
             $ownerNotified = $emailService->sendRequest($transferRequestId);
             if (!$ownerNotified) {
-                logger($user->data()->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Owner notification failed for transfer request #$transferRequestId — owner may not be aware of this request");
+                logger($userData->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Owner notification failed for transfer request #$transferRequestId — owner may not be aware of this request");
             }
         } catch (\Throwable $emailEx) {
-            logger($user->data()->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Unexpected exception sending owner notification for request #$transferRequestId: " . $emailEx->getMessage());
+            logger($userData->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Unexpected exception sending owner notification for request #$transferRequestId: " . $emailEx->getMessage());
         }
 
         // Send alert to administrators with error handling
         try {
             $adminNotified = $emailService->sendAdminAlert($transferRequestId);
             if (!$adminNotified) {
-                logger($user->data()->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Admin alert failed for transfer request #$transferRequestId");
+                logger($userData->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Admin alert failed for transfer request #$transferRequestId");
             }
         } catch (\Throwable $emailEx) {
-            logger($user->data()->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Unexpected exception sending admin alert for request #$transferRequestId: " . $emailEx->getMessage());
+            logger($userData->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "Unexpected exception sending admin alert for request #$transferRequestId: " . $emailEx->getMessage());
         }
 
     } catch (\Throwable $generalEmailEx) {
-        logger($user->data()->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "General email error for request #$transferRequestId: " . $generalEmailEx->getMessage());
+        logger($userData->id, LogCategories::LOG_CATEGORY_EMAIL_ERROR, "General email error for request #$transferRequestId: " . $generalEmailEx->getMessage());
     }
 
     ApiResponse::success('Transfer request submitted successfully.')
         ->withData('transfer_request_id', $transferRequestId)
-        ->withLogging($user->data()->id, LogCategories::LOG_CATEGORY_CAR_TRANSFER, "Transfer request submitted for car ID {$existingCar->id}")
+        ->withLogging($userData->id, LogCategories::LOG_CATEGORY_CAR_TRANSFER, "Transfer request submitted for car ID {$existingCar->id}")
         ->send();
 
 } catch (CarTransferException $e) {

--- a/docs/releases/RELEASE_NOTES_v2.28.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.28.0.md
@@ -1,0 +1,29 @@
+# Elan Registry v2.28.0 Release Notes
+
+**Release Date:** [DATE]
+**Type:** Minor Release — Injection & Dead-Code Foundation
+
+## Required Actions After Deployment
+
+None.
+
+## User-Facing Changes
+
+None — this release contains internal refactoring only.
+
+## Admin-Facing Changes
+
+### Bug Fixes
+
+- **Malformed model string now rejected cleanly** (#1286): A pipe-delimited model string with missing or empty segments (e.g. `||`) now returns a structured validation error instead of silently proceeding with empty series/variant/type values.
+
+## Issues Resolved
+
+- [#1145](https://github.com/elan-registry/registry/issues/1145) — Decouple Car class from global $user dependency
+- [#1239](https://github.com/elan-registry/registry/issues/1239) — refactor: fix Owner class coupling — remove CSRF from domain methods, fix static $db bypass in searchOwners()
+- [#1244](https://github.com/elan-registry/registry/issues/1244) — refactor: inject CarRepository into CarVerificationManager and CarImageProcessor constructors
+- [#1246](https://github.com/elan-registry/registry/issues/1246) — refactor: eliminate CarErrorMessages and FactoryDataFormatter — consolidate dead utility classes
+- [#1286](https://github.com/elan-registry/registry/issues/1286) — refactor: add CarValidator::parseModel() to consolidate pipe-split model string parsing
+- [#1318](https://github.com/elan-registry/registry/issues/1318) — tech-debt: typed exceptions in CarTransferRepository + dead-code and error-hygiene cleanup
+- [#1346](https://github.com/elan-registry/registry/issues/1346) — refactor: replace ob_start/include template rendering in TransferEmailService with EmailTemplate
+- [#1366](https://github.com/elan-registry/registry/issues/1366) — fix: update LogCategoriesUsageTest to use admin-core.js after manage-consolidated.js rename

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -737,8 +737,9 @@ final class CarValidatorTest extends TestCase
     public static function validModelStringProvider(): array
     {
         return [
-            'well-formed'       => ['S1|SE|65',       ['S1', 'SE', '65']],
-            'whitespace-padded' => [' S1 | SE | 65 ', ['S1', 'SE', '65']],
+            'well-formed'            => ['S1|SE|65',            ['S1', 'SE', '65']],
+            'whitespace-padded'      => [' S1 | SE | 65 ',     ['S1', 'SE', '65']],
+            'internal spaces kept'   => ['S1|Race Prep|65',    ['S1', 'Race Prep', '65']],
         ];
     }
 

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -716,4 +716,51 @@ final class CarValidatorTest extends TestCase
 
         $this->validator->validateAndSanitizeFields($data, true);
     }
+
+    // ============================================================
+    // parseModel() — static pipe-delimited string parser
+    // ============================================================
+
+    /**
+     * @param array{0: string, 1: string, 2: string} $expected
+     */
+    #[DataProvider('validModelStringProvider')]
+    public function testParseModelReturnsCorrectComponents(string $model, array $expected): void
+    {
+        $result = CarValidator::parseModel($model);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: array{0: string, 1: string, 2: string}}>
+     */
+    public static function validModelStringProvider(): array
+    {
+        return [
+            'well-formed'       => ['S1|SE|65',       ['S1', 'SE', '65']],
+            'whitespace-padded' => [' S1 | SE | 65 ', ['S1', 'SE', '65']],
+        ];
+    }
+
+    #[DataProvider('invalidModelStringProvider')]
+    public function testParseModelThrowsOnInvalidFormat(string $model): void
+    {
+        $this->expectException(CarValidationException::class);
+        $this->expectExceptionMessage('Invalid model format');
+        CarValidator::parseModel($model);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function invalidModelStringProvider(): array
+    {
+        return [
+            'single segment (no pipes)'  => ['S1'],
+            'too many pipes'             => ['S1|SE|65|extra'],
+            'empty string'               => [''],
+            'all empty segments (||)'    => ['||'],
+            'whitespace-only segments'   => [' | | '],
+        ];
+    }
 }

--- a/tests/unit/security/ChassisValidatorXssTest.php
+++ b/tests/unit/security/ChassisValidatorXssTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\Attributes\Group;
  * Because this guard executes before the override branch, $allowOverride=true
  * cannot bypass it. Tests 1–5 confirm rejection. Tests 6–8 confirm that
  * legitimate Lotus Elan formats still pass through the allowlist unharmed.
+ * Test 9 covers the parseModel() early-return path added in #1286.
  *
  * @see usersc/classes/ChassisValidator.php
  */
@@ -220,7 +221,7 @@ final class ChassisValidatorXssTest extends TestCase
     /**
      * A chassis submitted with a model string that does not contain two pipe
      * delimiters (e.g. "MALFORMED") triggers the parseModel() early-return path
-     * added in #1304 and must be rejected with an "Invalid model format" reason.
+     * added in #1286 and must be rejected with an "Invalid model format" reason.
      *
      * The chassis itself ("1234") passes the character allowlist, so only the
      * model-format guard can produce this result.

--- a/tests/unit/security/ChassisValidatorXssTest.php
+++ b/tests/unit/security/ChassisValidatorXssTest.php
@@ -212,4 +212,24 @@ final class ChassisValidatorXssTest extends TestCase
         $this->assertTrue($result['override_used']);
         $this->assertStringNotContainsString('invalid characters', $result['error_reason']);
     }
+
+    // -------------------------------------------------------------------------
+    // Malformed model string — early-return path
+    // -------------------------------------------------------------------------
+
+    /**
+     * A chassis submitted with a model string that does not contain two pipe
+     * delimiters (e.g. "MALFORMED") triggers the parseModel() early-return path
+     * added in #1304 and must be rejected with an "Invalid model format" reason.
+     *
+     * The chassis itself ("1234") passes the character allowlist, so only the
+     * model-format guard can produce this result.
+     */
+    public function testMalformedModelStringFailsValidation(): void
+    {
+        $result = (new \ElanRegistry\ChassisValidator())->validate('1234', 1966, 'MALFORMED', false);
+
+        $this->assertFalse($result['valid']);
+        $this->assertStringContainsString('Invalid model format', $result['error_reason']);
+    }
 }

--- a/tests/unit/uploads/FileUploadSecurityTest.php
+++ b/tests/unit/uploads/FileUploadSecurityTest.php
@@ -130,8 +130,8 @@ class FileUploadSecurityTest extends TestCase
             'tmp_name' => $this->createTestFile('valid.jpg', str_repeat('x', 1024 * 1024))
         ];
         
-        $this->assertTrue(validateFileUpload($validFile));
-        
+        validateFileUpload($validFile); // void — success means no exception thrown
+
         // Test file exceeding size limit
         $largeFile = [
             'error' => UPLOAD_ERR_OK,

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -28,7 +28,8 @@ class CarValidator
      *
      * @param string $model A string in "series|variant|type" format.
      * @return array{0: string, 1: string, 2: string} [$series, $variant, $type]
-     * @throws CarValidationException If the string does not contain exactly two pipe separators.
+     * @throws CarValidationException If the string does not contain exactly two pipe separators,
+     *                                or if any of the three resulting components is empty or whitespace-only.
      */
     public static function parseModel(string $model): array
     {

--- a/usersc/classes/Car/CarValidator.php
+++ b/usersc/classes/Car/CarValidator.php
@@ -24,6 +24,26 @@ class CarValidator
     public const MIN_CAR_DATE = '1957-01-01';
 
     /**
+     * Parse a pipe-delimited model string into its three components.
+     *
+     * @param string $model A string in "series|variant|type" format.
+     * @return array{0: string, 1: string, 2: string} [$series, $variant, $type]
+     * @throws CarValidationException If the string does not contain exactly two pipe separators.
+     */
+    public static function parseModel(string $model): array
+    {
+        $parts = explode('|', $model);
+        if (count($parts) !== 3) {
+            throw new CarValidationException('Invalid model format. Expected format: series|variant|type');
+        }
+        $trimmed = [trim($parts[0]), trim($parts[1]), trim($parts[2])];
+        if ($trimmed[0] === '' || $trimmed[1] === '' || $trimmed[2] === '') {
+            throw new CarValidationException('Invalid model format. Expected format: series|variant|type');
+        }
+        return $trimmed;
+    }
+
+    /**
      * Validate that required fields are present and not empty
      *
      * @param array<string, mixed> $fields Fields to validate
@@ -67,25 +87,10 @@ class CarValidator
 
                 case 'model':
                     if (!empty($value)) {
-                        // Sanitize input
                         $validatedFields[$key] = InputSanitizer::normalize($value, 100);
 
-                        // Validate format: "series|variant|type"
-                        $parts = explode('|', $validatedFields[$key]);
-                        if (count($parts) !== 3) {
-                            throw new CarValidationException(
-                                'Invalid model format. Expected format: series|variant|type'
-                            );
-                        }
+                        [$series, $variant, $type] = self::parseModel($validatedFields[$key]);
 
-                        list($series, $variant, $type) = $parts;
-
-                        // Trim whitespace
-                        $series = trim($series);
-                        $variant = trim($variant);
-                        $type = trim($type);
-
-                        // Validate model combination exists in car_models table
                         $carModelRef = new CarModel();
                         if (!$carModelRef->exists($series, $variant, $type)) {
                             throw new CarValidationException(
@@ -93,7 +98,6 @@ class CarValidator
                             );
                         }
 
-                        // Store validated model
                         $validatedFields[$key] = "{$series}|{$variant}|{$type}";
 
                     } elseif ($requireAll) {

--- a/usersc/classes/ChassisValidator.php
+++ b/usersc/classes/ChassisValidator.php
@@ -82,7 +82,7 @@ class ChassisValidator
         
         // Parse model components
         try {
-            [$series, $variant, $type] = CarValidator::parseModel($model);
+            [$series, $variant] = CarValidator::parseModel($model);
         } catch (CarValidationException $e) {
             $this->result['error_reason'] = 'Invalid model format';
             return $this->result;

--- a/usersc/classes/ChassisValidator.php
+++ b/usersc/classes/ChassisValidator.php
@@ -15,8 +15,6 @@ use ElanRegistry\Exceptions\CarValidationException;
  * including historical race car formats and production car evolution from 1963-1974.
  * 
  * @author Elan Registry Team
- * @copyright 2025
- * @version 1.0
  */
 
 class ChassisValidator 

--- a/usersc/classes/ChassisValidator.php
+++ b/usersc/classes/ChassisValidator.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace ElanRegistry;
 
-use Exception;
+use ElanRegistry\Car\CarValidator;
+use ElanRegistry\Exceptions\CarValidationException;
 
 /**
  * ChassisValidator.php
@@ -24,7 +25,7 @@ class ChassisValidator
      * Validation result structure
      * @var array{valid: bool, chassis: string, error_reason: string, format_type: string, override_used: bool}
      */
-    private $result = [
+    private array $result = [
         'valid' => false,
         'chassis' => '',
         'error_reason' => '',
@@ -32,19 +33,13 @@ class ChassisValidator
         'override_used' => false
     ];
 
-    /**
-     * Valid letter codes for different model types
-     * @var array
-     */
+    /** Valid letter codes for different model types */
     private const LETTER_CODES = [
         'elan' => ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K'], // Excluding I
         'plus2' => ['L', 'M', 'N']
     ];
 
-    /**
-     * Race car patterns by year
-     * @var array
-     */
+    /** Race car patterns by year */
     private const RACE_PATTERNS = [
         1963 => ['/^26-R-\d{2}$/'],
         1964 => ['/^26-R-\d{2}$/', '/^26-S2-\d{2}$/'],
@@ -88,20 +83,18 @@ class ChassisValidator
         $chassisLength = strlen($this->result['chassis']);
         
         // Parse model components
-        $modelParts = explode('|', $model);
-        $series = $modelParts[0] ?? '';
-        $variant = $modelParts[1] ?? '';
-        $type = $modelParts[2] ?? '';
-
         try {
-            // Validate based on variant (Race vs Production)
-            if (stripos($variant, 'Race') !== false) {
-                $this->validateRaceCar($this->result['chassis'], $year);
-            } else {
-                $this->validateProductionCar($this->result['chassis'], $year, $series, $chassisLength);
-            }
-        } catch (Exception $e) {
-            $this->result['error_reason'] = $e->getMessage();
+            [$series, $variant, $type] = CarValidator::parseModel($model);
+        } catch (CarValidationException $e) {
+            $this->result['error_reason'] = 'Invalid model format';
+            return $this->result;
+        }
+
+        // Validate based on variant (Race vs Production)
+        if (stripos($variant, 'Race') !== false) {
+            $this->validateRaceCar($this->result['chassis'], $year);
+        } else {
+            $this->validateProductionCar($this->result['chassis'], $year, $series, $chassisLength);
         }
 
         // Handle override if validation failed but override is allowed
@@ -115,12 +108,11 @@ class ChassisValidator
 
     /**
      * Validate race car chassis numbers
-     * 
+     *
      * @param string $chassis
      * @param int $year
-     * @throws Exception
      */
-    private function validateRaceCar(string $chassis, int $year): void 
+    private function validateRaceCar(string $chassis, int $year): void
     {
         $this->result['format_type'] = 'race';
         
@@ -133,34 +125,23 @@ class ChassisValidator
             }
         }
 
-        // Generate specific error message based on year
-        switch ($year) {
-            case 1963:
-                $this->result['error_reason'] = '1963 race cars must use format 26-R-xx (e.g., 26-R-01)';
-                break;
-            case 1964:
-                $this->result['error_reason'] = '1964 race cars must use format 26-R-xx or 26-S2-xx (e.g., 26-R-01 or 26-S2-01)';
-                break;
-            case 1965:
-            case 1966:
-                $this->result['error_reason'] = $year . ' race cars must use format 26-S2-xx (e.g., 26-S2-01)';
-                break;
-            default:
-                $this->result['error_reason'] = $year . ' race cars must use format 26-R-xx (e.g., 26-R-01)';
-                break;
-        }
+        $this->result['error_reason'] = match ($year) {
+            1963       => '1963 race cars must use format 26-R-xx (e.g., 26-R-01)',
+            1964       => '1964 race cars must use format 26-R-xx or 26-S2-xx (e.g., 26-R-01 or 26-S2-01)',
+            1965, 1966 => "{$year} race cars must use format 26-S2-xx (e.g., 26-S2-01)",
+            default    => "{$year} race cars must use format 26-R-xx (e.g., 26-R-01)",
+        };
     }
 
     /**
      * Validate production car chassis numbers
-     * 
+     *
      * @param string $chassis
      * @param int $year
      * @param string $series
      * @param int $chassisLength
-     * @throws Exception
      */
-    private function validateProductionCar(string $chassis, int $year, string $series, int $chassisLength): void 
+    private function validateProductionCar(string $chassis, int $year, string $series, int $chassisLength): void
     {
         if ($year < 1970) {
             $this->validatePre1970($chassis, $chassisLength);
@@ -285,13 +266,13 @@ class ChassisValidator
                 'type' => '+2',
                 'description' => 'L, M, N'
             ];
-        } else {
-            return [
-                'codes' => self::LETTER_CODES['elan'],
-                'type' => 'Elan',
-                'description' => 'A-K (excluding I)'
-            ];
         }
+
+        return [
+            'codes' => self::LETTER_CODES['elan'],
+            'type' => 'Elan',
+            'description' => 'A-K (excluding I)'
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds `CarValidator::parseModel(string $model): array` — a single static method that owns all pipe-delimited model string parsing. Throws `CarValidationException` on wrong pipe count or empty/whitespace-only segments.
- Replaces four independent `explode('|', $model)` + count-check patterns across `ChassisValidator`, `chassis-availability.php`, `transfer-request.php`, and `save.php::updateModel()`.
- Tightens the `ChassisValidator` model-parse path: previously empty segments (`||`) silently reached DB queries with empty `series`/`variant`/`type`; now rejected cleanly.
- Simplifies `ChassisValidator`: typed `$result` property, `match` replaces `switch` in `validateRaceCar()`, dead outer `try/catch(Exception)` removed, `getValidSuffixes()` flattened.

## Bug fix

**Malformed model string now rejected cleanly (#1286):** A pipe-delimited model string with missing or empty segments (e.g. `||`) now returns a structured validation error instead of silently proceeding with empty `series`/`variant`/`type` values.

## Test plan

- [ ] `CarValidatorTest` — 7 new `parseModel()` data-provider cases covering well-formed, whitespace-padded, no-pipes, too-many-pipes, empty string, `||`, and whitespace-only segments
- [ ] `ChassisValidatorXssTest` — 1 new test (`testMalformedModelStringFailsValidation`) covering the early-return path
- [ ] `FileUploadSecurityTest` — removed misleading `assertTrue()` on `void` function
- [ ] `composer test:quick` — 1246 passing, 1 skipped (pre-existing #1366)
- [ ] PHPStan — no errors on all 5 changed PHP files

Closes #1286

https://claude.ai/code/session_01RRNUqYWgZRZaWGv5qVBxkZ