### PR TITLE
refactor: inject CarRepository into CarVerificationManager and CarImageProcessor constructors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -88,13 +88,92 @@ jobs:
           fetch-depth: 0
           ref: refs/pull/${{ steps.ctx.outputs.pr_number }}/head
 
+      # claude-code-action@v1 now errors if track_progress is set (any value)
+      # on workflow_dispatch. Split into two conditional steps: one for PR
+      # events (track_progress: true) and one for on-demand dispatch (omitted).
       - name: Run Claude Issue-Level Review
+        if: github.event_name == 'pull_request'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # track_progress is unsupported for workflow_dispatch — disable it
-          # when this job is triggered on-demand (e.g. via /finish-issue).
-          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
+          track_progress: true
+          model: "claude-sonnet-5"
+          claude_args: >-
+            --allowedTools
+            "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git diff --name-only:*),Bash(php -l *),Bash(composer check:php),Bash(vendor/bin/phpstan analyse:*),Bash(npm run lint),Read,Grep,Glob"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.ctx.outputs.pr_number }}
+
+            You are reviewing an **issue-level PR** targeting a milestone branch.
+
+            - Base: ${{ steps.ctx.outputs.base_ref }}
+            - Head: ${{ steps.ctx.outputs.head_ref }}
+            - Title: ${{ steps.ctx.outputs.title }}
+
+            The author ran `/review-pr` locally before pushing. The parallel
+            Static Analysis, CodeQL, and Semgrep jobs catch obvious issues.
+
+            **You are the backstop.** Focus on what static tools cannot see.
+
+            ## Scope
+
+            Review only the diff on this PR:
+
+            ```bash
+            gh pr diff ${{ steps.ctx.outputs.pr_number }}
+            ```
+
+            Skip `vendor/**`, `node_modules/**`, and minified / generated assets.
+
+            ## What to check
+
+            - Does the change fit the architecture (CLAUDE.md patterns)?
+            - Are there silent failures in catch blocks or fallback paths?
+            - Are tests adequate for the behaviour being added?
+            - Does it cross the Users (auth) vs Owners (registry domain) boundary?
+            - Security-sensitive changes: CSRF, prepared statements, input validation
+
+            ## What to skip
+
+            - Type-hint absence, missing `declare(strict_types=1)`, unused imports —
+              PHPStan / coding-standards checker flag these
+            - Obvious SQL concatenation — CodeQL / Semgrep flag these
+            - JS style issues — ESLint flags these
+
+            ## Output
+
+            Post your review as a PR comment using:
+
+            ```bash
+            gh pr comment ${{ steps.ctx.outputs.pr_number }} --body "..."
+            ```
+
+            Structure the comment with these sections (use exactly these headings):
+
+            ### Blocking
+            Must fix before merge (critical bugs, security issues, silent
+            failures, CLAUDE.md violations). Omit this section entirely if
+            there are no blocking issues — do NOT include an empty section.
+
+            ### Important
+            Should address (design, test gaps, unclear code).
+
+            ### Suggestions
+            Optional improvements.
+
+            ### Strengths
+            What's done well.
+
+            Each item must cite `file:line` and the specific rule or reason.
+            If there is nothing to say in a section, omit it entirely.
+            Only post GitHub comments — do not output the review as a message.
+
+      - name: Run Claude Issue-Level Review (on-demand)
+        if: github.event_name == 'workflow_dispatch'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           model: "claude-sonnet-5"
           claude_args: >-
             --allowedTools

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -88,92 +88,11 @@ jobs:
           fetch-depth: 0
           ref: refs/pull/${{ steps.ctx.outputs.pr_number }}/head
 
-      # claude-code-action@v1 now errors if track_progress is set (any value)
-      # on workflow_dispatch. Split into two conditional steps: one for PR
-      # events (track_progress: true) and one for on-demand dispatch (omitted).
       - name: Run Claude Issue-Level Review
-        if: github.event_name == 'pull_request'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
-          model: "claude-sonnet-5"
-          claude_args: >-
-            --allowedTools
-            "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git diff --name-only:*),Bash(php -l *),Bash(composer check:php),Bash(vendor/bin/phpstan analyse:*),Bash(npm run lint),Read,Grep,Glob"
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ steps.ctx.outputs.pr_number }}
-
-            You are reviewing an **issue-level PR** targeting a milestone branch.
-
-            - Base: ${{ steps.ctx.outputs.base_ref }}
-            - Head: ${{ steps.ctx.outputs.head_ref }}
-            - Title: ${{ steps.ctx.outputs.title }}
-
-            The author ran `/review-pr` locally before pushing. The parallel
-            Static Analysis, CodeQL, and Semgrep jobs catch obvious issues.
-
-            **You are the backstop.** Focus on what static tools cannot see.
-
-            ## Scope
-
-            Review only the diff on this PR:
-
-            ```bash
-            gh pr diff ${{ steps.ctx.outputs.pr_number }}
-            ```
-
-            Skip `vendor/**`, `node_modules/**`, and minified / generated assets.
-
-            ## What to check
-
-            - Does the change fit the architecture (CLAUDE.md patterns)?
-            - Are there silent failures in catch blocks or fallback paths?
-            - Are tests adequate for the behaviour being added?
-            - Does it cross the Users (auth) vs Owners (registry domain) boundary?
-            - Security-sensitive changes: CSRF, prepared statements, input validation
-
-            ## What to skip
-
-            - Type-hint absence, missing `declare(strict_types=1)`, unused imports —
-              PHPStan / coding-standards checker flag these
-            - Obvious SQL concatenation — CodeQL / Semgrep flag these
-            - JS style issues — ESLint flags these
-
-            ## Output
-
-            Post your review as a PR comment using:
-
-            ```bash
-            gh pr comment ${{ steps.ctx.outputs.pr_number }} --body "..."
-            ```
-
-            Structure the comment with these sections (use exactly these headings):
-
-            ### Blocking
-            Must fix before merge (critical bugs, security issues, silent
-            failures, CLAUDE.md violations). Omit this section entirely if
-            there are no blocking issues — do NOT include an empty section.
-
-            ### Important
-            Should address (design, test gaps, unclear code).
-
-            ### Suggestions
-            Optional improvements.
-
-            ### Strengths
-            What's done well.
-
-            Each item must cite `file:line` and the specific rule or reason.
-            If there is nothing to say in a section, omit it entirely.
-            Only post GitHub comments — do not output the review as a message.
-
-      - name: Run Claude Issue-Level Review (on-demand)
-        if: github.event_name == 'workflow_dispatch'
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           model: "claude-sonnet-5"
           claude_args: >-
             --allowedTools

--- a/tests/unit/cars/services/CarImageProcessorTest.php
+++ b/tests/unit/cars/services/CarImageProcessorTest.php
@@ -65,18 +65,23 @@ final class CarImageProcessorTest extends TestCase
 
     public function testRemoveImageThrowsOnEmptyFilename(): void
     {
-        $this->expectException(ImageProcessingException::class);
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->never())->method('updateImage');
+        $processor = new CarImageProcessor($repo);
 
+        $this->expectException(ImageProcessingException::class);
         $carData = (object) ['id' => 1, 'image' => '["test.jpg"]'];
-        $this->processor->removeImage($carData, '');
+        $processor->removeImage($carData, '');
     }
 
     public function testRemoveImageReturnsFalseWhenImageNotFound(): void
     {
-        // Returns false before reaching the repo — no stub needed.
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->never())->method('updateImage');
+        $processor = new CarImageProcessor($repo);
+
         $carData = (object) ['id' => 1, 'image' => '["other.jpg"]'];
-        $result = $this->processor->removeImage($carData, 'nonexistent.jpg');
-        $this->assertFalse($result);
+        $this->assertFalse($processor->removeImage($carData, 'nonexistent.jpg'));
     }
 
     public function testRemoveImageReturnsTrueWhenFound(): void
@@ -110,6 +115,17 @@ final class CarImageProcessorTest extends TestCase
         $carData = (object) ['id' => 1, 'image' => 'test.jpg,other.jpg'];
         $result = $processor->removeImage($carData, 'test.jpg');
         $this->assertTrue($result);
+    }
+
+    public function testRemoveLastImageSetsCarDataImageToEmptyString(): void
+    {
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('updateImage')->willReturn(true);
+        $processor = new CarImageProcessor($repo);
+
+        $carData = (object) ['id' => 1, 'image' => '["test.jpg"]'];
+        $processor->removeImage($carData, 'test.jpg');
+        $this->assertSame('', $carData->image);
     }
 
     /**

--- a/tests/unit/cars/services/CarImageProcessorTest.php
+++ b/tests/unit/cars/services/CarImageProcessorTest.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use ElanRegistry\Car\CarImageProcessor;
+use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\CarConcurrentModificationException;
-use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\ImageProcessingException;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +20,7 @@ final class CarImageProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->processor = new CarImageProcessor();
+        $this->processor = new CarImageProcessor($this->createMock(CarRepository::class));
     }
 
     // ============================================================
@@ -60,69 +60,55 @@ final class CarImageProcessorTest extends TestCase
     }
 
     // ============================================================
-    // removeImage tests (requires mock DB)
+    // removeImage tests
     // ============================================================
-
-    /**
-     * Build a DB mock whose updateImage path returns the given outcome.
-     *
-     * removeImage() creates a CarRepository internally and calls updateImage(),
-     * which uses only query(), error(), and count().  Tests that exercise the
-     * update path must supply this mock instead of a real DB connection so the
-     * outcome is deterministic and independent of real DB state.
-     *
-     * @param bool $error      Whether the DB query should simulate a failure
-     * @param int  $rowsAffected  Rows reported by count() (1 = success, 0 = CAS conflict)
-     * @return \PHPUnit\Framework\MockObject\MockObject&DB
-     */
-    private function makeDbMockForUpdate(bool $error = false, int $rowsAffected = 1): object
-    {
-        $db = $this->createMock(DB::class);
-        $db->expects($this->once())->method('query')->willReturn(new QueryResult([]));
-        $db->method('error')->willReturn($error);
-        $db->method('count')->willReturn($rowsAffected);
-        return $db;
-    }
 
     public function testRemoveImageThrowsOnEmptyFilename(): void
     {
         $this->expectException(ImageProcessingException::class);
 
         $carData = (object) ['id' => 1, 'image' => '["test.jpg"]'];
-        $db = DB::getInstance();
-        $this->processor->removeImage($carData, '', $db);
+        $this->processor->removeImage($carData, '');
     }
 
     public function testRemoveImageReturnsFalseWhenImageNotFound(): void
     {
-        // Returns false before reaching the DB — no mock needed.
+        // Returns false before reaching the repo — no stub needed.
         $carData = (object) ['id' => 1, 'image' => '["other.jpg"]'];
-        $db = DB::getInstance();
-        $result = $this->processor->removeImage($carData, 'nonexistent.jpg', $db);
+        $result = $this->processor->removeImage($carData, 'nonexistent.jpg');
         $this->assertFalse($result);
     }
 
     public function testRemoveImageReturnsTrueWhenFound(): void
     {
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('updateImage')->willReturn(true);
+        $processor = new CarImageProcessor($repo);
+
         $carData = (object) ['id' => 1, 'image' => '["test.jpg","other.jpg"]'];
-        $db = $this->makeDbMockForUpdate();
-        $result = $this->processor->removeImage($carData, 'test.jpg', $db);
+        $result = $processor->removeImage($carData, 'test.jpg');
         $this->assertTrue($result);
     }
 
     public function testRemoveImageUpdatesCarData(): void
     {
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('updateImage')->willReturn(true);
+        $processor = new CarImageProcessor($repo);
+
         $carData = (object) ['id' => 1, 'image' => '["test.jpg","other.jpg"]'];
-        $db = $this->makeDbMockForUpdate();
-        $this->processor->removeImage($carData, 'test.jpg', $db);
+        $processor->removeImage($carData, 'test.jpg');
         $this->assertEquals('["other.jpg"]', $carData->image);
     }
 
     public function testRemoveImageHandlesCsvFormat(): void
     {
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('updateImage')->willReturn(true);
+        $processor = new CarImageProcessor($repo);
+
         $carData = (object) ['id' => 1, 'image' => 'test.jpg,other.jpg'];
-        $db = $this->makeDbMockForUpdate();
-        $result = $this->processor->removeImage($carData, 'test.jpg', $db);
+        $result = $processor->removeImage($carData, 'test.jpg');
         $this->assertTrue($result);
     }
 
@@ -134,11 +120,13 @@ final class CarImageProcessorTest extends TestCase
      */
     public function testRemoveImageThrowsCarConcurrentModificationExceptionOnCasConflict(): void
     {
-        $carData = (object) ['id' => 1, 'image' => '["test.jpg"]'];
         // count=0: UPDATE matched 0 rows → CAS guard failed → updateImage() returns false
-        $db = $this->makeDbMockForUpdate(false, 0);
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('updateImage')->willReturn(false);
+        $processor = new CarImageProcessor($repo);
 
+        $carData = (object) ['id' => 1, 'image' => '["test.jpg"]'];
         $this->expectException(CarConcurrentModificationException::class);
-        $this->processor->removeImage($carData, 'test.jpg', $db);
+        $processor->removeImage($carData, 'test.jpg');
     }
 }

--- a/tests/unit/cars/services/CarVerificationManagerTest.php
+++ b/tests/unit/cars/services/CarVerificationManagerTest.php
@@ -120,6 +120,7 @@ final class CarVerificationManagerTest extends TestCase
     #[DataProvider('invalidSoldDateProvider')]
     public function testMarkSoldRejectsInvalidDate(string $date): void
     {
+        $this->mockRepo->expects($this->never())->method('updateSoldDate');
         $this->expectException(CarValidationException::class);
 
         $carData = (object) ['id' => 1, 'solddate' => null];

--- a/tests/unit/cars/services/CarVerificationManagerTest.php
+++ b/tests/unit/cars/services/CarVerificationManagerTest.php
@@ -37,6 +37,7 @@ final class CarVerificationManagerTest extends TestCase
 
     public function testSetVerificationCodeRejectsShortCode(): void
     {
+        $this->mockRepo->expects($this->never())->method('updateVerificationCode');
         $this->expectException(CarValidationException::class);
 
         $carData = (object) ['id' => 1, 'vericode' => null];
@@ -45,6 +46,7 @@ final class CarVerificationManagerTest extends TestCase
 
     public function testSetVerificationCodeRejectsEmptyCode(): void
     {
+        $this->mockRepo->expects($this->never())->method('updateVerificationCode');
         $this->expectException(CarValidationException::class);
 
         $carData = (object) ['id' => 1, 'vericode' => null];

--- a/tests/unit/cars/services/CarVerificationManagerTest.php
+++ b/tests/unit/cars/services/CarVerificationManagerTest.php
@@ -142,4 +142,34 @@ final class CarVerificationManagerTest extends TestCase
         $carData = (object) ['id' => 1, 'solddate' => null];
         $this->manager->markSold($carData, '2024-06-15');
     }
+
+    public function testSetVerificationCodeThrowsCarDatabaseExceptionWhenRepositoryThrows(): void
+    {
+        $this->mockRepo->expects($this->once())->method('updateVerificationCode')
+            ->willThrowException(new \RuntimeException('DB connection lost'));
+        $this->expectException(CarDatabaseException::class);
+
+        $carData = (object) ['id' => 1, 'vericode' => null];
+        $this->manager->setVerificationCode($carData, 'VERIFY12345678');
+    }
+
+    public function testMarkVerifiedThrowsCarDatabaseExceptionWhenRepositoryThrows(): void
+    {
+        $this->mockRepo->expects($this->once())->method('updateLastVerified')
+            ->willThrowException(new \RuntimeException('DB connection lost'));
+        $this->expectException(CarDatabaseException::class);
+
+        $carData = (object) ['id' => 1, 'last_verified' => null];
+        $this->manager->markVerified($carData);
+    }
+
+    public function testMarkSoldThrowsCarDatabaseExceptionWhenRepositoryThrows(): void
+    {
+        $this->mockRepo->expects($this->once())->method('updateSoldDate')
+            ->willThrowException(new \RuntimeException('DB connection lost'));
+        $this->expectException(CarDatabaseException::class);
+
+        $carData = (object) ['id' => 1, 'solddate' => null];
+        $this->manager->markSold($carData, '2024-06-15');
+    }
 }

--- a/tests/unit/cars/services/CarVerificationManagerTest.php
+++ b/tests/unit/cars/services/CarVerificationManagerTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Car\CarVerificationManager;
+use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarValidationException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -14,19 +16,21 @@ use PHPUnit\Framework\TestCase;
 #[Group('fast')]
 final class CarVerificationManagerTest extends TestCase
 {
+    private CarRepository $mockRepo;
     private CarVerificationManager $manager;
-    private DB $db;
 
     protected function setUp(): void
     {
-        $this->manager = new CarVerificationManager();
-        $this->db = DB::getInstance();
+        $this->mockRepo = $this->createMock(CarRepository::class);
+        $this->manager = new CarVerificationManager($this->mockRepo);
     }
 
     public function testSetVerificationCodeSucceeds(): void
     {
+        $this->mockRepo->expects($this->once())->method('updateVerificationCode')->willReturn(true);
+
         $carData = (object) ['id' => 1, 'vericode' => null];
-        $result = $this->manager->setVerificationCode($carData, 'VERIFY12345678', $this->db);
+        $result = $this->manager->setVerificationCode($carData, 'VERIFY12345678');
         $this->assertTrue($result);
         $this->assertEquals('VERIFY12345678', $carData->vericode);
     }
@@ -36,7 +40,7 @@ final class CarVerificationManagerTest extends TestCase
         $this->expectException(CarValidationException::class);
 
         $carData = (object) ['id' => 1, 'vericode' => null];
-        $this->manager->setVerificationCode($carData, 'SHORT', $this->db);
+        $this->manager->setVerificationCode($carData, 'SHORT');
     }
 
     public function testSetVerificationCodeRejectsEmptyCode(): void
@@ -44,29 +48,53 @@ final class CarVerificationManagerTest extends TestCase
         $this->expectException(CarValidationException::class);
 
         $carData = (object) ['id' => 1, 'vericode' => null];
-        $this->manager->setVerificationCode($carData, '', $this->db);
+        $this->manager->setVerificationCode($carData, '');
+    }
+
+    public function testSetVerificationCodeThrowsCarDatabaseExceptionWhenRepositoryReturnsFalse(): void
+    {
+        $this->mockRepo->expects($this->once())->method('updateVerificationCode')->willReturn(false);
+        $this->expectException(CarDatabaseException::class);
+
+        $carData = (object) ['id' => 1, 'vericode' => null];
+        $this->manager->setVerificationCode($carData, 'VERIFY12345678');
     }
 
     public function testMarkVerifiedSucceeds(): void
     {
+        $this->mockRepo->expects($this->once())->method('updateLastVerified')->willReturn(true);
+
         $carData = (object) ['id' => 1, 'last_verified' => null];
-        $result = $this->manager->markVerified($carData, $this->db);
+        $result = $this->manager->markVerified($carData);
         $this->assertTrue($result);
         $this->assertNotNull($carData->last_verified);
     }
 
+    public function testMarkVerifiedThrowsCarDatabaseExceptionWhenRepositoryReturnsFalse(): void
+    {
+        $this->mockRepo->expects($this->once())->method('updateLastVerified')->willReturn(false);
+        $this->expectException(CarDatabaseException::class);
+
+        $carData = (object) ['id' => 1, 'last_verified' => null];
+        $this->manager->markVerified($carData);
+    }
+
     public function testMarkSoldSucceeds(): void
     {
+        $this->mockRepo->expects($this->once())->method('updateSoldDate')->willReturn(true);
+
         $carData = (object) ['id' => 1, 'solddate' => null];
-        $result = $this->manager->markSold($carData, '2024-06-15', $this->db);
+        $result = $this->manager->markSold($carData, '2024-06-15');
         $this->assertTrue($result);
         $this->assertEquals('2024-06-15', $carData->solddate);
     }
 
     public function testMarkSoldDefaultsToToday(): void
     {
+        $this->mockRepo->expects($this->once())->method('updateSoldDate')->willReturn(true);
+
         $carData = (object) ['id' => 1, 'solddate' => null];
-        $result = $this->manager->markSold($carData, null, $this->db);
+        $result = $this->manager->markSold($carData, null);
         $this->assertTrue($result);
         $this->assertEquals(date('Y-m-d'), $carData->solddate);
     }
@@ -93,14 +121,25 @@ final class CarVerificationManagerTest extends TestCase
         $this->expectException(CarValidationException::class);
 
         $carData = (object) ['id' => 1, 'solddate' => null];
-        $this->manager->markSold($carData, $date, $this->db);
+        $this->manager->markSold($carData, $date);
     }
 
     public function testMarkSoldAcceptsLeapDay(): void
     {
+        $this->mockRepo->expects($this->once())->method('updateSoldDate')->willReturn(true);
+
         $carData = (object) ['id' => 1, 'solddate' => null];
-        $result = $this->manager->markSold($carData, '2024-02-29', $this->db);
+        $result = $this->manager->markSold($carData, '2024-02-29');
         $this->assertTrue($result);
         $this->assertEquals('2024-02-29', $carData->solddate);
+    }
+
+    public function testMarkSoldThrowsCarDatabaseExceptionWhenRepositoryReturnsFalse(): void
+    {
+        $this->mockRepo->expects($this->once())->method('updateSoldDate')->willReturn(false);
+        $this->expectException(CarDatabaseException::class);
+
+        $carData = (object) ['id' => 1, 'solddate' => null];
+        $this->manager->markSold($carData, '2024-06-15');
     }
 }

--- a/tests/unit/security/ImageFilenameAllowlistTest.php
+++ b/tests/unit/security/ImageFilenameAllowlistTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use ElanRegistry\Car\CarImageProcessor;
+use ElanRegistry\Car\CarRepository;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -285,7 +286,7 @@ final class ImageFilenameAllowlistTest extends TestCase
 
     public function testDecodeAndProcessImagesSkipsTraversalFilename(): void
     {
-        $result = (new CarImageProcessor())->decodeAndProcessImages(
+        $result = (new CarImageProcessor($this->createMock(CarRepository::class)))->decodeAndProcessImages(
             json_encode(['../../../etc/passwd']), '/images/1/', '/', '/var/www/'
         );
         $this->assertEmpty($result, 'Traversal filename must not appear in decoded image list');
@@ -293,7 +294,7 @@ final class ImageFilenameAllowlistTest extends TestCase
 
     public function testDecodeAndProcessImagesSkipsWildcardFilename(): void
     {
-        $result = (new CarImageProcessor())->decodeAndProcessImages(
+        $result = (new CarImageProcessor($this->createMock(CarRepository::class)))->decodeAndProcessImages(
             json_encode(['*']), '/images/1/', '/', '/var/www/'
         );
         $this->assertEmpty($result, 'Wildcard filename must not appear in decoded image list');
@@ -302,7 +303,7 @@ final class ImageFilenameAllowlistTest extends TestCase
     public function testDecodeAndProcessImagesSkipsUnsupportedExtension(): void
     {
         // 'photo.bmp' is rejected by isSafeFilename() — unsupported extension.
-        $result = (new CarImageProcessor())->decodeAndProcessImages(
+        $result = (new CarImageProcessor($this->createMock(CarRepository::class)))->decodeAndProcessImages(
             json_encode(['photo.bmp']), '/images/1/', '/', '/var/www/'
         );
         $this->assertEmpty($result, 'Unsupported-extension filename must not appear in decoded image list');
@@ -310,7 +311,7 @@ final class ImageFilenameAllowlistTest extends TestCase
 
     public function testDecodeAndProcessImagesSkipsScriptTagFilename(): void
     {
-        $result = (new CarImageProcessor())->decodeAndProcessImages(
+        $result = (new CarImageProcessor($this->createMock(CarRepository::class)))->decodeAndProcessImages(
             json_encode(['<script>alert(1)</script>']), '/images/1/', '/', '/var/www/'
         );
         $this->assertEmpty($result, 'XSS payload filename must not appear in decoded image list');
@@ -330,7 +331,7 @@ final class ImageFilenameAllowlistTest extends TestCase
         file_put_contents($tmpDir . $safeName, str_repeat('x', 100));
 
         try {
-            $result = (new CarImageProcessor())->decodeAndProcessImages(
+            $result = (new CarImageProcessor($this->createMock(CarRepository::class)))->decodeAndProcessImages(
                 json_encode([$safeName, $unsafeName]),
                 '',
                 '',

--- a/usersc/classes/Car/Car.php
+++ b/usersc/classes/Car/Car.php
@@ -88,7 +88,7 @@ class Car
     private function getImageProcessor(): CarImageProcessor
     {
         if ($this->imageProcessor === null) {
-            $this->imageProcessor = new CarImageProcessor();
+            $this->imageProcessor = new CarImageProcessor($this->getRepository());
         }
         return $this->imageProcessor;
     }
@@ -104,7 +104,7 @@ class Car
     private function getVerificationManager(): CarVerificationManager
     {
         if ($this->verificationManager === null) {
-            $this->verificationManager = new CarVerificationManager();
+            $this->verificationManager = new CarVerificationManager($this->getRepository());
         }
         return $this->verificationManager;
     }
@@ -399,7 +399,7 @@ class Car
             throw new CarNotFoundException(CarErrorMessages::getMessage('car_not_found'));
         }
 
-        $result = $this->getImageProcessor()->removeImage($this->_data, $filename, $this->_db);
+        $result = $this->getImageProcessor()->removeImage($this->_data, $filename);
 
         if ($result) {
             // Clear cached images to force reload
@@ -480,8 +480,6 @@ class Car
             throw new CarPermissionException(CarErrorMessages::getMessage('user_auth_required', 'admin', ['operation' => 'car transfer']));
         }
 
-        $self = $this;
-
         $result = $this->getAdministrationService()->transfer(
             $this->_data,
             $newUserId,
@@ -489,14 +487,14 @@ class Car
             $operationType,
             currentUserId(),
             $this->getRepository(),
-            function (array $fields) use ($self): bool {
-                return $self->update($fields);
+            function (array $fields): bool {
+                return $this->update($fields);
             },
-            function (int $id) use ($self): object {
-                if (!$self->find($id)) {
+            function (int $id): object {
+                if (!$this->find($id)) {
                     throw new CarNotFoundException("Car ID {$id} not found after transfer");
                 }
-                return $self->data();
+                return $this->data();
             }
         );
 
@@ -558,7 +556,7 @@ class Car
             throw new CarNotFoundException(CarErrorMessages::getMessage('car_not_found_verification'));
         }
 
-        return $this->getVerificationManager()->setVerificationCode($this->_data, $verificationCode, $this->_db);
+        return $this->getVerificationManager()->setVerificationCode($this->_data, $verificationCode);
     }
 
     /**
@@ -575,7 +573,7 @@ class Car
             throw new CarNotFoundException(CarErrorMessages::getMessage('car_not_found_verify'));
         }
 
-        return $this->getVerificationManager()->markVerified($this->_data, $this->_db);
+        return $this->getVerificationManager()->markVerified($this->_data);
     }
 
     /**
@@ -593,7 +591,7 @@ class Car
             throw new CarNotFoundException(CarErrorMessages::getMessage('car_not_found_sold'));
         }
 
-        return $this->getVerificationManager()->markSold($this->_data, $soldDate, $this->_db);
+        return $this->getVerificationManager()->markSold($this->_data, $soldDate);
     }
 
     /**

--- a/usersc/classes/Car/CarImageProcessor.php
+++ b/usersc/classes/Car/CarImageProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ElanRegistry\Car;
 
-use DB;
 use ElanRegistry\CarErrorMessages;
 use ElanRegistry\Exceptions\CarConcurrentModificationException;
 use ElanRegistry\Exceptions\CarDatabaseException;
@@ -24,6 +23,8 @@ use ElanRegistry\LogCategories;
  */
 class CarImageProcessor
 {
+    public function __construct(private CarRepository $repo) {}
+
     /**
      * Allowed image file extensions. Shared by generateSecureFilename() (what
      * it may produce) and isValidFilename() (what it will accept).
@@ -203,13 +204,12 @@ class CarImageProcessor
      *
      * @param object $carData Car data object (must have ->image and ->id properties)
      * @param string $filename Image filename to remove
-     * @param DB $db Database instance
      * @return bool True if image was removed successfully, false if not found
      * @throws ImageProcessingException If filename is empty or encoding fails
      * @throws CarDatabaseException If database update fails
      * @throws CarConcurrentModificationException If a concurrent request modified the image list
      */
-    public function removeImage(object $carData, string $filename, DB $db): bool
+    public function removeImage(object $carData, string $filename): bool
     {
         if (empty($filename)) {
             throw new ImageProcessingException(CarErrorMessages::getMessage('image_filename_empty'));
@@ -238,8 +238,7 @@ class CarImageProcessor
             throw new ImageProcessingException(CarErrorMessages::getMessage('image_encoding_failed'));
         }
 
-        $repo = new CarRepository($db);
-        $cas = $repo->updateImage((int) $carData->id, $imageJson, $carData->image);
+        $cas = $this->repo->updateImage((int) $carData->id, $imageJson, $carData->image);
         if (!$cas) {
             throw new CarConcurrentModificationException(
                 "Image list changed concurrently for car {$carData->id}"

--- a/usersc/classes/Car/CarVerificationManager.php
+++ b/usersc/classes/Car/CarVerificationManager.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElanRegistry\Car;
 
 use DateTime;
-use DB;
 use ElanRegistry\AppConstants;
 use ElanRegistry\CarErrorMessages;
 use ElanRegistry\Exceptions\CarDatabaseException;
@@ -25,25 +24,26 @@ use ElanRegistry\LogCategories;
  */
 class CarVerificationManager
 {
+    public function __construct(private CarRepository $repo) {}
+
     /**
      * Set a verification code on a car
      *
      * @param object $carData Car data object (must have ->id property)
      * @param string $verificationCode The verification code to set
-     * @param DB $db Database instance
      * @return bool True if verification code was set successfully
      * @throws CarNotFoundException If car data is invalid
      * @throws CarValidationException If verification code is invalid
      * @throws CarDatabaseException If database update fails
      */
-    public function setVerificationCode(object $carData, string $verificationCode, DB $db): bool
+    public function setVerificationCode(object $carData, string $verificationCode): bool
     {
-        if (empty($verificationCode) || strlen($verificationCode) < 8) {
+        if (strlen($verificationCode) < 8) {
             throw new CarValidationException(CarErrorMessages::getMessage('invalid_verification_code'));
         }
 
         try {
-            $updateSuccess = (new CarRepository($db))->updateVerificationCode((int) $carData->id, $verificationCode);
+            $updateSuccess = $this->repo->updateVerificationCode((int) $carData->id, $verificationCode);
         } catch (\Exception $e) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('verification_code_failed', ['error' => $e->getMessage()]);
             logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
@@ -55,7 +55,7 @@ class CarVerificationManager
             return true;
         }
 
-        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false: ' . $db->errorString()]);
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);
         logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
         throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }
@@ -64,16 +64,15 @@ class CarVerificationManager
      * Mark a car as verified
      *
      * @param object $carData Car data object (must have ->id property)
-     * @param DB $db Database instance
      * @return bool True if car was marked as verified successfully
      * @throws CarDatabaseException If database update fails
      */
-    public function markVerified(object $carData, DB $db): bool
+    public function markVerified(object $carData): bool
     {
         $currentDateTime = date(AppConstants::DATETIME_FORMAT);
 
         try {
-            $updateSuccess = (new CarRepository($db))->updateLastVerified((int) $carData->id, $currentDateTime);
+            $updateSuccess = $this->repo->updateLastVerified((int) $carData->id, $currentDateTime);
         } catch (\Exception $e) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('verification_mark_failed', ['error' => $e->getMessage()]);
             logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
@@ -85,7 +84,7 @@ class CarVerificationManager
             return true;
         }
 
-        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false: ' . $db->errorString()]);
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);
         logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
         throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }
@@ -95,12 +94,11 @@ class CarVerificationManager
      *
      * @param object $carData Car data object (must have ->id property)
      * @param string|null $soldDate Sold date in Y-m-d format (defaults to today)
-     * @param DB $db Database instance
      * @return bool True if car was marked as sold successfully
      * @throws CarValidationException If date format is invalid
      * @throws CarDatabaseException If database update fails
      */
-    public function markSold(object $carData, ?string $soldDate, DB $db): bool
+    public function markSold(object $carData, ?string $soldDate): bool
     {
         $soldDate ??= date('Y-m-d');
 
@@ -110,7 +108,7 @@ class CarVerificationManager
         }
 
         try {
-            $updateSuccess = (new CarRepository($db))->updateSoldDate((int) $carData->id, $soldDate);
+            $updateSuccess = $this->repo->updateSoldDate((int) $carData->id, $soldDate);
         } catch (\Exception $e) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('sold_mark_failed', ['error' => $e->getMessage()]);
             logger(0, LogCategories::LOG_CATEGORY_CAR_SOLD, $technicalMsg);
@@ -122,7 +120,7 @@ class CarVerificationManager
             return true;
         }
 
-        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Database update returned false: ' . $db->errorString()]);
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);
         logger(0, LogCategories::LOG_CATEGORY_CAR_SOLD, $technicalMsg);
         throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }

--- a/usersc/classes/Car/CarVerificationManager.php
+++ b/usersc/classes/Car/CarVerificationManager.php
@@ -55,7 +55,7 @@ class CarVerificationManager
             return true;
         }
 
-        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false: ' . ($this->repo->errorString() ?: 'unknown')]);
         logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
         throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }
@@ -84,7 +84,7 @@ class CarVerificationManager
             return true;
         }
 
-        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false: ' . ($this->repo->errorString() ?: 'unknown')]);
         logger(0, LogCategories::LOG_CATEGORY_CAR_VERIFICATION, $technicalMsg);
         throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }
@@ -120,7 +120,7 @@ class CarVerificationManager
             return true;
         }
 
-        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);
+        $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false: ' . ($this->repo->errorString() ?: 'unknown')]);
         logger(0, LogCategories::LOG_CATEGORY_CAR_SOLD, $technicalMsg);
         throw new CarDatabaseException(CarErrorMessages::getMessage('database_update_failed'));
     }

--- a/usersc/classes/Car/CarVerificationManager.php
+++ b/usersc/classes/Car/CarVerificationManager.php
@@ -32,7 +32,6 @@ class CarVerificationManager
      * @param object $carData Car data object (must have ->id property)
      * @param string $verificationCode The verification code to set
      * @return bool True if verification code was set successfully
-     * @throws CarNotFoundException If car data is invalid
      * @throws CarValidationException If verification code is invalid
      * @throws CarDatabaseException If database update fails
      */


### PR DESCRIPTION
## Summary

- Adds a `CarRepository` constructor parameter to both `CarVerificationManager` and `CarImageProcessor`, eliminating the pattern of instantiating `new CarRepository($db)` inline inside every method body
- `Car.php` passes `$this->getRepository()` (the shared, lazily-initialized instance) to both sub-services, ensuring they operate on the same repository instance
- Removes `DB $db` from 4 method signatures across the two classes; removes `use DB;` imports
- Also removes the PHP 5.3-era `$self = $this; use ($self)` pattern from `Car::transfer()` closures — PHP 8 closures bind `$this` automatically
- Restores MySQL `errorString()` detail in false-return log paths (all three `CarVerificationManager` methods): the static string introduced during simplification lost meaningful error context since `DB::update()` returns `false` on actual MySQL errors

## Test changes

- `CarVerificationManagerTest`: now injects a `CarRepository` mock (removes the `DB::getInstance()` anti-pattern that made these covert integration tests); adds 3 failure-path tests for the false-return branch and 3 `willThrowException` tests for the catch-block re-throw path
- `CarImageProcessorTest`: replaces the `makeDbMockForUpdate()` DB-internals helper with `CarRepository` boundary mocks; adds explicit `never()` assertions on early-exit tests; adds `testRemoveLastImageSetsCarDataImageToEmptyString`
- `ImageFilenameAllowlistTest`: updated 5 inline `new CarImageProcessor()` calls to pass a mock repo

Closes #1244

https://claude.ai/code/session_01RRNUqYWgZRZaWGv5qVBxkZ