### PR TITLE
fix: add page-specific title and meta description to paint-colors.php

### DIFF
--- a/docs/reference/paint-colors.php
+++ b/docs/reference/paint-colors.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
  * @author Jim Boone
  */
 
+$pageTitle = 'Lotus Elan Paint Codes — Official Colour Chart L01–L26';
+$pageDescription = 'Complete reference for Lotus Elan and Elan Plus 2 paint codes L01–L26 with colour chips, date ranges, model applicability, and early pre-code colours.';
+
 require_once '../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 

--- a/docs/releases/RELEASE_NOTES_v2.29.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.0.md
@@ -7,6 +7,10 @@
 
 [To be filled in as issues are completed — check for DB migrations from #1155]
 
+- **#1372 (paint-colors.php SEO):**
+  - Run `npm run test:e2e` against the deployed test environment to validate the new Playwright title/description assertions against live Apache/PHP config
+  - Manual: GSC → URL Inspection → Request Indexing for `https://elanregistry.org/docs/reference/paint-colors.php`
+
 ## User-Facing Changes
 
 ### New Features

--- a/docs/releases/RELEASE_NOTES_v2.29.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.0.md
@@ -17,6 +17,7 @@
 ### Improvements
 
 - **GSC 404 cleanup** ([#1409](https://github.com/elan-registry/registry/issues/1409)): Legacy path redirects and PDF filename case mismatch fix — eliminates remaining 404 noise from Google Search Console.
+- **Paint colors SEO** ([#1372](https://github.com/elan-registry/registry/issues/1372)): `paint-colors.php` now has a descriptive `<title>` and meta description, so it can outrank the generic PDF snippet Google previously showed for this high-traffic page.
 - **Geocoding accuracy** ([#1400](https://github.com/elan-registry/registry/issues/1400)): Geocoding now resolves ambiguous city names correctly (e.g. Springfield OH no longer maps to Springfield MO).
 - **Registration UX** ([#1406](https://github.com/elan-registry/registry/issues/1406)): Owners trying to register with an existing email are now redirected to password recovery instead of seeing a generic error.
 

--- a/tests/playwright/e2e/not-logged-in.spec.js
+++ b/tests/playwright/e2e/not-logged-in.spec.js
@@ -162,6 +162,53 @@ test.describe('Elan Registry - All Pages (Not Logged In)', () => {
   });
 });
 
+// TODO(#1432): when the table-driven pages[] array above gains expectedTitle/
+// expectedDescription fields for the broader page-title rollout, fold
+// paint-colors.php's assertions into that table and remove this block instead
+// of duplicating coverage.
+test.describe('paint-colors.php SEO title/meta description (#1372)', () => {
+  test.beforeEach(async ({ }, testInfo) => {
+    if (testInfo.project.name !== 'not-logged-in') {
+      testInfo.skip();
+    }
+  });
+
+  test('has a page-specific <title> and meta description, not the generic site default', async ({ page }) => {
+    await page.goto('/docs/reference/paint-colors.php');
+
+    await expect(page).toHaveTitle(/Lotus Elan Paint Codes/);
+
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute('content');
+    expect(description).toContain('Lotus Elan and Elan Plus 2 paint codes L01–L26');
+
+    // $pageDescription feeds og:description and twitter:description too
+    // (they share $site_description in head_tags.php), so the social-share
+    // preview copy changes along with the meta description.
+    const ogDescription = await page
+      .locator('meta[property="og:description"]')
+      .getAttribute('content');
+    expect(ogDescription).toContain('Lotus Elan and Elan Plus 2 paint codes L01–L26');
+
+    const twitterDescription = await page
+      .locator('meta[name="twitter:description"]')
+      .getAttribute('content');
+    expect(twitterDescription).toContain('Lotus Elan and Elan Plus 2 paint codes L01–L26');
+  });
+
+  test('other docs/reference pages still render the generic site title/description (regression guard)', async ({ page }) => {
+    await page.goto('/docs/reference/identification-guide.php');
+
+    await expect(page).toHaveTitle(/^ Lotus Elan Registry$/);
+
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute('content');
+    expect(description).toContain('Registry for the Lotus Elan (1963-1973) and Elan Plus 2 (1967-1974)');
+  });
+});
+
 test.describe('Internal Links Discovery and Testing (Not Logged In)', () => {
   const pages = [
     { path: '/', name: 'Home' },

--- a/tests/unit/security/HeadTagsSecurityTest.php
+++ b/tests/unit/security/HeadTagsSecurityTest.php
@@ -156,6 +156,26 @@ class HeadTagsSecurityTest extends TestCase
     }
 
     /**
+     * Test that $site_description falls back to $pageDescription when set,
+     * and treats both unset and empty-string as "not set" (#1372).
+     */
+    public function testSiteDescriptionUsesPageDescriptionOverride(): void
+    {
+        $this->assertStringContainsString(
+            '!empty($pageDescription)',
+            $this->fileContent,
+            'head_tags.php should use !empty() (not ??) so an empty-string $pageDescription '
+                . 'also falls back to the generic default, not just unset/null'
+        );
+
+        $this->assertStringContainsString(
+            '$site_description = !empty($pageDescription)',
+            $this->fileContent,
+            'head_tags.php should assign $site_description from the $pageDescription override check'
+        );
+    }
+
+    /**
      * Test that conditional closing tag exists
      */
     public function testHasConditionalClosing(): void

--- a/usersc/includes/head_tags.php
+++ b/usersc/includes/head_tags.php
@@ -9,7 +9,9 @@ require_once $abs_us_root . $us_url_root . 'app/version.php';
 // loaded in Phase 1.11.12 (usersc/includes/loader.php)
 // Uses validated Server::getScheme() and Server::get('HTTP_HOST') with proper sanitization
 $site_title = $settings->site_name ?? 'Lotus Elan Registry';
-$site_description = 'Registry for the Lotus Elan (1963-1973) and Elan Plus 2 (1967-1974). Document your classic British sports car, connect with owners, and preserve automotive history.';
+$site_description = !empty($pageDescription)
+    ? $pageDescription
+    : 'Registry for the Lotus Elan (1963-1973) and Elan Plus 2 (1967-1974). Document your classic British sports car, connect with owners, and preserve automotive history.';
 $og_image = $us_url_root . 'usersc/images/og-lotus-elan.jpg';
 ?>
 


### PR DESCRIPTION
## Summary

- Adds a `$pageTitle`/`$pageDescription` override mechanism to `usersc/includes/head_tags.php` — falls back to the existing generic site-wide copy for every other page, zero behavior change elsewhere
- Sets both on `docs/reference/paint-colors.php`, the site's highest-impression page (1,994 impressions, 2.2% CTR vs. 5.3% site average) where Google previously showed a generic PDF snippet instead of this page's content
- `og:description`/`twitter:description` pick up the override too since they share `$site_description` with the meta description — verified locally
- `og:title`/`twitter:title` are a separate, already-tracked gap — filed as follow-up issue #1432 along with a broader convention for future pages
- Adds Playwright coverage (title, meta description, og:description, twitter:description, plus a regression guard confirming other `docs/reference/*.php` pages still render the generic fallback) and a PHPUnit test asserting the `!empty()` fallback logic (empty-string `$pageDescription` also falls back to the default, not just unset/null)

Closes #1372

## Test plan

- [x] `composer check:php` / PHPStan / phpcs / PHPUnit (1265 tests) — all pass via pre-commit hooks
- [x] `npm run lint` — pass
- [x] Manually verified via curl against local MAMP: `<title>`, meta description, og:description, twitter:description all render page-specific copy on `paint-colors.php`; `identification-guide.php` and `workshop.php` still render the generic fallback (regression check)
- [ ] `npm run test:e2e` against deployed test environment once merged, to validate the new Playwright assertions against live Apache/PHP config
- [ ] Manual: GSC → URL Inspection → Request Indexing for `https://elanregistry.org/docs/reference/paint-colors.php` (post-deploy, not automatable)