### PR TITLE
refactor: fix Owner class coupling — remove CSRF from domain methods, fix static $db bypass in searchOwners() (#1239)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -92,7 +92,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
+          # track_progress is unsupported for workflow_dispatch — disable it
+          # when this job is triggered on-demand (e.g. via /finish-issue).
+          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
           model: "claude-sonnet-5"
           claude_args: >-
             --allowedTools

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -92,9 +92,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # track_progress is unsupported for workflow_dispatch — disable it
-          # when this job is triggered on-demand (e.g. via /finish-issue).
-          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
+          track_progress: true
           model: "claude-sonnet-5"
           claude_args: >-
             --allowedTools

--- a/app/admin/includes/process-owner-search.php
+++ b/app/admin/includes/process-owner-search.php
@@ -57,7 +57,7 @@ try {
         ])
         ->withLogging(
             $user->data()->id,
-            'OwnerActions',
+            LogCategories::LOG_CATEGORY_OWNER_ACTIONS,
             "Owner search performed: '{$query}' - {$resultCount} results"
         )
         ->send();

--- a/app/admin/includes/process-owner-search.php
+++ b/app/admin/includes/process-owner-search.php
@@ -32,19 +32,19 @@ try {
     $searchResults = (new Owner())->searchOwners($query, 25);
 
     // Enhance results with data quality scoring
+    $esc = static fn(?string $v): string => htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8');
     $enhancedResults = [];
     foreach ($searchResults as $owner) {
         $qualityScore = Owner::qualityScoreFromRow($owner);
-
         $enhancedResults[] = [
-            'id' => (int)$owner->id,
-            'fname' => htmlspecialchars($owner->fname ?? '', ENT_QUOTES, 'UTF-8'),
-            'lname' => htmlspecialchars($owner->lname ?? '', ENT_QUOTES, 'UTF-8'),
-            'email' => htmlspecialchars($owner->email ?? '', ENT_QUOTES, 'UTF-8'),
-            'city' => htmlspecialchars($owner->city ?? '', ENT_QUOTES, 'UTF-8'),
-            'state' => htmlspecialchars($owner->state ?? '', ENT_QUOTES, 'UTF-8'),
-            'country' => htmlspecialchars($owner->country ?? '', ENT_QUOTES, 'UTF-8'),
-            'quality_score' => $qualityScore
+            'id'            => (int)$owner->id,
+            'fname'         => $esc($owner->fname),
+            'lname'         => $esc($owner->lname),
+            'email'         => $esc($owner->email),
+            'city'          => $esc($owner->city),
+            'state'         => $esc($owner->state),
+            'country'       => $esc($owner->country),
+            'quality_score' => $qualityScore,
         ];
     }
 

--- a/app/admin/includes/process-owner-search.php
+++ b/app/admin/includes/process-owner-search.php
@@ -29,7 +29,7 @@ if (strlen($query) > 100) {
 }
 
 try {
-    $searchResults = Owner::searchOwners($query, 25);
+    $searchResults = (new Owner())->searchOwners($query, 25);
 
     // Enhance results with data quality scoring
     $enhancedResults = [];

--- a/app/admin/includes/process-owner-update.php
+++ b/app/admin/includes/process-owner-update.php
@@ -53,36 +53,24 @@ try {
         $updateFields['lon'] = (float)$_POST['lon'];
     }
 
-    // Attempt to update owner profile
-    $success = $owner->update($updateFields);
+    // Attempt to update owner profile — throws OwnerValidationException or OwnerUpdateException on failure
+    $owner->update($updateFields);
 
-    if ($success) {
-        // Get updated data
-        $updatedOwner = new Owner($ownerId);
+    $updatedOwner = new Owner($ownerId);
+    $newQualityScore = $updatedOwner->getProfileQualityScore();
+    $missingFields = $updatedOwner->validateProfileCompleteness();
 
-        // Get updated quality score
-        $newQualityScore = $updatedOwner->getProfileQualityScore();
-        $missingFields = $updatedOwner->validateProfileCompleteness();
-
-        ApiResponse::success('Owner profile updated successfully!')
-            ->withDataArray([
-                'quality_score' => $newQualityScore,
-                'missing_fields' => $missingFields
-            ])
-            ->withLogging(
-                $user->data()->id,
-                'OwnerActions',
-                "Updated owner profile for user ID {$ownerId} (Admin: {$user->data()->fname} {$user->data()->lname})"
-            )
-            ->send();
-
-    } else {
-        ApiResponse::error(
-            'Failed to update owner profile. Please check your input and try again.',
-            400
+    ApiResponse::success('Owner profile updated successfully!')
+        ->withDataArray([
+            'quality_score' => $newQualityScore,
+            'missing_fields' => $missingFields
+        ])
+        ->withLogging(
+            $user->data()->id,
+            LogCategories::LOG_CATEGORY_OWNER_ACTIONS,
+            "Updated owner profile for user ID {$ownerId} (Admin: {$user->data()->fname} {$user->data()->lname})"
         )
         ->send();
-    }
 
 } catch (OwnerValidationException $e) {
     ApiResponse::error(

--- a/app/admin/includes/process-owner-update.php
+++ b/app/admin/includes/process-owner-update.php
@@ -47,7 +47,7 @@ try {
     }
 
     // Accept coordinates from location picker (frontend provides precise coordinates)
-    if (!empty($_POST['lat']) && !empty($_POST['lon'])) {
+    if (isset($_POST['lat']) && $_POST['lat'] !== '' && isset($_POST['lon']) && $_POST['lon'] !== '') {
         $updateFields['lat'] = (float)$_POST['lat'];
         $updateFields['lon'] = (float)$_POST['lon'];
     }

--- a/app/admin/includes/process-owner-update.php
+++ b/app/admin/includes/process-owner-update.php
@@ -38,7 +38,6 @@ try {
     // Prepare update fields
     $updateFields = [
         'id' => $ownerId,
-        'csrf' => $_POST['csrf']
     ];
 
     // Text fields: basic info and location (coordinates handled separately below)

--- a/app/admin/includes/process-owner-update.php
+++ b/app/admin/includes/process-owner-update.php
@@ -15,7 +15,6 @@ use ElanRegistry\Owner;
  * Processes owner profile updates using Owner class
  */
 
-// Include required files
 require_once '../../../users/init.php';
 
 requireAdminAjax('owner update');
@@ -54,11 +53,11 @@ try {
     }
 
     // Attempt to update owner profile — throws OwnerValidationException or OwnerUpdateException on failure
+    // update() calls find() internally, so $owner->data() is already fresh after this returns
     $owner->update($updateFields);
 
-    $updatedOwner = new Owner($ownerId);
-    $newQualityScore = $updatedOwner->getProfileQualityScore();
-    $missingFields = $updatedOwner->validateProfileCompleteness();
+    $newQualityScore = $owner->getProfileQualityScore();
+    $missingFields = $owner->validateProfileCompleteness();
 
     ApiResponse::success('Owner profile updated successfully!')
         ->withDataArray([

--- a/app/admin/includes/process-owner-update.php
+++ b/app/admin/includes/process-owner-update.php
@@ -100,7 +100,7 @@ try {
     ApiResponse::serverError('Update failed: ' . $e->getUserMessage())
         ->withLogging(
             $user->data()->id,
-            'DatabaseError',
+            LogCategories::LOG_CATEGORY_DATABASE_ERROR,
             "Owner update failed for user ID {$ownerId}: " . $e->getMessage()
         )
         ->send();

--- a/docs/development/CLASSES.md
+++ b/docs/development/CLASSES.md
@@ -306,7 +306,7 @@ $results = (new Owner())->searchOwners('Portland');
 
 **Integration**:
 
-- Works with `getUserWithProfile($userId)` custom function
+- Use `(new Owner($userId))->data()` to load combined user+profile data
 - Used in admin consolidated management interface
 
 ### CarValidator
@@ -824,7 +824,7 @@ class MyDomainClass {
 
 ```php
 // Combined user + profile data
-$owner = getUserWithProfile($userId);
+$ownerData = (new Owner($userId))->data();
 ```
 
 **UserSpice Classes**:
@@ -868,7 +868,7 @@ Car
 Owner
 ├── Uses: DB (singleton)
 ├── Related: Car (via user_id)
-└── Integrates: getUserWithProfile()
+└── Uses: (new Owner($userId))->data() for combined user+profile
 
 CarView
 ├── Uses: Resize (for image processing)

--- a/docs/development/CLASSES.md
+++ b/docs/development/CLASSES.md
@@ -288,8 +288,7 @@ $owner->update([
     'id' => $userId,
     'city' => 'Portland',
     'state' => 'Oregon',
-    'country' => 'United States',
-    'csrf' => Token::generate()
+    'country' => 'United States'
 ]);
 // Note: Pass lat/lon explicitly; coordinates are not auto-populated server-side
 
@@ -297,7 +296,7 @@ $owner->update([
 $score = $owner->getProfileQualityScore(); // Returns 0-100
 
 // Search owners (admin function)
-$results = Owner::searchOwners('Portland');
+$results = (new Owner())->searchOwners('Portland');
 ```
 
 **Database Tables**:
@@ -802,9 +801,9 @@ class MyDomainClass {
     }
 
     // Update existing record
+    // CSRF is validated by the caller (HTTP layer) before update() is called
     public function update(array $fields): bool {
         // Validation
-        // CSRF check
         // Database update
         // Audit logging
         return true;

--- a/tests/integration/AdminOwnerManagementTest.php
+++ b/tests/integration/AdminOwnerManagementTest.php
@@ -251,6 +251,28 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     }
 
     /**
+     * Multi-word UNION path: a two-word search term ('Greg Surcouf') resolves
+     * via the exact-name UNION branch and returns the matching owner.
+     *
+     * Validates the three-UNION SQL path in searchOwners() and guards against
+     * parameter-ordering regressions in the 14-placeholder prepared statement.
+     */
+    public function testSearchOwnersReturnsMatchingOwnerForMultiWordQuery(): void
+    {
+        $userId = $this->createTestUser(['fname' => 'Greg', 'lname' => 'Surcouf']);
+
+        $results = (new Owner())->searchOwners('Greg Surcouf', 25);
+
+        $this->assertIsArray($results);
+        $this->assertNotEmpty($results, 'Multi-word searchOwners() must return the test user');
+
+        $ids = array_column((array) $results, 'id');
+        $this->assertContains((string) $userId, array_map('strval', $ids),
+            'Multi-word search must find the user by exact first+last name'
+        );
+    }
+
+    /**
      * Happy path for owner-update: Owner::update() persists a changed city to
      * the profiles table. CSRF is validated by the caller (HTTP layer) before
      * update() is called.

--- a/tests/integration/AdminOwnerManagementTest.php
+++ b/tests/integration/AdminOwnerManagementTest.php
@@ -241,7 +241,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
 
     /**
      * Happy path for owner-search: a test user created in the DB is returned
-     * by Owner::searchOwners() when searched by first name.
+     * by $owner->searchOwners() when searched by first name.
      *
      * Validates that the search logic used by process-owner-search.php finds
      * real owners from the database.
@@ -250,7 +250,7 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     {
         $userId = $this->createTestUser(['fname' => 'SearchHappy', 'lname' => 'PathTest']);
 
-        $results = Owner::searchOwners('SearchHappy', 25);
+        $results = (new Owner())->searchOwners('SearchHappy', 25);
 
         $this->assertIsArray($results);
         $this->assertNotEmpty($results, 'searchOwners() must return the newly created test user');
@@ -262,8 +262,9 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     }
 
     /**
-     * Happy path for owner-update: Owner::update() persists a
-     * changed city to the profiles table when called with a valid CSRF token.
+     * Happy path for owner-update: Owner::update() persists a changed city to
+     * the profiles table. CSRF is validated by the caller (HTTP layer) before
+     * update() is called.
      *
      * Validates the DB write path used by process-owner-update.php.
      */
@@ -272,12 +273,9 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
         $userId = $this->createTestUser();
         $this->createTestProfile($userId, ['city' => 'Salem']);
 
-        $token = $this->seedCsrfToken();
-
         $owner = new Owner($userId);
         $result = $owner->update([
             'id'   => $userId,
-            'csrf' => $token,
             'city' => 'Eugene',
         ]);
 

--- a/tests/integration/AdminOwnerManagementTest.php
+++ b/tests/integration/AdminOwnerManagementTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/IntegrationTestCase.php';
 
 use ElanRegistry\Owner;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -99,128 +100,35 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
     }
 
     /**
-     * process-owner-search.php must delegate auth+CSRF guard to requireAdminAjax().
+     * Every admin AJAX endpoint must delegate auth+CSRF guard to requireAdminAjax().
+     * To add a new endpoint to this contract, append one entry to the provider array.
+     *
+     * @return array<string, array{string}>
      */
-    public function testOwnerSearchEndpointRequiresRegistryAdmin(): void
+    public static function adminEndpointProvider(): array
     {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-search.php');
-        $this->assertNotFalse($content, 'Could not read process-owner-search.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-owner-search.php must call requireAdminAjax() for auth+CSRF guard'
-        );
+        return [
+            'process-owner-search'       => ['app/admin/includes/process-owner-search.php'],
+            'process-owner-update'       => ['app/admin/includes/process-owner-update.php'],
+            'process-owner-sync-location' => ['app/admin/includes/process-owner-sync-location.php'],
+            'load-owner-info'            => ['app/admin/includes/load-owner-info.php'],
+            'load-owner-profile'         => ['app/admin/includes/load-owner-profile.php'],
+            'process-car-details'        => ['app/admin/includes/process-car-details.php'],
+            'process-transfer-approve'   => ['app/admin/includes/process-transfer-approve.php'],
+            'process-transfer-deny'      => ['app/admin/includes/process-transfer-deny.php'],
+            'process-user-details'       => ['app/admin/includes/process-user-details.php'],
+        ];
     }
 
-    /**
-     * process-owner-update.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testOwnerUpdateEndpointRequiresRegistryAdmin(): void
+    #[DataProvider('adminEndpointProvider')]
+    public function testEndpointHasAdminGuard(string $relativePath): void
     {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-update.php');
-        $this->assertNotFalse($content, 'Could not read process-owner-update.php');
+        $content = file_get_contents(__DIR__ . '/../../' . $relativePath);
+        $this->assertNotFalse($content, "Could not read {$relativePath}");
         $this->assertStringContainsString(
             'requireAdminAjax(',
             $content,
-            'process-owner-update.php must call requireAdminAjax() for auth+CSRF guard'
-        );
-    }
-
-    /**
-     * process-owner-sync-location.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testOwnerSyncLocationEndpointRequiresRegistryAdmin(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-owner-sync-location.php');
-        $this->assertNotFalse($content, 'Could not read process-owner-sync-location.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-owner-sync-location.php must call requireAdminAjax() for auth+CSRF guard'
-        );
-    }
-
-    /**
-     * load-owner-info.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testLoadOwnerInfoEndpointHasAdminGuard(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/load-owner-info.php');
-        $this->assertNotFalse($content, 'Could not read load-owner-info.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'load-owner-info.php must call requireAdminAjax() for auth+CSRF guard'
-        );
-    }
-
-    /**
-     * load-owner-profile.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testLoadOwnerProfileEndpointHasAdminGuard(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/load-owner-profile.php');
-        $this->assertNotFalse($content, 'Could not read load-owner-profile.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'load-owner-profile.php must call requireAdminAjax() for auth+CSRF guard'
-        );
-    }
-
-    /**
-     * process-car-details.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testProcessCarDetailsEndpointHasAdminGuard(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-car-details.php');
-        $this->assertNotFalse($content, 'Could not read process-car-details.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-car-details.php must call requireAdminAjax() for auth+CSRF guard'
-        );
-    }
-
-    /**
-     * process-transfer-approve.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testProcessTransferApproveEndpointHasAdminGuard(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-transfer-approve.php');
-        $this->assertNotFalse($content, 'Could not read process-transfer-approve.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-transfer-approve.php must call requireAdminAjax() for auth+CSRF guard'
-        );
-    }
-
-    /**
-     * process-transfer-deny.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testProcessTransferDenyEndpointHasAdminGuard(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-transfer-deny.php');
-        $this->assertNotFalse($content, 'Could not read process-transfer-deny.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-transfer-deny.php must call requireAdminAjax() for auth+CSRF guard'
-        );
-    }
-
-    /**
-     * process-user-details.php must delegate auth+CSRF guard to requireAdminAjax().
-     */
-    public function testProcessUserDetailsEndpointHasAdminGuard(): void
-    {
-        $content = file_get_contents(__DIR__ . '/../../app/admin/includes/process-user-details.php');
-        $this->assertNotFalse($content, 'Could not read process-user-details.php');
-        $this->assertStringContainsString(
-            'requireAdminAjax(',
-            $content,
-            'process-user-details.php must call requireAdminAjax() for auth+CSRF guard'
+            "{$relativePath} must call requireAdminAjax() for auth+CSRF guard"
         );
     }
 

--- a/tests/integration/AdminOwnerManagementTest.php
+++ b/tests/integration/AdminOwnerManagementTest.php
@@ -74,17 +74,6 @@ final class AdminOwnerManagementTest extends IntegrationTestCase
         $this->createdProfileIds[] = (int) $row->id;
     }
 
-    /**
-     * Seed a valid CSRF token into the session and return it.
-     * The token is a 64-char hex string matching Token::check() format requirements.
-     */
-    private function seedCsrfToken(): string
-    {
-        $token = bin2hex(random_bytes(32));
-        $_SESSION['token'] = $token;
-        return $token;
-    }
-
     // =========================================================================
     // Auth-guard and CSRF-guard source-inspection tests
     // =========================================================================

--- a/tests/integration/OwnerIntegrationTest.php
+++ b/tests/integration/OwnerIntegrationTest.php
@@ -471,6 +471,18 @@ class OwnerIntegrationTest extends IntegrationTestCase
             'username must be silently dropped by validateAndSanitizeFields');
     }
 
+    /**
+     * update() with only 'id' and no other fields must throw OwnerValidationException.
+     *
+     * This guard is newly reachable without a 'csrf' field in the array (previously
+     * the array was never empty because 'csrf' was always present).
+     */
+    public function testUpdateWithOnlyIdThrowsValidationException(): void
+    {
+        $this->expectException(\ElanRegistry\Exceptions\OwnerValidationException::class);
+        (new Owner())->update(['id' => 1]);
+    }
+
     public function testExtractUserFieldsExcludesDangerousColumns(): void
     {
         $owner = new Owner();

--- a/tests/integration/OwnerIntegrationTest.php
+++ b/tests/integration/OwnerIntegrationTest.php
@@ -290,11 +290,9 @@ class OwnerIntegrationTest extends IntegrationTestCase
         ]);
         $this->assertTrue((bool) $insertResult, 'Test fixture: profiles insert must succeed');
         try {
-            $csrf = Token::generate();
             $owner = new Owner($userId);
             $owner->update([
                 'id' => $userId,
-                'csrf' => $csrf,
                 'lat' => '0',
                 'lon' => '0',
             ]);
@@ -418,11 +416,9 @@ class OwnerIntegrationTest extends IntegrationTestCase
         try {
             $before = $this->db->query("SELECT active, permissions FROM users WHERE id = ?", [$userId])
                 ->first();
-            $csrf = \Token::generate();
             $owner = new Owner($userId);
             $owner->update([
                 'id'          => $userId,
-                'csrf'        => $csrf,
                 'active'      => '0',
                 'permissions' => '3',
                 'city'        => 'AfterCity',
@@ -452,11 +448,9 @@ class OwnerIntegrationTest extends IntegrationTestCase
             'lat' => 0.0, 'lon' => 0.0,
         ]);
         try {
-            $csrf = \Token::generate();
             $owner = new Owner($userId);
             $owner->update([
                 'id'     => $userId,
-                'csrf'   => $csrf,
                 'active' => '1',
                 'city'   => 'AfterCity',
             ]);

--- a/tests/unit/Owner/OwnerSearchTest.php
+++ b/tests/unit/Owner/OwnerSearchTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use ElanRegistry\Exceptions\OwnerSearchException;
+use ElanRegistry\Owner;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('fast')]
+#[Group('unit')]
+#[Group('owner')]
+final class OwnerSearchTest extends TestCase
+{
+    private function createMockDb(int $rowCount = 0, bool $hasError = false, array $rows = []): object
+    {
+        return new class($rowCount, $hasError, $rows) {
+            public function __construct(
+                private int $rowCount,
+                private bool $hasError,
+                private array $rows,
+            ) {}
+
+            public function query(string $sql, array $params = []): object
+            {
+                $count = $this->rowCount;
+                $rows  = $this->rows;
+                return new class($count, $rows) {
+                    public function __construct(
+                        private int $count,
+                        private array $rows,
+                    ) {}
+                    public function count(): int { return $this->count; }
+                    public function results(): array { return $this->rows; }
+                };
+            }
+
+            public function error(): bool { return $this->hasError; }
+            public function errorString(): string { return 'mock error'; }
+        };
+    }
+
+    public function testSearchOwnersReturnsEmptyArrayWhenNoResults(): void
+    {
+        $db      = $this->createMockDb(0);
+        $owner   = new Owner(null, $db);
+        $results = $owner->searchOwners('Portland');
+
+        $this->assertSame([], $results);
+    }
+
+    public function testSearchOwnersReturnsResultsFromDb(): void
+    {
+        $row     = (object)['id' => 1, 'fname' => 'Alice', 'lname' => 'Smith'];
+        $db      = $this->createMockDb(1, false, [$row]);
+        $owner   = new Owner(null, $db);
+        $results = $owner->searchOwners('Alice');
+
+        $this->assertCount(1, $results);
+        $this->assertSame($row, $results[0]);
+    }
+
+    public function testSearchOwnersThrowsOnDbError(): void
+    {
+        $db    = $this->createMockDb(0, true);
+        $owner = new Owner(null, $db);
+
+        $this->expectException(OwnerSearchException::class);
+        $owner->searchOwners('Portland');
+    }
+}

--- a/usersc/classes/Owner.php
+++ b/usersc/classes/Owner.php
@@ -56,9 +56,9 @@ class Owner
     /**
      * Find and load owner data by user ID
      *
-     * Executes a users LEFT JOIN profiles query. Profile fields absent from the
-     * profiles row are normalised: city/state/country/website default to '' and
-     * lat/lon default to null.
+     * Executes a users LEFT JOIN profiles query. When no profiles row exists,
+     * string location fields (city, state, country, website) are normalised to ''
+     * rather than null; lat and lon remain null as returned by the LEFT JOIN.
      *
      * Returns false both when the user ID does not exist and when a DB error
      * occurs. DB errors are logged to LOG_CATEGORY_DATABASE_ERROR so callers can
@@ -93,8 +93,6 @@ class Owner
             $ownerData->state   = $ownerData->state   ?? '';
             $ownerData->country = $ownerData->country ?? '';
             $ownerData->website = $ownerData->website ?? '';
-            $ownerData->lat     = $ownerData->lat     ?? null;
-            $ownerData->lon     = $ownerData->lon     ?? null;
             $this->_data = $ownerData;
             return true;
         }
@@ -428,11 +426,23 @@ class Owner
             return [];
         }
 
-        // Handle multi-word searches (e.g., "Greg Surcouf", "Portland Oregon")
+        // Split into words; for multi-word input, also strip commas from each token.
+        // Single-word input bypasses comma-stripping to preserve the original term exactly.
         $searchWords = array_values(array_filter(explode(' ', strtolower($searchTerm))));
 
-        if (count($searchWords) === 1) {
-            // Single word search - use original OR logic
+        if (count($searchWords) > 1) {
+            $searchWords = array_values(array_filter(array_map(
+                static fn(string $word) => trim($word, ', '),
+                $searchWords
+            )));
+        }
+
+        if (count($searchWords) === 0) {
+            return [];
+        }
+
+        if (count($searchWords) < 2) {
+            // Single-word search: matches name, email, and location
             $searchPattern = '%' . $searchWords[0] . '%';
             $sql = "SELECT u.id, u.fname, u.lname, u.email, p.city, p.state, p.country, p.lat, p.lon
                     FROM users u
@@ -445,66 +455,44 @@ class Owner
             $params = [$searchPattern, $searchPattern, $searchPattern, $searchPattern, $searchPattern, $searchPattern];
 
         } else {
-            // Multi-word search - use UNION to prioritize exact matches over partial matches
-            $searchWords = array_values(array_filter(array_map(function($word) {
-                return trim($word, ', ');
-            }, $searchWords)));
+            // Multi-word search: UNION-based query to prioritize exact matches
+            // ($searchWords are already lowercased from strtolower($searchTerm) above)
+            $word1 = $searchWords[0];
+            $word2 = $searchWords[1];
 
-            if (count($searchWords) === 0) {
-                return [];
-            }
+            $sql = "
+            (SELECT u.id, u.fname, u.lname, u.email, p.city, p.state, p.country, p.lat, p.lon, 1 as priority
+             FROM users u LEFT JOIN profiles p ON u.id = p.user_id
+             WHERE (LOWER(u.fname) = ? AND LOWER(u.lname) = ?) OR (LOWER(u.fname) = ? AND LOWER(u.lname) = ?))
+            UNION
+            (SELECT u.id, u.fname, u.lname, u.email, p.city, p.state, p.country, p.lat, p.lon, 2 as priority
+             FROM users u LEFT JOIN profiles p ON u.id = p.user_id
+             WHERE ((LOWER(u.fname) = ? OR LOWER(u.lname) = ?) AND (LOWER(p.city) = ? OR LOWER(p.state) = ?))
+                OR ((LOWER(u.fname) = ? OR LOWER(u.lname) = ?) AND (LOWER(p.city) = ? OR LOWER(p.state) = ?)))
+            UNION
+            (SELECT u.id, u.fname, u.lname, u.email, p.city, p.state, p.country, p.lat, p.lon, 3 as priority
+             FROM users u LEFT JOIN profiles p ON u.id = p.user_id
+             WHERE (LOWER(p.city) = ? AND LOWER(p.state) = ?) OR (LOWER(p.city) = ? AND LOWER(p.state) = ?))
+            ORDER BY priority, lname, fname
+            LIMIT " . (int)$limit;
 
-            if (count($searchWords) < 2) {
-                // Fallback to single word search
-                $searchPattern = '%' . $searchWords[0] . '%';
-                $sql = "SELECT u.id, u.fname, u.lname, u.email, p.city, p.state, p.country, p.lat, p.lon
-                        FROM users u
-                        LEFT JOIN profiles p ON u.id = p.user_id
-                        WHERE LOWER(u.fname) LIKE ? OR LOWER(u.lname) LIKE ? OR LOWER(u.email) LIKE ?
-                           OR LOWER(p.city) LIKE ? OR LOWER(p.state) LIKE ? OR LOWER(p.country) LIKE ?
-                        ORDER BY u.lname, u.fname
-                        LIMIT " . (int)$limit;
-                $params = [$searchPattern, $searchPattern, $searchPattern, $searchPattern, $searchPattern, $searchPattern];
-            } else {
-                // Use UNION to prioritize exact matches
-                $word1 = strtolower($searchWords[0]);
-                $word2 = strtolower($searchWords[1]);
-
-                $sql = "
-                (SELECT u.id, u.fname, u.lname, u.email, p.city, p.state, p.country, p.lat, p.lon, 1 as priority
-                 FROM users u LEFT JOIN profiles p ON u.id = p.user_id
-                 WHERE (LOWER(u.fname) = ? AND LOWER(u.lname) = ?) OR (LOWER(u.fname) = ? AND LOWER(u.lname) = ?))
-                UNION
-                (SELECT u.id, u.fname, u.lname, u.email, p.city, p.state, p.country, p.lat, p.lon, 2 as priority
-                 FROM users u LEFT JOIN profiles p ON u.id = p.user_id
-                 WHERE ((LOWER(u.fname) = ? OR LOWER(u.lname) = ?) AND (LOWER(p.city) = ? OR LOWER(p.state) = ?))
-                    OR ((LOWER(u.fname) = ? OR LOWER(u.lname) = ?) AND (LOWER(p.city) = ? OR LOWER(p.state) = ?)))
-                UNION
-                (SELECT u.id, u.fname, u.lname, u.email, p.city, p.state, p.country, p.lat, p.lon, 3 as priority
-                 FROM users u LEFT JOIN profiles p ON u.id = p.user_id
-                 WHERE (LOWER(p.city) = ? AND LOWER(p.state) = ?) OR (LOWER(p.city) = ? AND LOWER(p.state) = ?))
-                ORDER BY priority, lname, fname
-                LIMIT " . (int)$limit;
-
-                $params = [
-                    // First UNION: exact name matches
-                    $word1, $word2,  // fname=word1 AND lname=word2
-                    $word2, $word1,  // fname=word2 AND lname=word1
-                    // Second UNION: name + location matches
-                    $word1, $word1, $word2, $word2,  // (fname=word1 OR lname=word1) AND (city=word2 OR state=word2)
-                    $word2, $word2, $word1, $word1,  // (fname=word2 OR lname=word2) AND (city=word1 OR state=word1)
-                    // Third UNION: location pairs
-                    $word1, $word2,  // city=word1 AND state=word2
-                    $word2, $word1   // city=word2 AND state=word1
-                ];
-            }
+            $params = [
+                // First UNION: exact name matches
+                $word1, $word2,  // fname=word1 AND lname=word2
+                $word2, $word1,  // fname=word2 AND lname=word1
+                // Second UNION: name + location matches
+                $word1, $word1, $word2, $word2,  // (fname=word1 OR lname=word1) AND (city=word2 OR state=word2)
+                $word2, $word2, $word1, $word1,  // (fname=word2 OR lname=word2) AND (city=word1 OR state=word1)
+                // Third UNION: location pairs
+                $word1, $word2,  // city=word1 AND state=word2
+                $word2, $word1   // city=word2 AND state=word1
+            ];
         }
 
-        $db = $this->_db;
-        $searchQuery = $db->query($sql, $params);
-        if ($db->error()) {
+        $searchQuery = $this->_db->query($sql, $params);
+        if ($this->_db->error()) {
             throw OwnerSearchException::withUserMessage(
-                'Owner search DB query failed: ' . $db->errorString(),
+                'Owner search DB query failed: ' . $this->_db->errorString(),
                 'Search failed. Please try again.'
             );
         }

--- a/usersc/classes/Owner.php
+++ b/usersc/classes/Owner.php
@@ -5,7 +5,6 @@ namespace ElanRegistry;
 
 use DB;
 use Exception;
-use Token;
 use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\OwnerCreationException;
 use ElanRegistry\Exceptions\OwnerSearchException;
@@ -129,17 +128,6 @@ class Owner
             );
         }
 
-        // CSRF Protection
-        if (!isset($fields['csrf']) || !Token::check($fields['csrf'])) {
-            throw OwnerCreationException::withUserMessage(
-                'Invalid CSRF token provided',
-                'Your session may have expired. Please refresh the page and try again.'
-            );
-        }
-
-        // Remove token from fields array after validation
-        unset($fields['csrf']);
-
         // Validate required fields for both user and profile
         $this->validateRequiredFields($fields, ['fname', 'lname', 'email']);
 
@@ -210,18 +198,6 @@ class Owner
                 'Unable to process update. Please try again.'
             );
         }
-
-        // CSRF Protection
-        if (!isset($fields['csrf']) || !Token::check($fields['csrf'])) {
-            logger($fields['id'] ?? 0, LogCategories::LOG_CATEGORY_VALIDATION_ERROR, 'Owner update failed: Invalid CSRF token');
-            throw OwnerValidationException::withUserMessage(
-                'Invalid CSRF token provided',
-                'Your session may have expired. Please refresh the page and try again.'
-            );
-        }
-
-        // Remove token from fields array after validation
-        unset($fields['csrf']);
 
         if (!is_numeric($fields['id']) || $fields['id'] <= 0) {
             throw OwnerValidationException::withUserMessage(
@@ -433,7 +409,7 @@ class Owner
      * @param int $limit Maximum number of results (default 50)
      * @return array Array of owner search results
      */
-    public static function searchOwners(string $searchTerm, int $limit = 50): array
+    public function searchOwners(string $searchTerm, int $limit = 50): array
     {
         $searchTerm = trim($searchTerm);
         if (empty($searchTerm)) {
@@ -512,7 +488,7 @@ class Owner
             }
         }
 
-        $db = DB::getInstance();
+        $db = $this->_db;
         $searchQuery = $db->query($sql, $params);
         if ($db->error()) {
             throw OwnerSearchException::withUserMessage(

--- a/usersc/classes/Owner.php
+++ b/usersc/classes/Owner.php
@@ -290,6 +290,12 @@ class Owner
             [$this->_data->id]
         );
 
+        if ($this->_db->error()) {
+            logger((int)$this->_data->id, LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                "getCarsOwned DB error for userId={$this->_data->id}: " . $this->_db->errorString());
+            return [];
+        }
+
         $this->_carsOwned = $carsQuery->count() > 0 ? $carsQuery->results() : [];
         return $this->_carsOwned;
     }
@@ -313,6 +319,12 @@ class Owner
              ORDER BY ch.ctime DESC",
             [$this->_data->id]
         );
+
+        if ($this->_db->error()) {
+            logger((int)$this->_data->id, LogCategories::LOG_CATEGORY_DATABASE_ERROR,
+                "getOwnershipHistory DB error for userId={$this->_data->id}: " . $this->_db->errorString());
+            return [];
+        }
 
         return $historyQuery->count() > 0 ? $historyQuery->results() : [];
     }


### PR DESCRIPTION
## Summary

- Removes CSRF validation from `Owner::create()` and `Owner::update()` — CSRF is a transport-layer concern enforced by `requireAdminAjax()` at the HTTP boundary, not a domain responsibility. Callers are not broken: the only production caller of `update()` (`process-owner-update.php`) already calls `requireAdminAjax('owner update')` before any Owner method runs.
- Converts `Owner::searchOwners()` from `public static` to `public function`, replacing the `DB::getInstance()` static call with `$this->_db`, making the method testable via dependency injection.
- Adds DB error checks to `getCarsOwned()` and `getOwnershipHistory()` (previously silently returned whatever a failed query produced).
- Fixes `!empty()` coordinate guard in `process-owner-update.php` — `empty("0")` is true in PHP, so equatorial/prime meridian coordinates were silently dropped. Replaced with `isset() && !== ''`.
- Replaces all magic log-category strings with `LogCategories` constants.

## Test plan

- [ ] `composer test:medium` passes (unit + integration)
- [ ] New `tests/unit/Owner/OwnerSearchTest.php` — 3 mock-DB unit tests: empty results, results returned, throws `OwnerSearchException` on DB error
- [ ] `tests/integration/AdminOwnerManagementTest.php` — multi-word UNION path test added, 9 source-inspection tests consolidated into 1 `#[DataProvider]` test, `seedCsrfToken()` removed
- [ ] `tests/integration/OwnerIntegrationTest.php` — CSRF removed from 3 tests, `testUpdateWithOnlyIdThrowsValidationException` added (guards the newly-reachable no-fields path)
- [ ] PHPStan clean on all modified files

Closes #1239

https://claude.ai/code/session_01RRNUqYWgZRZaWGv5qVBxkZ