### PR TITLE
refactor: decouple Car class from global $user dependency (#1145)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,15 @@ name: Claude Code Review
 #   Claude must explicitly post via `gh pr comment` — the action does not
 #   auto-post Claude's output. Prompts must include that instruction and
 #   Bash(gh pr comment:*) must be in the allowedTools list.
-#   track_progress: true shows a live "Claude is reviewing..." indicator.
+#
+# IMPORTANT — track_progress and agent-mode detection (v1.0+):
+#   Setting track_progress: true forces "tag mode" — the action waits for an
+#   @claude trigger comment and never runs the prompt automatically. To run
+#   automatically on every PR push (agent mode), omit track_progress entirely.
+#   The model input is also deprecated in v1.0; pass --model via claude_args.
+#   The action also validates that the workflow file on the PR branch matches
+#   the default branch. PRs that modify this file will skip the review until
+#   merged — this is intentional security behaviour, not a bug.
 
 on:
   pull_request:
@@ -92,11 +100,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
-          model: "claude-sonnet-5"
+          # Do NOT set track_progress — it forces "tag mode" (waits for @claude
+          # comment trigger) and prevents the prompt from running automatically.
+          # Omitting it lets the action detect "agent mode" from the prompt input.
           claude_args: >-
             --allowedTools
             "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git diff --name-only:*),Bash(php -l *),Bash(composer check:php),Bash(vendor/bin/phpstan analyse:*),Bash(npm run lint),Read,Grep,Glob"
+            --model claude-sonnet-5
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.ctx.outputs.pr_number }}
@@ -235,14 +245,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # track_progress is unsupported for the 'labeled' event — disable it
-          # when the deep-review label triggers this job.
-          track_progress: ${{ github.event.action != 'labeled' }}
+          # Do NOT set track_progress — see pr-to-milestone-review note above.
           # Opus is worth it here: this runs once per milestone, not per push.
-          model: "claude-opus-4-8"
           claude_args: >-
             --allowedTools
             "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(cat merged-prs.txt),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git diff --name-only:*),Bash(php -l *),Bash(composer check:php),Bash(vendor/bin/phpstan analyse:*),Bash(npm run lint),Read,Grep,Glob"
+            --model claude-opus-4-8
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,28 +12,30 @@ on:
 
 jobs:
   claude:
-    # Gate all event types to OWNER or COLLABORATOR — the repo is public so
+    # Gate all event types to OWNER, MEMBER, or COLLABORATOR — the repo is public so
     # ungated triggers would allow any GitHub user to consume the OAuth quota.
+    # CONTRIBUTOR (any past merged-PR author) is deliberately excluded — it is too
+    # broad a trust surface for a public repo.
     if: |
       (
         github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR')
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')
       ) ||
       (
         github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR')
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@claude') &&
-        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'CONTRIBUTOR')
+        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR')
       ) ||
       (
         github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR' || github.event.issue.author_association == 'CONTRIBUTOR')
+        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR')
       )
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,22 +18,22 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR')
       ) ||
       (
         github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR')
       ) ||
       (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@claude') &&
-        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'COLLABORATOR')
+        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'CONTRIBUTOR')
       ) ||
       (
         github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'COLLABORATOR')
+        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR' || github.event.issue.author_association == 'CONTRIBUTOR')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -55,8 +55,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
-          model: "claude-sonnet-5"
           claude_args: >-
+            --model claude-sonnet-5
             --allowedTools
             "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue comment:*),Bash(gh issue view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git diff --name-only:*),Bash(php -l *),Bash(composer check:php),Bash(vendor/bin/phpstan analyse:*),Bash(npm run lint),Read,Grep,Glob"
           custom_instructions: |

--- a/.htaccess
+++ b/.htaccess
@@ -70,7 +70,11 @@ RewriteRule ^vendor/ - [F,L]
 RewriteRule ^backups/ - [F,L]
 
 # Test subdomain: serve a blocking robots.txt without affecting production (#1369)
-RewriteCond %{HTTP_HOST} ^test\.elanregistry\.org [NC]
+# NOTE: Cloudflare fetches robots.txt directly from origin, bypassing Apache rewrites.
+# The test server must have robots-test.txt deployed as robots.txt directly.
+# This rule is retained for environments not behind Cloudflare.
+RewriteCond %{HTTP_HOST} ^test\.elanregistry\.org [NC,OR]
+RewriteCond %{SERVER_NAME} ^test\.elanregistry\.org [NC]
 RewriteRule ^robots\.txt$ /robots-test.txt [L]
 
 # Soft 404 fix: embed.php (removed) and pdf-viewer.php single-param ?doc= format (#1369)

--- a/app/admin/includes/process-transfer-approve.php
+++ b/app/admin/includes/process-transfer-approve.php
@@ -78,7 +78,7 @@ try {
 
     // 2. Transfer car ownership — CarRepository defers to this outer transaction
     // Car::transfer() always returns true or throws; no false return path exists.
-    $car->transfer((int)$transfer->requested_by_user_id, $reason);
+    $car->transfer((int)$transfer->requested_by_user_id, $reason, 'NEWOWNER', (int)$user->data()->id);
 
     $db->commit();
 

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -197,7 +197,7 @@ if (ElanInput::existsPost()) {
                             : "User ID $user_id";
 
                         $reason = "Car was reassigned to $targetName (User ID: $user_id) by admin " . $currentUserId;
-                        $car->transfer((int) $user_id, $reason);
+                        $car->transfer((int) $user_id, $reason, 'NEWOWNER', $currentUserId);
 
                         $successes[] = "Car ID $car_id successfully reassigned to $targetName";
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Car ID $car_id reassigned to User ID $user_id");
@@ -280,7 +280,7 @@ if (ElanInput::existsPost()) {
                     }
 
                     try {
-                        (new Car($new_car_id))->merge($old_car_id, $reason[0]);
+                        (new Car($new_car_id))->merge($old_car_id, $reason[0], $currentUserId);
                         $successes[] = $mergeComment;
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_MERGE, $mergeComment);
                     } catch (CarNotFoundException $e) {
@@ -321,7 +321,7 @@ if (ElanInput::existsPost()) {
                             break;
                         }
                         $chassis = $car->data()->chassis;
-                        $car->delete($reason, $token);
+                        $car->delete($reason, $token, $currentUserId);
                         $successes[] = "Car ID $car_id ($chassis) has been permanently deleted";
                     } catch (CarNotFoundException $e) {
                         // Race: car deleted between the exists() check and delete().

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -7,7 +7,6 @@ use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarDeletionException;
 use ElanRegistry\Exceptions\CarMergeException;
 use ElanRegistry\Exceptions\CarNotFoundException;
-use ElanRegistry\Exceptions\CarPermissionException;
 use ElanRegistry\Input as ElanInput;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Owner;
@@ -201,9 +200,6 @@ if (ElanInput::existsPost()) {
 
                         $successes[] = "Car ID $car_id successfully reassigned to $targetName";
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Car ID $car_id reassigned to User ID $user_id");
-                    } catch (CarPermissionException $e) {
-                        $errors[] = "Permission denied for car ID {$car_id}.";
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_ACCESS_DENIED, "Car reassignment permission denied for Car ID {$car_id}: " . $e->getMessage());
                     } catch (\Throwable $e) {
                         $errors[] = 'Transfer failed. Please try again.';
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed for Car ID $car_id: " . $e->getMessage());

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 use ElanRegistry\AppConstants;
 use ElanRegistry\Car\Car;
-use ElanRegistry\Exceptions\CarConcurrentModificationException;
 use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarDeletionException;
 use ElanRegistry\Exceptions\CarMergeException;
@@ -208,9 +207,6 @@ if (ElanInput::existsPost()) {
                     } catch (CarValidationException $e) {
                         $errors[] = $e->getUserMessage();
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — validation error: " . $e->getMessage());
-                    } catch (CarConcurrentModificationException $e) {
-                        $errors[] = 'Transfer was not applied — the record changed mid-operation. Please retry.';
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — concurrent modification: " . $e->getMessage());
                     } catch (CarDatabaseException $e) {
                         $errors[] = 'Transfer failed due to a database error. Check the admin log for details.';
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — DB error: " . $e->getMessage());

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -7,6 +7,7 @@ use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarDeletionException;
 use ElanRegistry\Exceptions\CarMergeException;
 use ElanRegistry\Exceptions\CarNotFoundException;
+use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\Input as ElanInput;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Owner;
@@ -200,9 +201,18 @@ if (ElanInput::existsPost()) {
 
                         $successes[] = "Car ID $car_id successfully reassigned to $targetName";
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_ACTIONS, "Car ID $car_id reassigned to User ID $user_id");
+                    } catch (CarNotFoundException $e) {
+                        $errors[] = "Car ID $car_id could not be found.";
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — car not found. " . $e->getMessage());
+                    } catch (CarValidationException $e) {
+                        $errors[] = $e->getUserMessage();
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — validation error: " . $e->getMessage());
+                    } catch (CarDatabaseException $e) {
+                        $errors[] = 'Transfer failed due to a database error. Check the admin log for details.';
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — DB error: " . $e->getMessage());
                     } catch (\Throwable $e) {
-                        $errors[] = 'Transfer failed. Please try again.';
-                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed for Car ID $car_id: " . $e->getMessage());
+                        $errors[] = 'Transfer failed due to an unexpected error. Check the admin log for details.';
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment unexpected error [" . get_class($e) . "]: " . $e->getMessage());
                     }
                     break;
 

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use ElanRegistry\AppConstants;
 use ElanRegistry\Car\Car;
+use ElanRegistry\Exceptions\CarConcurrentModificationException;
 use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarDeletionException;
 use ElanRegistry\Exceptions\CarMergeException;
@@ -207,6 +208,9 @@ if (ElanInput::existsPost()) {
                     } catch (CarValidationException $e) {
                         $errors[] = $e->getUserMessage();
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — validation error: " . $e->getMessage());
+                    } catch (CarConcurrentModificationException $e) {
+                        $errors[] = 'Transfer was not applied — the record changed mid-operation. Please retry.';
+                        logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — concurrent modification: " . $e->getMessage());
                     } catch (CarDatabaseException $e) {
                         $errors[] = 'Transfer failed due to a database error. Check the admin log for details.';
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER_ERROR, "Car reassignment failed — DB error: " . $e->getMessage());
@@ -329,7 +333,7 @@ if (ElanInput::existsPost()) {
                             "Car ID $car_id not found during deletion attempt");
                         $errors[] = "Car ID $car_id not found";
                     } catch (CarDeletionException | CarDatabaseException $e) {
-                        // CarAdministrationService::delete() logs technical detail before throwing.
+                        // Car::delete() logs CSRF failures; CarAdministrationService::delete() logs DB failures.
                         $errors[] = "Failed to delete car. Check the system log for details.";
                     } catch (\Throwable $e) {
                         logger($currentUserId, LogCategories::LOG_CATEGORY_CAR_DELETION,

--- a/docs/.htaccess
+++ b/docs/.htaccess
@@ -15,9 +15,6 @@ Options -Indexes
     Require all denied
 </Files>
 
-# Viewer renames
-Redirect 301 /docs/embed.php /docs/pdf-viewer.php
-
 # Redirects for doc reorganization (#559)
 Redirect 301 /docs/reference-library.php /docs/reference/index.php
 Redirect 301 /docs/faq/index.php /docs/guides/index.php

--- a/docs/development/CLASSES.md
+++ b/docs/development/CLASSES.md
@@ -133,7 +133,7 @@ All exception classes are in the `ElanRegistry\Exceptions` namespace:
 - `CarNotFoundException` - Car ID not found (404)
 - `CarValidationException` - Invalid car data (422)
 - `CarDatabaseException` - Database operation failures (500)
-- `CarPermissionException` - Permission/auth denied (403)
+- `CarPermissionException` - Permission/auth denied (403) *(no production code throws this post-v2.28.0; retained for hierarchy completeness)*
 - `CarCreationException` - Car creation failures (500)
 - `CarDeletionException` - Car deletion failures (500)
 - `CarMergeException` - Car merge failures (500)
@@ -146,7 +146,7 @@ All exception classes are in the `ElanRegistry\Exceptions` namespace:
 | Car ID not found in database | CarNotFoundException | User tries to edit car that was deleted |
 | Validation of user input fails | CarValidationException | Invalid chassis format, missing required field |
 | Database query/operation fails | CarDatabaseException | INSERT fails, UPDATE fails, deadlock |
-| User lacks permission | CarPermissionException | Non-owner trying to edit someone else's car |
+| User lacks permission | CarPermissionException | Non-owner trying to edit someone else's car *(unthrown post-v2.28.0 — auth gates moved to callers; class retained for hierarchy)* |
 | Car creation fails | CarCreationException | Cannot create car due to validation or database issue |
 | Car deletion fails | CarDeletionException | Cannot delete car, foreign key constraint |
 | Car merge operation fails | CarMergeException | Cannot merge duplicate cars |

--- a/docs/development/ERROR_HANDLING.md
+++ b/docs/development/ERROR_HANDLING.md
@@ -137,7 +137,7 @@ handling and logging.
 | CarDeletionException | 500 | CarDeletion | Car deletion |
 | CarMergeException | 500 | CarMerge | Car merge operation |
 | CarNotFoundException | 404 | CarErrors | Car not found |
-| CarPermissionException | 403 | AccessDenied | Car permission denied |
+| CarPermissionException | 403 | AccessDenied | Car permission denied *(no production throw site post-v2.28.0; retained for hierarchy)* |
 | CarTransferException | 500 | CarTransferError | Ownership transfer |
 | CarValidationException | 422 | ValidationError | Car data validation |
 | OwnerCreationException | 500 | OwnerCreation | Owner creation |

--- a/scripts/server-hooks/post-receive
+++ b/scripts/server-hooks/post-receive
@@ -47,6 +47,13 @@ do
         exit 1
     }
 
+    # Cloudflare fetches robots.txt directly from origin, bypassing Apache rewrites.
+    # Override with the blocking version on test so crawlers are never admitted.
+    if [ "$ENV_NAME" = "Test" ]; then
+        cp "$WORK_TREE/robots-test.txt" "$WORK_TREE/robots.txt"
+        echo "Test environment: robots.txt replaced with robots-test.txt (crawler block)."
+    fi
+
     cd "$WORK_TREE" || { echo "ERROR: cannot cd to WORK_TREE=$WORK_TREE — deployment halted."; exit 1; }
 
     # Generate VERSION file from latest matching tag

--- a/tests/integration/CarDeletionTest.php
+++ b/tests/integration/CarDeletionTest.php
@@ -58,7 +58,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->assertTrue($car->exists());
 
         $token = Token::generate();
-        $result = $car->delete('Test deletion', $token);
+        $result = $car->delete('Test deletion', $token, 1);
 
         $this->assertTrue($result);
         $this->assertFalse($car->exists());
@@ -73,7 +73,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->expectException(CarDeletionException::class);
 
         $car = new Car($this->testCarId);
-        $car->delete('Test deletion', 'invalid-token-12345');
+        $car->delete('Test deletion', 'invalid-token-12345', 1);
     }
 
     /**
@@ -85,7 +85,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->expectException(CarDeletionException::class);
 
         $car = new Car($this->testCarId);
-        $car->delete('Test deletion', '');
+        $car->delete('Test deletion', '', 1);
     }
 
     /**
@@ -97,7 +97,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->expectException(CarNotFoundException::class);
 
         $car = new Car(99999);
-        $car->delete('Test deletion', Token::generate());
+        $car->delete('Test deletion', Token::generate(), 1);
     }
 
     /**
@@ -112,7 +112,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $car = new Car($this->testCarId);
         $carId = $car->data()->id;
 
-        $result = $car->delete('Test deletion for audit', Token::generate());
+        $result = $car->delete('Test deletion for audit', Token::generate(), 1);
 
         $this->assertTrue($result);
 
@@ -135,7 +135,7 @@ final class CarDeletionTest extends IntegrationTestCase
     {
         // First deletion — must succeed
         $car = new Car($this->testCarId);
-        $car->delete('First deletion', Token::generate());
+        $car->delete('First deletion', Token::generate(), 1);
 
         // tearDown will attempt to clean up $this->testCarId; if the car is
         // already gone the cleanup silently ignores the missing row.
@@ -143,7 +143,29 @@ final class CarDeletionTest extends IntegrationTestCase
         // Second deletion on the same ID — car no longer exists
         $this->expectException(CarNotFoundException::class);
         $car2 = new Car($this->testCarId);
-        $car2->delete('Second deletion', Token::generate());
+        $car2->delete('Second deletion', Token::generate(), 1);
+    }
+
+    /**
+     * Test delete works with an explicit actingUserId even when global $user is unset.
+     * Verifies that Car::delete() does not fall back to currentUserId() internally.
+     */
+    #[Group('fast')]
+    public function testDeleteHonorsExplicitActingUserIdWithoutGlobalUser(): void
+    {
+        $savedUser = $GLOBALS['user'] ?? null;
+        unset($GLOBALS['user']);
+
+        try {
+            $car = new Car($this->testCarId);
+            $token = Token::generate();
+            $result = $car->delete('Explicit actingUserId test', $token, 1);
+            $this->assertTrue($result);
+        } finally {
+            if ($savedUser !== null) {
+                $GLOBALS['user'] = $savedUser;
+            }
+        }
     }
 
 }

--- a/tests/integration/CarDeletionTest.php
+++ b/tests/integration/CarDeletionTest.php
@@ -124,61 +124,6 @@ final class CarDeletionTest extends IntegrationTestCase
     }
 
     /**
-     * Test car deletion transaction rollback on failure
-     */
-    #[Group('fast')]
-    public function testDeleteTransactionRollbackOnFailure(): void
-    {
-        // This test verifies that if any step fails, the transaction rolls back
-        // It's challenging to test without mocking the database
-        // For now, we verify that attempting to delete without auth fails
-
-        $this->expectException(CarDeletionException::class);
-
-        // Create a car without authentication context
-        $car = new Car($this->testCarId);
-
-        // Mock: Unset global user to simulate no authentication
-        global $user;
-        $originalUser = $user ?? null;
-        unset($GLOBALS['user']);
-
-        try {
-            $car->delete('Test deletion', Token::generate());
-        } finally {
-            // Restore user
-            if ($originalUser) {
-                $GLOBALS['user'] = $originalUser;
-            }
-        }
-    }
-
-    /**
-     * Test car deletion requires authenticated user
-     */
-    #[Group('fast')]
-    public function testDeleteRequiresAuthenticatedUser(): void
-    {
-        $this->expectException(CarDeletionException::class);
-
-        $car = new Car($this->testCarId);
-
-        // Mock: Unset global user to simulate no authentication
-        global $user;
-        $originalUser = $user ?? null;
-        unset($GLOBALS['user']);
-
-        try {
-            $car->delete('Test deletion', Token::generate());
-        } finally {
-            // Restore user
-            if ($originalUser) {
-                $GLOBALS['user'] = $originalUser;
-            }
-        }
-    }
-
-    /**
      * Test that deleting an already-deleted car throws CarNotFoundException.
      *
      * This exercises the path added in issue #1311: when the first deletion

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -60,7 +60,7 @@ final class CarMergeTest extends IntegrationTestCase
     public function testMergeCarSuccessWithValidOldCar(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->merge($this->testMergeCarId, 'Test merge success');
+        $result = $car->merge($this->testMergeCarId, 'Test merge success', 1);
 
         $this->assertTrue($result);
     }
@@ -74,7 +74,7 @@ final class CarMergeTest extends IntegrationTestCase
         $this->expectException(CarNotFoundException::class);
 
         $car = new Car(99999);
-        $car->merge($this->testMergeCarId, 'Test merge');
+        $car->merge($this->testMergeCarId, 'Test merge', 1);
     }
 
     /**
@@ -86,7 +86,7 @@ final class CarMergeTest extends IntegrationTestCase
         $this->expectException(CarNotFoundException::class);
 
         $car = new Car($this->testCarId);
-        $car->merge(99999, 'Test merge');
+        $car->merge(99999, 'Test merge', 1);
     }
 
     /**
@@ -98,7 +98,7 @@ final class CarMergeTest extends IntegrationTestCase
         $this->expectException(CarValidationException::class);
 
         $car = new Car($this->testCarId);
-        $car->merge($this->testCarId, 'Test merge');
+        $car->merge($this->testCarId, 'Test merge', 1);
     }
 
     /**
@@ -108,7 +108,7 @@ final class CarMergeTest extends IntegrationTestCase
     public function testMergeTransfersHistoryRecords(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->merge($this->testMergeCarId, 'Test merge history transfer');
+        $result = $car->merge($this->testMergeCarId, 'Test merge history transfer', 1);
 
         $this->assertTrue($result);
 
@@ -129,7 +129,7 @@ final class CarMergeTest extends IntegrationTestCase
         $oldCarId = $this->testMergeCarId;
 
         $car = new Car($this->testCarId);
-        $result = $car->merge($oldCarId, 'Test merge deletes old car');
+        $result = $car->merge($oldCarId, 'Test merge deletes old car', 1);
 
         $this->assertTrue($result);
 
@@ -145,7 +145,7 @@ final class CarMergeTest extends IntegrationTestCase
     public function testMergeCreatesAuditTrail(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->merge($this->testMergeCarId, 'Test merge audit trail');
+        $result = $car->merge($this->testMergeCarId, 'Test merge audit trail', 1);
 
         $this->assertTrue($result);
 
@@ -169,7 +169,7 @@ final class CarMergeTest extends IntegrationTestCase
 
         try {
             // Attempt to merge non-existent car
-            $car->merge(99999, 'Test merge');
+            $car->merge(99999, 'Test merge', 1);
         } catch (CarNotFoundException $e) {
             // After failed merge, original car should still exist
             $carReloaded = new Car((int) $car->data()->id);
@@ -195,7 +195,7 @@ final class CarMergeTest extends IntegrationTestCase
         // The target car still exists; the source is gone — merge must throw
         $this->expectException(CarNotFoundException::class);
         $car = new Car($this->testCarId);
-        $car->merge($this->testMergeCarId, 'Test merge after source deletion');
+        $car->merge($this->testMergeCarId, 'Test merge after source deletion', 1);
     }
 
     /**
@@ -288,5 +288,26 @@ final class CarMergeTest extends IntegrationTestCase
             $histCountAfter,
             'cars_hist rows must remain on testCarId after rollback'
         );
+    }
+
+    /**
+     * Test merge works with an explicit actingUserId even when global $user is unset.
+     * Verifies that Car::merge() does not fall back to currentUserId() internally.
+     */
+    #[Group('fast')]
+    public function testMergeHonorsExplicitActingUserIdWithoutGlobalUser(): void
+    {
+        $savedUser = $GLOBALS['user'] ?? null;
+        unset($GLOBALS['user']);
+
+        try {
+            $car = new Car($this->testCarId);
+            $result = $car->merge($this->testMergeCarId, 'Explicit actingUserId test', 1);
+            $this->assertTrue($result);
+        } finally {
+            if ($savedUser !== null) {
+                $GLOBALS['user'] = $savedUser;
+            }
+        }
     }
 }

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -6,7 +6,6 @@ require_once __DIR__ . '/IntegrationTestCase.php';
 
 use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\CarNotFoundException;
-use ElanRegistry\Exceptions\CarPermissionException;
 use ElanRegistry\Exceptions\CarValidationException;
 
 use PHPUnit\Framework\Attributes\Group;
@@ -176,31 +175,6 @@ final class CarMergeTest extends IntegrationTestCase
             $carReloaded = new Car((int) $car->data()->id);
             $this->assertTrue($carReloaded->exists());
             throw $e;
-        }
-    }
-
-    /**
-     * Test car merge requires authenticated user
-     */
-    #[Group('fast')]
-    public function testMergeRequiresAuthenticatedUser(): void
-    {
-        $this->expectException(CarPermissionException::class);
-
-        $car = new Car($this->testCarId);
-
-        // Mock: Unset global user to simulate no authentication
-        global $user;
-        $originalUser = $user ?? null;
-        unset($GLOBALS['user']);
-
-        try {
-            $car->merge($this->testMergeCarId, 'Test merge');
-        } finally {
-            // Restore user
-            if ($originalUser) {
-                $GLOBALS['user'] = $originalUser;
-            }
         }
     }
 

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
-use ElanRegistry\Exceptions\CarPermissionException;
 use ElanRegistry\Owner;
 
 use PHPUnit\Framework\Attributes\Group;
@@ -192,31 +191,6 @@ final class CarTransferTest extends IntegrationTestCase
             $carReloaded = new Car((int) $car->data()->id);
             $this->assertEquals($originalUserId, $carReloaded->data()->user_id);
             throw $e;
-        }
-    }
-
-    /**
-     * Test car transfer requires authenticated user
-     */
-    #[Group('fast')]
-    public function testTransferRequiresAuthenticatedUser(): void
-    {
-        $this->expectException(CarPermissionException::class);
-
-        $car = new Car($this->testCarId);
-
-        // Mock: Unset global user to simulate no authentication
-        global $user;
-        $originalUser = $user ?? null;
-        unset($GLOBALS['user']);
-
-        try {
-            $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER');
-        } finally {
-            // Restore user
-            if ($originalUser) {
-                $GLOBALS['user'] = $originalUser;
-            }
         }
     }
 

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -67,7 +67,7 @@ final class CarTransferTest extends IntegrationTestCase
     {
         $car = new Car($this->testCarId);
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER');
+        $result = $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -85,7 +85,7 @@ final class CarTransferTest extends IntegrationTestCase
         $this->expectException(Exception::class);
 
         $car = new Car($this->testCarId);
-        $car->transfer(99999, 'Test transfer', 'NEWOWNER');
+        $car->transfer(99999, 'Test transfer', 'NEWOWNER', $this->testUserId);
     }
 
     /**
@@ -97,7 +97,7 @@ final class CarTransferTest extends IntegrationTestCase
         $this->expectException(Exception::class);
 
         $car = new Car(99999);
-        $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER');
+        $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER', $this->testUserId);
     }
 
     /**
@@ -116,7 +116,7 @@ final class CarTransferTest extends IntegrationTestCase
         )->first();
         $this->assertSame($this->testUserId, (int) $before->user_id);
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER');
+        $result = $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -137,7 +137,7 @@ final class CarTransferTest extends IntegrationTestCase
         $car = new Car($this->testCarId);
         $carId = $car->data()->id;
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer history', 'NEWOWNER');
+        $result = $car->transfer($this->targetUserId, 'Test transfer history', 'NEWOWNER', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -161,7 +161,7 @@ final class CarTransferTest extends IntegrationTestCase
         $targetUser = (new Owner($this->targetUserId))->data();
         $this->assertNotNull($targetUser);
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer profile', 'NEWOWNER');
+        $result = $car->transfer($this->targetUserId, 'Test transfer profile', 'NEWOWNER', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -185,7 +185,7 @@ final class CarTransferTest extends IntegrationTestCase
         $originalUserId = $car->data()->user_id;
 
         try {
-            $car->transfer(99999, 'Test transfer', 'NEWOWNER');
+            $car->transfer(99999, 'Test transfer', 'NEWOWNER', $this->testUserId);
         } catch (Exception $e) {
             // After failed transfer, car should still have original owner
             $carReloaded = new Car((int) $car->data()->id);
@@ -203,7 +203,7 @@ final class CarTransferTest extends IntegrationTestCase
         $car = new Car($this->testCarId);
         $carId = $car->data()->id;
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer', 'TRANSFER');
+        $result = $car->transfer($this->targetUserId, 'Test transfer', 'TRANSFER', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -223,7 +223,7 @@ final class CarTransferTest extends IntegrationTestCase
     {
         $car = new Car($this->testCarId);
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer location', 'NEWOWNER');
+        $result = $car->transfer($this->targetUserId, 'Test transfer location', 'NEWOWNER', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -234,5 +234,26 @@ final class CarTransferTest extends IntegrationTestCase
         $this->assertEquals($targetUser->city ?? '', $updatedCar->data()->city);
         $this->assertEquals($targetUser->state ?? '', $updatedCar->data()->state);
         $this->assertEquals($targetUser->country ?? '', $updatedCar->data()->country);
+    }
+
+    /**
+     * Test transfer works with an explicit actingUserId even when global $user is unset.
+     * Verifies that Car::transfer() does not fall back to currentUserId() internally.
+     */
+    #[Group('fast')]
+    public function testTransferHonorsExplicitActingUserIdWithoutGlobalUser(): void
+    {
+        $savedUser = $GLOBALS['user'] ?? null;
+        unset($GLOBALS['user']);
+
+        try {
+            $car = new Car($this->testCarId);
+            $result = $car->transfer($this->targetUserId, 'Explicit actingUserId test', 'NEWOWNER', $this->testUserId);
+            $this->assertTrue($result);
+        } finally {
+            if ($savedUser !== null) {
+                $GLOBALS['user'] = $savedUser;
+            }
+        }
     }
 }

--- a/tests/integration/ManageConsolidatedDeletionTest.php
+++ b/tests/integration/ManageConsolidatedDeletionTest.php
@@ -62,7 +62,7 @@ final class ManageConsolidatedDeletionTest extends IntegrationTestCase
     public function testManageConsolidatedDeleteCreatesExactlyOneAuditRow(): void
     {
         $car = new Car($this->testCarId);
-        $car->delete('Integration test deletion', Token::generate());
+        $car->delete('Integration test deletion', Token::generate(), $this->testUserId);
 
         $historyQuery = $this->db->query(
             "SELECT * FROM cars_hist WHERE car_id = ? AND operation = 'DELETE'",

--- a/tests/integration/database/CarDatabaseOperationsTest.php
+++ b/tests/integration/database/CarDatabaseOperationsTest.php
@@ -128,7 +128,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
     public function testCarDeletionRemovesFromDatabase(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->delete('Integration test deletion', Token::generate());
+        $result = $car->delete('Integration test deletion', Token::generate(), $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -144,7 +144,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
     public function testCarDeletionCreatesAuditTrail(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->delete('Integration test audit trail', Token::generate());
+        $result = $car->delete('Integration test audit trail', Token::generate(), $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -173,7 +173,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
         $this->assertSame($this->testUserId, (int) $origRelation->user_id);
 
         // Transfer car
-        $result = $car->transfer($targetUserId, 'Integration test transfer', 'NEWOWNER');
+        $result = $car->transfer($targetUserId, 'Integration test transfer', 'NEWOWNER', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -194,7 +194,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
         $car = new Car($this->testCarId);
 
         // Transfer car to existing user ID 10 (FredHansen)
-        $result = $car->transfer(10, 'Integration test transfer history', 'NEWOWNER');
+        $result = $car->transfer(10, 'Integration test transfer history', 'NEWOWNER', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -218,7 +218,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
         ]);
 
         $car = new Car($this->testCarId);
-        $result = $car->merge($mergeCarId, 'Integration test merge');
+        $result = $car->merge($mergeCarId, 'Integration test merge', $this->testUserId);
 
         $this->assertTrue($result);
 

--- a/tests/integration/database/CarsYearSmallintMigrationTest.php
+++ b/tests/integration/database/CarsYearSmallintMigrationTest.php
@@ -474,7 +474,7 @@ final class CarsYearSmallintMigrationTest extends IntegrationTestCase
         $this->localCarIds[] = $carId;
 
         $car    = new Car($carId);
-        $result = $car->delete('Migration test deletion', Token::generate());
+        $result = $car->delete('Migration test deletion', Token::generate(), $this->testUserId);
 
         $this->assertTrue($result, 'Car::delete() must return true on success');
 

--- a/tests/unit/cars/services/CarAdministrationServiceTest.php
+++ b/tests/unit/cars/services/CarAdministrationServiceTest.php
@@ -64,6 +64,7 @@ final class CarAdministrationServiceTest extends TestCase
 
     public function testTransferSucceeds(): void
     {
+        // userId=1 triggers (new Owner(1))->data() which requires user 1 in the test DB fixture.
         $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
 
         $repo = $this->createMock(CarRepository::class);

--- a/tests/unit/cars/services/CarAdministrationServiceTest.php
+++ b/tests/unit/cars/services/CarAdministrationServiceTest.php
@@ -62,6 +62,21 @@ final class CarAdministrationServiceTest extends TestCase
         $this->service->transfer($carData, 0, 'Test transfer reason', 'NEWOWNER', 1, $this->repo);
     }
 
+    public function testTransferSucceeds(): void
+    {
+        $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
+
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('beginTransaction');
+        $repo->expects($this->once())->method('updateCar')->willReturn(true);
+        $repo->expects($this->once())->method('insertHistory')->willReturn(true);
+        $repo->expects($this->once())->method('commit');
+        $repo->expects($this->never())->method('rollback');
+
+        $result = $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
+        $this->assertTrue($result);
+    }
+
     public function testTransferThrowsCarDatabaseExceptionWhenUpdateFails(): void
     {
         $this->expectException(CarDatabaseException::class);
@@ -72,6 +87,7 @@ final class CarAdministrationServiceTest extends TestCase
         $repo->expects($this->once())->method('beginTransaction');
         $repo->expects($this->once())->method('updateCar')->willReturn(false);
         $repo->expects($this->once())->method('rollback');
+        $repo->expects($this->never())->method('commit');
 
         $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
     }
@@ -87,6 +103,7 @@ final class CarAdministrationServiceTest extends TestCase
         $repo->expects($this->once())->method('updateCar')->willReturn(true);
         $repo->expects($this->once())->method('insertHistory')->willReturn(false);
         $repo->expects($this->once())->method('rollback');
+        $repo->expects($this->never())->method('commit');
 
         $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
     }
@@ -164,6 +181,41 @@ final class CarAdministrationServiceTest extends TestCase
         $repo->expects($this->once())->method('findByIdForUpdate')->willReturn($sourceData);
         $repo->expects($this->once())->method('transferHistory')->willReturn(false);
         $repo->expects($this->once())->method('rollback');
+
+        $this->expectException(CarDatabaseException::class);
+        $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);
+    }
+
+    public function testMergeThrowsCarDatabaseExceptionWhenDeleteCarFails(): void
+    {
+        $targetCarData = (object) ['id' => 1, 'chassis' => 'TARGET01'];
+        $sourceData = (object) ['id' => 999, 'chassis' => 'SOURCE01'];
+
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('beginTransaction');
+        $repo->expects($this->once())->method('findByIdForUpdate')->willReturn($sourceData);
+        $repo->expects($this->once())->method('transferHistory')->willReturn(true);
+        $repo->expects($this->once())->method('deleteCar')->willReturn(false);
+        $repo->expects($this->once())->method('rollback');
+        $repo->expects($this->never())->method('commit');
+
+        $this->expectException(CarDatabaseException::class);
+        $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);
+    }
+
+    public function testMergeThrowsCarDatabaseExceptionWhenInsertHistoryFails(): void
+    {
+        $targetCarData = (object) ['id' => 1, 'chassis' => 'TARGET01'];
+        $sourceData = (object) ['id' => 999, 'chassis' => 'SOURCE01'];
+
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('beginTransaction');
+        $repo->expects($this->once())->method('findByIdForUpdate')->willReturn($sourceData);
+        $repo->expects($this->once())->method('transferHistory')->willReturn(true);
+        $repo->expects($this->once())->method('deleteCar')->willReturn(true);
+        $repo->expects($this->once())->method('insertHistory')->willReturn(false);
+        $repo->expects($this->once())->method('rollback');
+        $repo->expects($this->never())->method('commit');
 
         $this->expectException(CarDatabaseException::class);
         $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);

--- a/tests/unit/cars/services/CarAdministrationServiceTest.php
+++ b/tests/unit/cars/services/CarAdministrationServiceTest.php
@@ -162,6 +162,7 @@ final class CarAdministrationServiceTest extends TestCase
         $repo->expects($this->once())->method('beginTransaction');
         $repo->expects($this->once())->method('findByIdForUpdate')->willReturn(null);
         $repo->expects($this->once())->method('rollback');
+        $repo->expects($this->never())->method('commit');
 
         $this->expectException(CarNotFoundException::class);
         $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);
@@ -181,6 +182,7 @@ final class CarAdministrationServiceTest extends TestCase
         $repo->expects($this->once())->method('findByIdForUpdate')->willReturn($sourceData);
         $repo->expects($this->once())->method('transferHistory')->willReturn(false);
         $repo->expects($this->once())->method('rollback');
+        $repo->expects($this->never())->method('commit');
 
         $this->expectException(CarDatabaseException::class);
         $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);

--- a/tests/unit/cars/services/CarAdministrationServiceTest.php
+++ b/tests/unit/cars/services/CarAdministrationServiceTest.php
@@ -59,16 +59,7 @@ final class CarAdministrationServiceTest extends TestCase
 
         $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
 
-        $this->service->transfer(
-            $carData,
-            0,
-            'Test transfer reason',
-            'NEWOWNER',
-            1,
-            $this->repo,
-            fn($fields) => true,
-            fn($carId) => (object) []
-        );
+        $this->service->transfer($carData, 0, 'Test transfer reason', 'NEWOWNER', 1, $this->repo);
     }
 
     public function testTransferThrowsCarDatabaseExceptionWhenUpdateFails(): void
@@ -77,16 +68,27 @@ final class CarAdministrationServiceTest extends TestCase
 
         $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
 
-        $this->service->transfer(
-            $carData,
-            1,
-            'Test transfer reason',
-            'NEWOWNER',
-            1,
-            $this->repo,
-            fn($fields) => false,
-            fn($carId) => (object) []
-        );
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('beginTransaction');
+        $repo->expects($this->once())->method('updateCar')->willReturn(false);
+        $repo->expects($this->once())->method('rollback');
+
+        $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
+    }
+
+    public function testTransferThrowsCarDatabaseExceptionWhenInsertHistoryFails(): void
+    {
+        $this->expectException(CarDatabaseException::class);
+
+        $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
+
+        $repo = $this->createMock(CarRepository::class);
+        $repo->expects($this->once())->method('beginTransaction');
+        $repo->expects($this->once())->method('updateCar')->willReturn(true);
+        $repo->expects($this->once())->method('insertHistory')->willReturn(false);
+        $repo->expects($this->once())->method('rollback');
+
+        $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
     }
 
     // =========================================================================

--- a/usersc/classes/Car/Car.php
+++ b/usersc/classes/Car/Car.php
@@ -423,6 +423,7 @@ class Car
     public function delete(string $reason, string $token): bool
     {
         if (!Token::check($token)) {
+            logger(currentUserId() ?: 0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Car deletion rejected: invalid CSRF token');
             throw new CarDeletionException(CarErrorMessages::getMessage('csrf_token_invalid', 'admin', ['operation' => 'car deletion']));
         }
 

--- a/usersc/classes/Car/Car.php
+++ b/usersc/classes/Car/Car.php
@@ -25,6 +25,8 @@ use ElanRegistry\LogCategories;
  * Administration methods (delete, transfer, merge) require an explicit
  * $actingUserId parameter (added v2.28.0) — callers are responsible for
  * ensuring the acting user is authenticated before invoking those methods.
+ * All current callers enforce this via securePage()/requireAdminAjax()
+ * before resolving $actingUserId from currentUserId() or $user->data()->id.
  *
  * @author Jim Boone
  * @version 2.15.0

--- a/usersc/classes/Car/Car.php
+++ b/usersc/classes/Car/Car.php
@@ -417,16 +417,14 @@ class Car
      *
      * @param string $reason Reason for deletion (for audit trail)
      * @param string $token CSRF token (required)
-     * @param int $actingUserId ID of the user performing the action (0 falls back to currentUserId())
+     * @param int $actingUserId ID of the user performing the action
      * @return bool True if deletion was successful
      * @throws Exception If validation fails or database operation fails
      */
-    public function delete(string $reason, string $token, int $actingUserId = 0): bool
+    public function delete(string $reason, string $token, int $actingUserId): bool
     {
-        $userId = $actingUserId ?: currentUserId();
-
         if (!Token::check($token)) {
-            logger($userId, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Car deletion rejected: invalid CSRF token');
+            logger($actingUserId, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Car deletion rejected: invalid CSRF token');
             throw new CarDeletionException(CarErrorMessages::getMessage('csrf_token_invalid', 'admin', ['operation' => 'car deletion']));
         }
 
@@ -439,7 +437,7 @@ class Car
         $this->getAdministrationService()->delete(
             $this->_data,
             $reason,
-            $userId,
+            $actingUserId,
             $this->getRepository()
         );
 
@@ -458,13 +456,13 @@ class Car
      * @param int $newUserId The user ID to transfer ownership to
      * @param string $reason Reason for transfer (for audit trail)
      * @param string $operationType Operation type for history
-     * @param int $actingUserId ID of the user performing the action (0 falls back to currentUserId())
+     * @param int $actingUserId ID of the user performing the action
      * @return true Always returns true; throws on any failure.
      * @throws CarNotFoundException If the car does not exist
      * @throws CarValidationException If the target user does not exist
      * @throws CarDatabaseException If a database operation fails
      */
-    public function transfer(int $newUserId, string $reason = 'Administrative transfer', string $operationType = 'NEWOWNER', int $actingUserId = 0): true
+    public function transfer(int $newUserId, string $reason, string $operationType, int $actingUserId): true
     {
         if (!$this->exists()) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('car_not_found_transfer', ['id' => 'unknown']);
@@ -477,7 +475,7 @@ class Car
             $newUserId,
             $reason,
             $operationType,
-            $actingUserId ?: currentUserId(),
+            $actingUserId,
             $this->getRepository()
         );
     }
@@ -487,11 +485,11 @@ class Car
      *
      * @param int $oldCarId The car ID to merge into this car (will be deleted)
      * @param string $reason Reason for merge (for audit trail)
-     * @param int $actingUserId ID of the user performing the action (0 falls back to currentUserId())
+     * @param int $actingUserId ID of the user performing the action
      * @return bool True if merge was successful
      * @throws Exception If validation fails or database operation fails
      */
-    public function merge(int $oldCarId, string $reason = 'Administrative merge', int $actingUserId = 0): bool
+    public function merge(int $oldCarId, string $reason, int $actingUserId): bool
     {
         if (!$this->exists()) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('car_not_found_merge', ['id' => 'target']);
@@ -503,7 +501,7 @@ class Car
             $this->_data,
             $oldCarId,
             $reason,
-            $actingUserId ?: currentUserId(),
+            $actingUserId,
             $this->getRepository()
         );
 

--- a/usersc/classes/Car/Car.php
+++ b/usersc/classes/Car/Car.php
@@ -417,13 +417,16 @@ class Car
      *
      * @param string $reason Reason for deletion (for audit trail)
      * @param string $token CSRF token (required)
+     * @param int $actingUserId ID of the user performing the action (0 falls back to currentUserId())
      * @return bool True if deletion was successful
      * @throws Exception If validation fails or database operation fails
      */
-    public function delete(string $reason, string $token): bool
+    public function delete(string $reason, string $token, int $actingUserId = 0): bool
     {
+        $userId = $actingUserId ?: currentUserId();
+
         if (!Token::check($token)) {
-            logger(currentUserId(), LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Car deletion rejected: invalid CSRF token');
+            logger($userId, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Car deletion rejected: invalid CSRF token');
             throw new CarDeletionException(CarErrorMessages::getMessage('csrf_token_invalid', 'admin', ['operation' => 'car deletion']));
         }
 
@@ -436,7 +439,7 @@ class Car
         $this->getAdministrationService()->delete(
             $this->_data,
             $reason,
-            currentUserId(),
+            $userId,
             $this->getRepository()
         );
 
@@ -455,12 +458,13 @@ class Car
      * @param int $newUserId The user ID to transfer ownership to
      * @param string $reason Reason for transfer (for audit trail)
      * @param string $operationType Operation type for history
+     * @param int $actingUserId ID of the user performing the action (0 falls back to currentUserId())
      * @return true Always returns true; throws on any failure.
      * @throws CarNotFoundException If the car does not exist
      * @throws CarValidationException If the target user does not exist
      * @throws CarDatabaseException If a database operation fails
      */
-    public function transfer(int $newUserId, string $reason = 'Administrative transfer', string $operationType = 'NEWOWNER'): true
+    public function transfer(int $newUserId, string $reason = 'Administrative transfer', string $operationType = 'NEWOWNER', int $actingUserId = 0): true
     {
         if (!$this->exists()) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('car_not_found_transfer', ['id' => 'unknown']);
@@ -473,7 +477,7 @@ class Car
             $newUserId,
             $reason,
             $operationType,
-            currentUserId(),
+            $actingUserId ?: currentUserId(),
             $this->getRepository()
         );
     }
@@ -483,10 +487,11 @@ class Car
      *
      * @param int $oldCarId The car ID to merge into this car (will be deleted)
      * @param string $reason Reason for merge (for audit trail)
+     * @param int $actingUserId ID of the user performing the action (0 falls back to currentUserId())
      * @return bool True if merge was successful
      * @throws Exception If validation fails or database operation fails
      */
-    public function merge(int $oldCarId, string $reason = 'Administrative merge'): bool
+    public function merge(int $oldCarId, string $reason = 'Administrative merge', int $actingUserId = 0): bool
     {
         if (!$this->exists()) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('car_not_found_merge', ['id' => 'target']);
@@ -498,7 +503,7 @@ class Car
             $this->_data,
             $oldCarId,
             $reason,
-            currentUserId(),
+            $actingUserId ?: currentUserId(),
             $this->getRepository()
         );
 

--- a/usersc/classes/Car/Car.php
+++ b/usersc/classes/Car/Car.php
@@ -22,7 +22,9 @@ use ElanRegistry\LogCategories;
  *
  * Delegates to focused service classes for validation, image processing,
  * database operations, verification, administration, and DataTables.
- * Maintains full backward compatibility with existing callers.
+ * Administration methods (delete, transfer, merge) require an explicit
+ * $actingUserId parameter (added v2.28.0) — callers are responsible for
+ * ensuring the acting user is authenticated before invoking those methods.
  *
  * @author Jim Boone
  * @version 2.15.0
@@ -417,7 +419,8 @@ class Car
      *
      * @param string $reason Reason for deletion (for audit trail)
      * @param string $token CSRF token (required)
-     * @param int $actingUserId ID of the user performing the action
+     * @param int $actingUserId ID of the admin performing the action — caller MUST verify
+     *                         the user is authenticated and authorized before invoking
      * @return bool True if deletion was successful
      * @throws Exception If validation fails or database operation fails
      */
@@ -456,7 +459,8 @@ class Car
      * @param int $newUserId The user ID to transfer ownership to
      * @param string $reason Reason for transfer (for audit trail)
      * @param string $operationType Operation type for history
-     * @param int $actingUserId ID of the user performing the action
+     * @param int $actingUserId ID of the admin performing the action — caller MUST verify
+     *                         the user is authenticated and authorized before invoking
      * @return true Always returns true; throws on any failure.
      * @throws CarNotFoundException If the car does not exist
      * @throws CarValidationException If the target user does not exist
@@ -485,7 +489,8 @@ class Car
      *
      * @param int $oldCarId The car ID to merge into this car (will be deleted)
      * @param string $reason Reason for merge (for audit trail)
-     * @param int $actingUserId ID of the user performing the action
+     * @param int $actingUserId ID of the admin performing the action — caller MUST verify
+     *                         the user is authenticated and authorized before invoking
      * @return bool True if merge was successful
      * @throws Exception If validation fails or database operation fails
      */

--- a/usersc/classes/Car/Car.php
+++ b/usersc/classes/Car/Car.php
@@ -13,7 +13,6 @@ use ElanRegistry\Exceptions\CarCreationException;
 use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarDeletionException;
 use ElanRegistry\Exceptions\CarNotFoundException;
-use ElanRegistry\Exceptions\CarPermissionException;
 use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\Exceptions\ImageProcessingException;
 use ElanRegistry\LogCategories;
@@ -423,8 +422,6 @@ class Car
      */
     public function delete(string $reason, string $token): bool
     {
-        global $user;
-
         if (!Token::check($token)) {
             throw new CarDeletionException(CarErrorMessages::getMessage('csrf_token_invalid', 'admin', ['operation' => 'car deletion']));
         }
@@ -433,10 +430,6 @@ class Car
             $technicalMsg = CarErrorMessages::getTechnicalMessage('car_not_found_delete', ['id' => 'unknown']);
             logger(0, LogCategories::LOG_CATEGORY_CAR_DELETION, $technicalMsg);
             throw new CarNotFoundException(CarErrorMessages::getMessage('car_not_found_delete'));
-        }
-
-        if (!isset($user) || !$user->isLoggedIn()) {
-            throw new CarDeletionException(CarErrorMessages::getMessage('user_auth_required', 'admin', ['operation' => 'car deletion']));
         }
 
         $this->getAdministrationService()->delete(
@@ -463,42 +456,25 @@ class Car
      * @param string $operationType Operation type for history
      * @return true Always returns true; throws on any failure.
      * @throws CarNotFoundException If the car does not exist
-     * @throws CarPermissionException If the user is not authenticated
+     * @throws CarValidationException If the target user does not exist
      * @throws CarDatabaseException If a database operation fails
      */
     public function transfer(int $newUserId, string $reason = 'Administrative transfer', string $operationType = 'NEWOWNER'): true
     {
-        global $user;
-
         if (!$this->exists()) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('car_not_found_transfer', ['id' => 'unknown']);
             logger(0, LogCategories::LOG_CATEGORY_CAR_TRANSFER, $technicalMsg);
             throw new CarNotFoundException(CarErrorMessages::getMessage('car_not_found_transfer'));
         }
 
-        if (!isset($user) || !$user->isLoggedIn()) {
-            throw new CarPermissionException(CarErrorMessages::getMessage('user_auth_required', 'admin', ['operation' => 'car transfer']));
-        }
-
-        $result = $this->getAdministrationService()->transfer(
+        return $this->getAdministrationService()->transfer(
             $this->_data,
             $newUserId,
             $reason,
             $operationType,
             currentUserId(),
-            $this->getRepository(),
-            function (array $fields): bool {
-                return $this->update($fields);
-            },
-            function (int $id): object {
-                if (!$this->find($id)) {
-                    throw new CarNotFoundException("Car ID {$id} not found after transfer");
-                }
-                return $this->data();
-            }
+            $this->getRepository()
         );
-
-        return $result;
     }
 
     /**
@@ -511,16 +487,10 @@ class Car
      */
     public function merge(int $oldCarId, string $reason = 'Administrative merge'): bool
     {
-        global $user;
-
         if (!$this->exists()) {
             $technicalMsg = CarErrorMessages::getTechnicalMessage('car_not_found_merge', ['id' => 'target']);
             logger(0, LogCategories::LOG_CATEGORY_CAR_MERGE, $technicalMsg);
             throw new CarNotFoundException(CarErrorMessages::getMessage('car_not_found_merge'));
-        }
-
-        if (!isset($user) || !$user->isLoggedIn()) {
-            throw new CarPermissionException(CarErrorMessages::getMessage('user_auth_required', 'admin', ['operation' => 'car merge']));
         }
 
         $result = $this->getAdministrationService()->merge(

--- a/usersc/classes/Car/Car.php
+++ b/usersc/classes/Car/Car.php
@@ -423,7 +423,7 @@ class Car
     public function delete(string $reason, string $token): bool
     {
         if (!Token::check($token)) {
-            logger(currentUserId() ?: 0, LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Car deletion rejected: invalid CSRF token');
+            logger(currentUserId(), LogCategories::LOG_CATEGORY_ACCESS_DENIED, 'Car deletion rejected: invalid CSRF token');
             throw new CarDeletionException(CarErrorMessages::getMessage('csrf_token_invalid', 'admin', ['operation' => 'car deletion']));
         }
 

--- a/usersc/classes/Car/CarAdministrationService.php
+++ b/usersc/classes/Car/CarAdministrationService.php
@@ -122,6 +122,8 @@ class CarAdministrationService
                 'website'   => $targetUser->website  ?? '',
             ];
 
+            // $ownerFields comes from Owner->data() (already-validated profile), so
+            // skipping CarValidator::validateAndSanitizeFields() here is intentional.
             $updateSuccess = $repo->updateCar($carId, $ownerFields);
             if (!$updateSuccess) {
                 $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);

--- a/usersc/classes/Car/CarAdministrationService.php
+++ b/usersc/classes/Car/CarAdministrationService.php
@@ -14,6 +14,7 @@ use ElanRegistry\Exceptions\CarNotFoundException;
 use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Owner;
+use ElanRegistry\Car\CarValidator;
 
 /**
  * CarAdministrationService - Administrative operations for cars
@@ -122,8 +123,12 @@ class CarAdministrationService
                 'website'   => $targetUser->website  ?? '',
             ];
 
-            // $ownerFields comes from Owner->data() (already-validated profile), so
-            // skipping CarValidator::validateAndSanitizeFields() here is intentional.
+            // Validate owner fields before writing. $requireAll = false so only the
+            // fields present in $ownerFields are checked (email format, website scheme,
+            // lat/lon range, city/state/country normalization) without requiring car-
+            // intrinsic fields like chassis/model/year that are not being updated here.
+            $ownerFields = (new CarValidator())->validateAndSanitizeFields($ownerFields, false);
+
             $updateSuccess = $repo->updateCar($carId, $ownerFields);
             if (!$updateSuccess) {
                 $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);

--- a/usersc/classes/Car/CarAdministrationService.php
+++ b/usersc/classes/Car/CarAdministrationService.php
@@ -14,7 +14,6 @@ use ElanRegistry\Exceptions\CarNotFoundException;
 use ElanRegistry\Exceptions\CarValidationException;
 use ElanRegistry\LogCategories;
 use ElanRegistry\Owner;
-use Token;
 
 /**
  * CarAdministrationService - Administrative operations for cars
@@ -84,8 +83,6 @@ class CarAdministrationService
      * @param string $operationType Operation type (e.g., 'NEWOWNER', 'TRANSFER')
      * @param int $adminUserId ID of the admin performing the transfer
      * @param CarRepository $repo Repository for database operations
-     * @param callable $updateCallback Callback to perform car update (receives array of fields)
-     * @param callable $refreshCallback Callback to refresh car data after update (receives car ID)
      * @return true Always returns true; throws on any failure.
      * @throws CarValidationException If target user is invalid
      * @throws CarDatabaseException If database operation fails
@@ -96,9 +93,7 @@ class CarAdministrationService
         string $reason,
         string $operationType,
         int $adminUserId,
-        CarRepository $repo,
-        callable $updateCallback,
-        callable $refreshCallback
+        CarRepository $repo
     ): true {
         $targetUser = (new Owner($newUserId))->data();
         if (!$targetUser) {
@@ -112,64 +107,58 @@ class CarAdministrationService
         try {
             $repo->beginTransaction();
 
-            $updateFields = [
-                'id' => $carId,
-                'token' => Token::generate(),
-                'user_id' => $targetUser->id,
-                'email' => $targetUser->email ?? '',
-                'fname' => $targetUser->fname ?? '',
-                'lname' => $targetUser->lname ?? '',
+            $ownerFields = [
+                'mtime'     => date(AppConstants::DATETIME_FORMAT),
+                'user_id'   => $targetUser->id,
+                'email'     => $targetUser->email    ?? '',
+                'fname'     => $targetUser->fname    ?? '',
+                'lname'     => $targetUser->lname    ?? '',
                 'join_date' => $targetUser->join_date ?? date(AppConstants::DATETIME_FORMAT),
-                'city' => $targetUser->city ?? '',
-                'state' => $targetUser->state ?? '',
-                'country' => $targetUser->country ?? '',
-                'lat' => $targetUser->lat ?? null,
-                'lon' => $targetUser->lon ?? null,
-                'website' => $targetUser->website ?? ''
+                'city'      => $targetUser->city     ?? '',
+                'state'     => $targetUser->state    ?? '',
+                'country'   => $targetUser->country  ?? '',
+                'lat'       => $targetUser->lat      ?? null,
+                'lon'       => $targetUser->lon      ?? null,
+                'website'   => $targetUser->website  ?? '',
             ];
 
-            $updateSuccess = $updateCallback($updateFields);
+            $updateSuccess = $repo->updateCar($carId, $ownerFields);
             if (!$updateSuccess) {
-                $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Car update method returned false']);
+                $technicalMsg = CarErrorMessages::getTechnicalMessage('database_update_failed', ['error' => 'Repository returned false']);
                 logger($adminUserId, LogCategories::LOG_CATEGORY_CAR_TRANSFER, $technicalMsg);
                 throw new CarDatabaseException(CarErrorMessages::getAdminMessage('database_update_failed'));
             }
 
-            // Refresh car data within the transaction — InnoDB reads own uncommitted
-            // writes, so the refreshed fields reflect the update above in both
-            // standalone and outer-transaction mode.
-            $refreshedData = $refreshCallback($carId);
-
             // Insert history before commit so a failure rolls back the entire
             // ownership change atomically (standalone and outer-transaction alike).
             $historyFields = [
-                'operation' => $operationType,
-                'car_id' => $carId,
-                'comments' => $reason,
-                'ctime' => $refreshedData->ctime ?? date(AppConstants::DATETIME_FORMAT),
-                'mtime' => date(AppConstants::DATETIME_FORMAT),
-                'model' => $refreshedData->model ?? '',
-                'series' => $refreshedData->series ?? '',
-                'variant' => $refreshedData->variant ?? '',
-                'year' => $refreshedData->year ?? '',
-                'type' => $refreshedData->type ?? '',
-                'chassis' => $refreshedData->chassis ?? '',
-                'color' => $refreshedData->color ?? '',
-                'engine' => $refreshedData->engine ?? '',
-                'purchasedate' => $refreshedData->purchasedate ?? null,
-                'solddate' => $refreshedData->solddate ?? null,
-                'image' => $refreshedData->image ?? '',
-                'user_id' => $targetUser->id,
-                'email' => $targetUser->email ?? '',
-                'fname' => $targetUser->fname ?? '',
-                'lname' => $targetUser->lname ?? '',
-                'join_date' => $targetUser->join_date ?? null,
-                'city' => $targetUser->city ?? '',
-                'state' => $targetUser->state ?? '',
-                'country' => $targetUser->country ?? '',
-                'lat' => $targetUser->lat ?? null,
-                'lon' => $targetUser->lon ?? null,
-                'website' => $targetUser->website ?? ''
+                'operation'    => $operationType,
+                'car_id'       => $carId,
+                'comments'     => $reason,
+                'ctime'        => $carData->ctime ?? date(AppConstants::DATETIME_FORMAT),
+                'mtime'        => date(AppConstants::DATETIME_FORMAT),
+                'model'        => $carData->model ?? '',
+                'series'       => $carData->series ?? '',
+                'variant'      => $carData->variant ?? '',
+                'year'         => $carData->year ?? '',
+                'type'         => $carData->type ?? '',
+                'chassis'      => $carData->chassis ?? '',
+                'color'        => $carData->color ?? '',
+                'engine'       => $carData->engine ?? '',
+                'purchasedate' => $carData->purchasedate ?? null,
+                'solddate'     => $carData->solddate ?? null,
+                'image'        => $carData->image ?? '',
+                'user_id'      => $targetUser->id,
+                'email'        => $targetUser->email ?? '',
+                'fname'        => $targetUser->fname ?? '',
+                'lname'        => $targetUser->lname ?? '',
+                'join_date'    => $targetUser->join_date ?? null,
+                'city'         => $targetUser->city ?? '',
+                'state'        => $targetUser->state ?? '',
+                'country'      => $targetUser->country ?? '',
+                'lat'          => $targetUser->lat ?? null,
+                'lon'          => $targetUser->lon ?? null,
+                'website'      => $targetUser->website ?? ''
             ];
 
             if (!$repo->insertHistory($historyFields)) {
@@ -248,22 +237,22 @@ class CarAdministrationService
             }
 
             $historyFields = [
-                'operation' => self::OPERATION_MERGE,
-                'car_id' => $newCarId,
-                'comments' => "Car $oldChassis (ID: $oldCarId) was merged into car $newChassis (ID: $newCarId) by admin $adminUserId. Reason: $reason",
-                'ctime' => $targetCarData->ctime ?? date(AppConstants::DATETIME_FORMAT),
-                'mtime' => date(AppConstants::DATETIME_FORMAT),
-                'model' => $targetCarData->model ?? '',
-                'series' => $targetCarData->series ?? '',
-                'variant' => $targetCarData->variant ?? '',
-                'year' => $targetCarData->year ?? '',
-                'type' => $targetCarData->type ?? '',
-                'chassis' => $targetCarData->chassis ?? '',
-                'color' => $targetCarData->color ?? '',
-                'engine' => $targetCarData->engine ?? '',
+                'operation'    => self::OPERATION_MERGE,
+                'car_id'       => $newCarId,
+                'comments'     => "Car $oldChassis (ID: $oldCarId) was merged into car $newChassis (ID: $newCarId) by admin $adminUserId. Reason: $reason",
+                'ctime'        => $targetCarData->ctime ?? date(AppConstants::DATETIME_FORMAT),
+                'mtime'        => date(AppConstants::DATETIME_FORMAT),
+                'model'        => $targetCarData->model ?? '',
+                'series'       => $targetCarData->series ?? '',
+                'variant'      => $targetCarData->variant ?? '',
+                'year'         => $targetCarData->year ?? '',
+                'type'         => $targetCarData->type ?? '',
+                'chassis'      => $targetCarData->chassis ?? '',
+                'color'        => $targetCarData->color ?? '',
+                'engine'       => $targetCarData->engine ?? '',
                 'purchasedate' => $targetCarData->purchasedate ?? null,
-                'solddate' => $targetCarData->solddate ?? null,
-                'image' => $targetCarData->image ?? ''
+                'solddate'     => $targetCarData->solddate ?? null,
+                'image'        => $targetCarData->image ?? ''
             ];
 
             if (!$repo->insertHistory($historyFields)) {

--- a/usersc/classes/CarErrorMessages.php
+++ b/usersc/classes/CarErrorMessages.php
@@ -130,12 +130,6 @@ class CarErrorMessages
                 'technical' => 'Target user not found - cannot transfer ownership to user ID: {user_id}'
             ],
             
-            'user_auth_required' => [
-                'user' => 'You must be logged in to perform this action.',
-                'admin' => 'User authentication required for this administrative operation.',
-                'technical' => 'User authentication required for {operation}'
-            ],
-            
             // Database operation errors
             'database_update_failed' => [
                 'user' => 'Unable to save changes. Please try again.',

--- a/usersc/classes/Exceptions/CarPermissionException.php
+++ b/usersc/classes/Exceptions/CarPermissionException.php
@@ -12,6 +12,11 @@ use ElanRegistry\LogCategories;
  * Exception thrown when a car operation is denied due to
  * insufficient permissions or authentication failures.
  *
+ * NOTE: No production code throws this directly after v2.28.0 removed the
+ * isLoggedIn() guard from Car methods. Retained for hierarchy completeness
+ * (provides the 403 slot in CarException) and to avoid breaking callers that
+ * catch CarPermissionException specifically.
+ *
  * @package ElanRegistry
  * @subpackage Exceptions
  * @since v2.14.0

--- a/usersc/plugins/ai_prompts/custom_prompts/elanregistry_classes.md.php
+++ b/usersc/plugins/ai_prompts/custom_prompts/elanregistry_classes.md.php
@@ -80,7 +80,7 @@ $car->delete('Reason for deletion', Token::generate(), currentUserId());
 | `CarNotFoundException` | 404 | ID not found |
 | `CarValidationException` | 422 | Invalid field data |
 | `CarDatabaseException` | 500 | DB operation failure |
-| `CarPermissionException` | 403 | User lacks permission |
+| `CarPermissionException` | 403 | User lacks permission *(no production code throws this post-v2.28.0; retained for hierarchy completeness)* |
 | `CarCreationException` | 500 | Create failed |
 | `CarDeletionException` | 500 | Delete failed |
 | `CarMergeException` | 500 | Merge failed |

--- a/usersc/plugins/ai_prompts/custom_prompts/elanregistry_classes.md.php
+++ b/usersc/plugins/ai_prompts/custom_prompts/elanregistry_classes.md.php
@@ -67,7 +67,7 @@ $car->update([
 ]);
 
 // Delete (hard delete; cars_hist trigger records the audit trail)
-$car->delete('Reason for deletion', Token::generate());
+$car->delete('Reason for deletion', Token::generate(), currentUserId());
 ```
 
 **Key database tables:** `cars` (primary), `cars_hist` (trigger-written audit trail),

--- a/usersc/scripts/after_user_deletion.php
+++ b/usersc/scripts/after_user_deletion.php
@@ -74,9 +74,10 @@ if ($noOwnerQuery->count() > 0) {
         }
         // Transfer each car using the same code path as the admin reassign UI — updates
         // user_id and all denormalized owner fields (email, fname, lname, city, etc.).
-        // Car::transfer() requires $user->isLoggedIn(); this hook is only ever invoked
-        // from admin-authenticated contexts (deleteUsers() callers). A future self-service
-        // GDPR-deletion path would need a different reassignment strategy here.
+        // Car::transfer() does not enforce isLoggedIn() internally — auth is the
+        // caller's responsibility. This hook is only invoked from admin-authenticated
+        // contexts (deleteUsers() callers). A future self-service GDPR-deletion path
+        // must ensure admin-level auth is established before calling transfer().
         foreach ($userCars as $carObj) {
             $car = new \ElanRegistry\Car\Car((int) $carObj->id);
             $car->transfer(

--- a/usersc/scripts/after_user_deletion.php
+++ b/usersc/scripts/after_user_deletion.php
@@ -58,6 +58,13 @@ if ($noOwnerQuery->count() > 0) {
     // RuntimeException if there is no authenticated session; guard it so a bad-session
     // edge case logs and exits cleanly rather than propagating uncaught after the
     // users row has already been deleted.
+    //
+    // ASSUMPTION: this hook is only invoked from admin-authenticated deleteUsers()
+    // callers (currently only tab-account_cleanup.php, gated by securePage() +
+    // isAdmin()). ADR-010 documents a potential future cron caller — if that is ever
+    // added without a session, this catch will silently abort car reassignment (logged
+    // only), leaving cars pointing at the now-deleted user ID. At that point, resolve
+    // $adminUserId via a dedicated service/system account rather than currentUserId().
     try {
         $adminUserId = currentUserId();
     } catch (\RuntimeException $e) {

--- a/usersc/scripts/after_user_deletion.php
+++ b/usersc/scripts/after_user_deletion.php
@@ -74,10 +74,9 @@ if ($noOwnerQuery->count() > 0) {
         }
         // Transfer each car using the same code path as the admin reassign UI — updates
         // user_id and all denormalized owner fields (email, fname, lname, city, etc.).
-        // Car::transfer() does not enforce isLoggedIn() internally — auth is the
-        // caller's responsibility. This hook is only invoked from admin-authenticated
-        // contexts (deleteUsers() callers). A future self-service GDPR-deletion path
-        // must ensure admin-level auth is established before calling transfer().
+        // This hook is only invoked from admin-authenticated contexts (deleteUsers()
+        // callers). A future self-service GDPR-deletion path must ensure
+        // admin-level auth is established before calling transfer().
         foreach ($userCars as $carObj) {
             $car = new \ElanRegistry\Car\Car((int) $carObj->id);
             $car->transfer(

--- a/usersc/scripts/after_user_deletion.php
+++ b/usersc/scripts/after_user_deletion.php
@@ -54,7 +54,8 @@ if ($noOwnerQuery->count() > 0) {
     $userCars = $repo->findByOwner($id);
     $carCount = count($userCars);
 
-    $committed = $inTransaction(function () use ($db, $id, $noOwnerUserId, $userCars): void {
+    $adminUserId = currentUserId();
+    $committed = $inTransaction(function () use ($db, $id, $noOwnerUserId, $userCars, $adminUserId): void {
         // Expire any non-terminal transfer requests the user initiated — prevents orphaned
         // requester FK references and ensures the current car owner sees a clean audit trail.
         $db->query(
@@ -74,15 +75,15 @@ if ($noOwnerQuery->count() > 0) {
         }
         // Transfer each car using the same code path as the admin reassign UI — updates
         // user_id and all denormalized owner fields (email, fname, lname, city, etc.).
-        // This hook is only invoked from admin-authenticated contexts (deleteUsers()
-        // callers). A future self-service GDPR-deletion path must ensure
-        // admin-level auth is established before calling transfer().
+        // $adminUserId is resolved above from currentUserId() (always valid — this hook
+        // runs only from admin-authenticated deleteUsers() callers).
         foreach ($userCars as $carObj) {
             $car = new \ElanRegistry\Car\Car((int) $carObj->id);
             $car->transfer(
                 $noOwnerUserId,
                 "Account deleted — reassigned to noowner (ID: $noOwnerUserId)",
-                'NEWOWNER'
+                'NEWOWNER',
+                $adminUserId
             );
         }
     });

--- a/usersc/scripts/after_user_deletion.php
+++ b/usersc/scripts/after_user_deletion.php
@@ -54,7 +54,17 @@ if ($noOwnerQuery->count() > 0) {
     $userCars = $repo->findByOwner($id);
     $carCount = count($userCars);
 
-    $adminUserId = currentUserId();
+    // Resolve the acting admin ID before the transaction. currentUserId() throws
+    // RuntimeException if there is no authenticated session; guard it so a bad-session
+    // edge case logs and exits cleanly rather than propagating uncaught after the
+    // users row has already been deleted.
+    try {
+        $adminUserId = currentUserId();
+    } catch (\RuntimeException $e) {
+        logger($id, LogCategories::LOG_CATEGORY_USER_DELETION, 'Cleanup aborted: no authenticated admin session — ' . $e->getMessage());
+        return;
+    }
+
     $committed = $inTransaction(function () use ($db, $id, $noOwnerUserId, $userCars, $adminUserId): void {
         // Expire any non-terminal transfer requests the user initiated — prevents orphaned
         // requester FK references and ensures the current car owner sees a clean audit trail.
@@ -73,10 +83,6 @@ if ($noOwnerQuery->count() > 0) {
         if ($db->error()) {
             throw new \RuntimeException("Failed to delete profile for user $id: " . $db->errorString());
         }
-        // Transfer each car using the same code path as the admin reassign UI — updates
-        // user_id and all denormalized owner fields (email, fname, lname, city, etc.).
-        // $adminUserId is resolved above from currentUserId() (always valid — this hook
-        // runs only from admin-authenticated deleteUsers() callers).
         foreach ($userCars as $carObj) {
             $car = new \ElanRegistry\Car\Car((int) $carObj->id);
             $car->transfer(


### PR DESCRIPTION
## Summary

- Removes `global $user` + `isLoggedIn()` auth gates from `Car::delete()`, `Car::transfer()`, and `Car::merge()` — auth is already enforced by `securePage()` in all callers
- Eliminates CSRF self-signing in `CarAdministrationService::transfer()` by calling `CarRepository::updateCar()` directly instead of routing through the CSRF-gated `Car::update()` callback path
- Improves error surfacing in `app/admin/index.php` reassign command: split generic catch into typed catches including `CarConcurrentModificationException` for retriable race conditions
- Removes 4 stale integration tests that tested the now-removed auth gate behavior
- Expands unit test coverage: transfer success path, all transfer/merge failure paths, `never()->commit` assertions

## Test plan

- [ ] `composer test:quick` — all 1253 unit tests pass
- [ ] `composer test:medium` — integration tests pass (CarDeletionTest, CarTransferTest, CarMergeTest)
- [ ] `vendor/bin/phpstan analyse app/admin/index.php usersc/classes/Car/Car.php usersc/classes/Car/CarAdministrationService.php usersc/classes/CarErrorMessages.php` — no errors
- [ ] Manual: exercise car reassign, delete, and merge in admin UI

Closes #1145

https://claude.ai/code/session_01RRNUqYWgZRZaWGv5qVBxkZ