### PR TITLE
fix: .htaccess redirects, robots.txt crawl control, and test-subdomain blocking

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,7 +1,5 @@
-# Disable directory browsing for security
 Options -Indexes
 
-# Custom error pages
 ErrorDocument 400 /error/500.php
 ErrorDocument 401 /error/500.php
 ErrorDocument 403 /error/403.php
@@ -12,13 +10,11 @@ ErrorDocument 500 /error/500.php
 ErrorDocument 502 /error/500.php
 ErrorDocument 504 /error/500.php
 
-# Security headers
 Header always set X-Frame-Options "SAMEORIGIN"
 Header always set X-Content-Type-Options "nosniff"
 Header always set Referrer-Policy "strict-origin-when-cross-origin"
 Header always set Permissions-Policy "geolocation=(), camera=(), microphone=(), payment=()"
 
-# Deny access to sensitive files
 <Files "*.env*">
     Require all denied
 </Files>
@@ -68,27 +64,33 @@ Header always set Permissions-Policy "geolocation=(), camera=(), microphone=(), 
     Require all denied
 </LimitExcept>
 
-# Block access to sensitive directories using RewriteRule
 RewriteEngine On
 
-# Block access to backup directories
-RewriteRule ^@backup/ - [F,L]
-RewriteRule ^db-backups/ - [F,L]
-
-# Block access to node_modules
-RewriteRule ^node_modules/ - [F,L]
-
-# Block access to vendor directory from web
 RewriteRule ^vendor/ - [F,L]
+RewriteRule ^backups/ - [F,L]
 
-# Block access to test directories
-RewriteRule ^tests/ - [F,L]
+# Test subdomain: serve a blocking robots.txt without affecting production (#1369)
+RewriteCond %{HTTP_HOST} ^test\.elanregistry\.org [NC]
+RewriteRule ^robots\.txt$ /robots-test.txt [L]
 
-# Block access to SQL directory
-RewriteRule ^SQL/ - [F,L]
+# Soft 404 fix: embed.php (removed) and pdf-viewer.php single-param ?doc= format (#1369)
+# All referenced PDFs confirmed in docs/reference/assets/
+# NE preserves URL encoding in filenames with spaces/parens; QSD drops the original query string
+RewriteCond %{QUERY_STRING} ^doc=([^&]+\.pdf)$ [NC]
+RewriteRule ^docs/(embed|pdf-viewer)\.php$ /docs/pdf-viewer.php?subdir=reference/assets&doc=%1 [R=301,L,NE,QSD]
 
-# Block access to FIX directory except operational scripts (admin interface)
-RewriteRule ^FIX/(?!index\.php$|[0-9]+-.*\.php$|[A-Za-z]+-.*\.php$) - [F,L]
+# /stories/* moved to /docs/stories/ — redirect was missing until #1369
+RewriteRule ^stories/(.+)$ /docs/stories/$1 [R=301,L]
+
+# docs/view.php and docs/guide-viewer.php removed in #911
+RewriteCond %{QUERY_STRING} doc=IDENTIFICATION_GUIDE\.md [NC]
+RewriteRule ^docs/view\.php$ /docs/reference/identification-guide.php [R=301,L,QSD]
+
+RewriteCond %{QUERY_STRING} doc=CAR_TRANSFER_FAQ\.md [NC]
+RewriteRule ^docs/(view|guide-viewer)\.php$ /docs/guides/car-transfer-faq.php [R=301,L,QSD]
+
+RewriteCond %{QUERY_STRING} doc=CAR_TRANSFER_USER_GUIDE\.md [NC]
+RewriteRule ^docs/guide-viewer\.php$ /docs/guides/ [R=301,L,QSD]
 
 # Redirects for migrated pages (#559)
 Redirect 301 /app/cars/identify.php /docs/reference/identification-guide.php
@@ -105,3 +107,15 @@ Redirect 301 /app/contact/index.php /app/owner/contact/index.php
 Redirect 301 /app/contact/owner.php /app/owner/contact/owner.php
 Redirect 301 /app/reports/statistics.php /app/owner/reports/statistics.php
 Redirect 301 /app/privacy.php /app/owner/privacy.php
+
+# Legacy paths — GSC 404 cleanup (#1369)
+# /app/car_details.php preserves ?car_id=N automatically via mod_alias
+Redirect 301 /app/car_details.php /app/owner/cars/details.php
+Redirect 301 /app/identification.php /docs/reference/identification-guide.php
+Redirect 301 /app/list_cars.php /app/owner/cars/index.php
+Redirect 301 /list_cars.php /app/owner/cars/index.php
+Redirect 301 /guide.php /docs/
+# @slug: /app/cars/ prefix redirect fires first → /app/owner/cars/@the_elan_sprint_diary → this rule
+Redirect 301 /app/owner/cars/@the_elan_sprint_diary /docs/car-stories.php
+# Duplicate PDF path: /docs/assets/ renamed to /docs/reference/assets/ in #715
+Redirect 301 /docs/assets/ /docs/reference/assets/

--- a/docs/releases/RELEASE_NOTES_v2.28.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.28.0.md
@@ -9,7 +9,10 @@ None.
 
 ## User-Facing Changes
 
-None — this release contains internal refactoring only.
+### SEO & Search Indexing
+
+- **Legacy URL redirects** (#1369): 34 URLs that were returning 404 or soft 404 in Google Search Console now redirect correctly to their current locations. Covers: old `docs/embed.php` and single-parameter `docs/pdf-viewer.php` links, the `/stories/` → `/docs/stories/` migration, retired doc viewer query-string URLs, and pre-migration app paths including `/app/car_details.php`, `/list_cars.php`, and `/guide.php`. Also fixes the "Duplicate Engine number PDF" GSC issue (`/docs/assets/` → `/docs/reference/assets/`).
+- **Crawl control** (#1369): Login-required pages (`/app/owner/cars/edit.php`, `/app/owner/contact/`) added to `robots.txt` so Google stops crawling and wasting crawl budget on pages that redirect to the login form. Test subdomain (`test.elanregistry.org`) now blocked from all crawlers via its own `robots.txt`.
 
 ## Admin-Facing Changes
 
@@ -27,3 +30,4 @@ None — this release contains internal refactoring only.
 - [#1318](https://github.com/elan-registry/registry/issues/1318) — tech-debt: typed exceptions in CarTransferRepository + dead-code and error-hygiene cleanup
 - [#1346](https://github.com/elan-registry/registry/issues/1346) — refactor: replace ob_start/include template rendering in TransferEmailService with EmailTemplate
 - [#1366](https://github.com/elan-registry/registry/issues/1366) — fix: update LogCategoriesUsageTest to use admin-core.js after manage-consolidated.js rename
+- [#1369](https://github.com/elan-registry/registry/issues/1369) — fix: .htaccess and robots.txt — redirects, crawl control, and test subdomain blocking

--- a/robots-test.txt
+++ b/robots-test.txt
@@ -1,0 +1,3 @@
+# Block all crawlers from the test subdomain
+User-agent: *
+Disallow: /

--- a/robots.txt
+++ b/robots.txt
@@ -6,11 +6,11 @@ User-agent: *
 Disallow: /users/
 Disallow: /usersc/
 Disallow: /app/admin/
-Disallow: /FIX/
 Disallow: /error/
 Disallow: /vendor/
-Disallow: /tests/
-Disallow: /scripts/
+# Login-required pages — redirect to login without authentication
+Disallow: /app/owner/cars/edit.php
+Disallow: /app/owner/contact/
 
 # Block AI training bots
 User-agent: GPTBot

--- a/tests/playwright/e2e/not-logged-in.spec.js
+++ b/tests/playwright/e2e/not-logged-in.spec.js
@@ -416,3 +416,96 @@ test.describe('Internal Links Discovery and Testing (Not Logged In)', () => {
     console.log(`Failed: ${failCount}`);
   });
 });
+
+test.describe('Redirect verification — GSC 404 and soft 404 cleanup (#1369)', () => {
+  test.beforeEach(async ({ }, testInfo) => {
+    if (testInfo.project.name !== 'not-logged-in') {
+      testInfo.skip();
+    }
+  });
+
+  const BASE = 'https://elanregistry.org';
+
+  const redirects = [
+    {
+      from: '/docs/embed.php?doc=Elan_26_36_Workshop_Manual.pdf',
+      to: '/docs/pdf-viewer.php?subdir=reference/assets&doc=Elan_26_36_Workshop_Manual.pdf',
+      label: 'embed.php soft 404 → pdf-viewer.php with subdir',
+    },
+    {
+      from: '/docs/pdf-viewer.php?doc=Elan_26_36_Workshop_Manual.pdf',
+      to: '/docs/pdf-viewer.php?subdir=reference/assets&doc=Elan_26_36_Workshop_Manual.pdf',
+      label: 'pdf-viewer.php single-param → two-param format',
+    },
+    {
+      from: '/stories/type26register.com/index.html',
+      to: '/docs/stories/type26register.com/index.html',
+      label: 'stories/* migration',
+    },
+    // Legacy doc viewer removed in #911
+    {
+      from: '/docs/view.php?doc=IDENTIFICATION_GUIDE.md',
+      to: '/docs/reference/identification-guide.php',
+      label: 'docs/view.php IDENTIFICATION_GUIDE.md',
+    },
+    {
+      from: '/docs/view.php?doc=CAR_TRANSFER_FAQ.md',
+      to: '/docs/guides/car-transfer-faq.php',
+      label: 'docs/view.php CAR_TRANSFER_FAQ.md',
+    },
+    {
+      from: '/docs/guide-viewer.php?doc=CAR_TRANSFER_FAQ.md',
+      to: '/docs/guides/car-transfer-faq.php',
+      label: 'docs/guide-viewer.php CAR_TRANSFER_FAQ.md',
+    },
+    {
+      from: '/docs/guide-viewer.php?doc=CAR_TRANSFER_USER_GUIDE.md',
+      to: '/docs/guides/',
+      label: 'docs/guide-viewer.php CAR_TRANSFER_USER_GUIDE.md',
+    },
+    {
+      from: '/app/car_details.php?car_id=100',
+      to: '/app/owner/cars/details.php?car_id=100',
+      label: '/app/car_details.php preserves car_id query string',
+    },
+    {
+      from: '/app/identification.php',
+      to: '/docs/reference/identification-guide.php',
+      label: '/app/identification.php legacy path',
+    },
+    {
+      from: '/app/list_cars.php',
+      to: '/app/owner/cars/index.php',
+      label: '/app/list_cars.php legacy path',
+    },
+    {
+      from: '/list_cars.php',
+      to: '/app/owner/cars/index.php',
+      label: '/list_cars.php root-level legacy path',
+    },
+    {
+      from: '/guide.php',
+      to: '/docs/',
+      label: '/guide.php legacy guide index',
+    },
+    // Duplicate PDF path: /docs/assets/ renamed to /docs/reference/assets/ in #715
+    {
+      from: '/docs/assets/Elan_26_36_Workshop_Manual.pdf',
+      to: '/docs/reference/assets/Elan_26_36_Workshop_Manual.pdf',
+      label: '/docs/assets/ → /docs/reference/assets/ (duplicate PDF path)',
+    },
+  ];
+
+  redirects.forEach(({ from, to, label }) => {
+    test(`301: ${label}`, async ({ request }) => {
+      const response = await request.get(`${BASE}${from}`, { maxRedirects: 0 });
+      expect(response.status(), `Expected 301 for ${from}`).toBe(301);
+      const location = response.headers()['location'] ?? '';
+      // Normalize absolute Location headers to path + query for comparison
+      const locationPath = location.startsWith('http')
+        ? new URL(location).pathname + new URL(location).search
+        : location;
+      expect(locationPath, `Expected Location: ${to} for ${from}`).toBe(to);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **301 redirects** for 13 URLs flagged in Google Search Console as 404 or soft 404: legacy `embed.php`/`pdf-viewer.php` single-param format, `/stories/*` → `/docs/stories/*` migration, retired doc viewer query-string paths (`view.php`, `guide-viewer.php`), and pre-migration app paths (`/app/car_details.php`, `/list_cars.php`, `/guide.php`, `/docs/assets/*`).
- **Test subdomain blocking**: `robots-test.txt` added; a `RewriteRule` intercepts `/robots.txt` requests from `test.elanregistry.org` and serves `Disallow: /` so the test site is never indexed.
- **robots.txt cleanup**: removed stale `Disallow` entries for directories deleted on deploy (`/FIX/`, `/tests/`, `/scripts/`); added login-required pages crawlers should skip.
- **`.htaccess` block rule cleanup**: removed 6 dead block rules for directories that do not exist on the production server (`@backup/`, `db-backups/`, `node_modules/`, `tests/`, `SQL/`, `FIX/`); added `backups/` block which exists on server but was previously unprotected.
- **Playwright e2e tests**: 13 redirect assertions verifying status 301 and `Location` header for every redirect added.

## Test plan

- [ ] `npm run test:e2e` — all 13 redirect tests pass against production
- [ ] `curl -I https://test.elanregistry.org/robots.txt` returns `Disallow: /`
- [ ] `curl -I https://elanregistry.org/robots.txt` returns normal robots.txt
- [ ] Spot-check a legacy path (e.g. `/app/car_details.php?car_id=100`) returns 301 to `/app/owner/cars/details.php?car_id=100`

Closes #1369
Closes #1370

https://claude.ai/code/session_01853Yjpu7YYthKNscqtAc6v