### PR TITLE
refactor: remove CSRF from Owner domain methods, fix static $db bypass in searchOwners()

### DIFF
--- a/app/admin/includes/process-owner-search.php
+++ b/app/admin/includes/process-owner-search.php
@@ -29,7 +29,7 @@ if (strlen($query) > 100) {
 }
 
 try {
-    $searchResults = Owner::searchOwners($query, 25);
+    $searchResults = (new Owner())->searchOwners($query, 25);
 
     // Enhance results with data quality scoring
     $enhancedResults = [];

--- a/app/admin/includes/process-owner-update.php
+++ b/app/admin/includes/process-owner-update.php
@@ -38,7 +38,6 @@ try {
     // Prepare update fields
     $updateFields = [
         'id' => $ownerId,
-        'csrf' => $_POST['csrf']
     ];
 
     // Text fields: basic info and location (coordinates handled separately below)

--- a/docs/development/CLASSES.md
+++ b/docs/development/CLASSES.md
@@ -288,8 +288,7 @@ $owner->update([
     'id' => $userId,
     'city' => 'Portland',
     'state' => 'Oregon',
-    'country' => 'United States',
-    'csrf' => Token::generate()
+    'country' => 'United States'
 ]);
 // Note: Pass lat/lon explicitly; coordinates are not auto-populated server-side
 
@@ -297,7 +296,7 @@ $owner->update([
 $score = $owner->getProfileQualityScore(); // Returns 0-100
 
 // Search owners (admin function)
-$results = Owner::searchOwners('Portland');
+$results = (new Owner())->searchOwners('Portland');
 ```
 
 **Database Tables**:
@@ -802,9 +801,9 @@ class MyDomainClass {
     }
 
     // Update existing record
+    // CSRF is validated by the caller (HTTP layer) before update() is called
     public function update(array $fields): bool {
         // Validation
-        // CSRF check
         // Database update
         // Audit logging
         return true;

--- a/tests/integration/OwnerIntegrationTest.php
+++ b/tests/integration/OwnerIntegrationTest.php
@@ -290,11 +290,9 @@ class OwnerIntegrationTest extends IntegrationTestCase
         ]);
         $this->assertTrue((bool) $insertResult, 'Test fixture: profiles insert must succeed');
         try {
-            $csrf = Token::generate();
             $owner = new Owner($userId);
             $owner->update([
                 'id' => $userId,
-                'csrf' => $csrf,
                 'lat' => '0',
                 'lon' => '0',
             ]);
@@ -418,11 +416,9 @@ class OwnerIntegrationTest extends IntegrationTestCase
         try {
             $before = $this->db->query("SELECT active, permissions FROM users WHERE id = ?", [$userId])
                 ->first();
-            $csrf = \Token::generate();
             $owner = new Owner($userId);
             $owner->update([
                 'id'          => $userId,
-                'csrf'        => $csrf,
                 'active'      => '0',
                 'permissions' => '3',
                 'city'        => 'AfterCity',
@@ -452,11 +448,9 @@ class OwnerIntegrationTest extends IntegrationTestCase
             'lat' => 0.0, 'lon' => 0.0,
         ]);
         try {
-            $csrf = \Token::generate();
             $owner = new Owner($userId);
             $owner->update([
                 'id'     => $userId,
-                'csrf'   => $csrf,
                 'active' => '1',
                 'city'   => 'AfterCity',
             ]);

--- a/tests/unit/Owner/OwnerSearchTest.php
+++ b/tests/unit/Owner/OwnerSearchTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use ElanRegistry\Exceptions\OwnerSearchException;
+use ElanRegistry\Owner;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('fast')]
+#[Group('unit')]
+#[Group('owner')]
+final class OwnerSearchTest extends TestCase
+{
+    private function createMockDb(int $rowCount = 0, bool $hasError = false, array $rows = []): object
+    {
+        return new class($rowCount, $hasError, $rows) {
+            public function __construct(
+                private int $rowCount,
+                private bool $hasError,
+                private array $rows,
+            ) {}
+
+            public function query(string $sql, array $params = []): object
+            {
+                $count = $this->rowCount;
+                $rows  = $this->rows;
+                return new class($count, $rows) {
+                    public function __construct(
+                        private int $count,
+                        private array $rows,
+                    ) {}
+                    public function count(): int { return $this->count; }
+                    public function results(): array { return $this->rows; }
+                };
+            }
+
+            public function error(): bool { return $this->hasError; }
+            public function errorString(): string { return 'mock error'; }
+        };
+    }
+
+    public function testSearchOwnersReturnsEmptyArrayWhenNoResults(): void
+    {
+        $db      = $this->createMockDb(0);
+        $owner   = new Owner(null, $db);
+        $results = $owner->searchOwners('Portland');
+
+        $this->assertSame([], $results);
+    }
+
+    public function testSearchOwnersReturnsResultsFromDb(): void
+    {
+        $row     = (object)['id' => 1, 'fname' => 'Alice', 'lname' => 'Smith'];
+        $db      = $this->createMockDb(1, false, [$row]);
+        $owner   = new Owner(null, $db);
+        $results = $owner->searchOwners('Alice');
+
+        $this->assertCount(1, $results);
+        $this->assertSame($row, $results[0]);
+    }
+
+    public function testSearchOwnersThrowsOnDbError(): void
+    {
+        $db    = $this->createMockDb(0, true);
+        $owner = new Owner(null, $db);
+
+        $this->expectException(OwnerSearchException::class);
+        $owner->searchOwners('Portland');
+    }
+}

--- a/usersc/classes/Owner.php
+++ b/usersc/classes/Owner.php
@@ -5,7 +5,6 @@ namespace ElanRegistry;
 
 use DB;
 use Exception;
-use Token;
 use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\OwnerCreationException;
 use ElanRegistry\Exceptions\OwnerSearchException;
@@ -129,17 +128,6 @@ class Owner
             );
         }
 
-        // CSRF Protection
-        if (!isset($fields['csrf']) || !Token::check($fields['csrf'])) {
-            throw OwnerCreationException::withUserMessage(
-                'Invalid CSRF token provided',
-                'Your session may have expired. Please refresh the page and try again.'
-            );
-        }
-
-        // Remove token from fields array after validation
-        unset($fields['csrf']);
-
         // Validate required fields for both user and profile
         $this->validateRequiredFields($fields, ['fname', 'lname', 'email']);
 
@@ -210,18 +198,6 @@ class Owner
                 'Unable to process update. Please try again.'
             );
         }
-
-        // CSRF Protection
-        if (!isset($fields['csrf']) || !Token::check($fields['csrf'])) {
-            logger($fields['id'] ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'Owner update failed: Invalid CSRF token');
-            throw OwnerValidationException::withUserMessage(
-                'Invalid CSRF token provided',
-                'Your session may have expired. Please refresh the page and try again.'
-            );
-        }
-
-        // Remove token from fields array after validation
-        unset($fields['csrf']);
 
         if (!is_numeric($fields['id']) || $fields['id'] <= 0) {
             throw OwnerValidationException::withUserMessage(
@@ -433,7 +409,7 @@ class Owner
      * @param int $limit Maximum number of results (default 50)
      * @return array Array of owner search results
      */
-    public static function searchOwners(string $searchTerm, int $limit = 50): array
+    public function searchOwners(string $searchTerm, int $limit = 50): array
     {
         $searchTerm = trim($searchTerm);
         if (empty($searchTerm)) {
@@ -512,7 +488,7 @@ class Owner
             }
         }
 
-        $db = DB::getInstance();
+        $db = $this->_db;
         $searchQuery = $db->query($sql, $params);
         if ($db->error()) {
             throw OwnerSearchException::withUserMessage(


### PR DESCRIPTION
## Summary

- Removes CSRF validation from `Owner::create()` and `Owner::update()` — CSRF is an HTTP-layer concern; domain methods should not validate it directly. Callers are responsible for CSRF checks before invoking these methods.
- Converts `Owner::searchOwners()` from `static` to instance method, replacing `DB::getInstance()` with the injected `$this->_db` connection.
- Updates callers (`process-owner-search.php`, `process-owner-update.php`) and integration tests to match the new signatures.
- Documents the CSRF delegation pattern in CLASSES.md.

## Test plan

- [ ] `composer test:medium` — OwnerIntegrationTest passes with csrf removed from fixtures
- [ ] New `tests/unit/Owner/OwnerSearchTest.php` unit tests pass
- [ ] Admin owner search and owner update flows work end-to-end

Closes #1239

https://claude.ai/code/session_01853Yjpu7YYthKNscqtAc6v