### PR TITLE
docs: document Sendinblue plugin update procedure and record 1.6.2 bump

### DIFF
--- a/docs/development/EMAIL_SYSTEM.md
+++ b/docs/development/EMAIL_SYSTEM.md
@@ -114,6 +114,42 @@ In the registry admin panel:
 
 Logs include timestamps, recipient addresses, and any API error messages returned by Brevo.
 
+## Updating the Plugin
+
+`scripts/check-plugin-updates/` runs weekly and opens a GitHub issue labeled
+`plugin-update` when a newer version is published upstream. It only detects
+drift — it does not apply the update. Plugin files under `usersc/plugins/sendinblue/`
+are gitignored, so there is no git diff to review; the update is a manual
+file-replacement performed once per environment (local dev, test, prod).
+
+1. **Back up the current plugin directory** before updating:
+
+   ```bash
+   cp -r usersc/plugins/sendinblue usersc/plugins/sendinblue_backup_$(date +%Y%m%d)
+   ```
+
+   (`.gitignore` already excludes `sendinblue_backup_*/` directories.)
+
+2. **Apply the update via Spice Shaker:** Admin → Spice Shaker → Installed
+   Plugins → Update. Repeat on each environment being updated — updating one
+   environment does not affect the others.
+
+3. **Check for dependency changes:** diff `usersc/plugins/sendinblue/composer.json`
+   and `composer.lock` against the backup. If they changed, run
+   `composer install` inside `usersc/plugins/sendinblue/` to regenerate
+   `vendor/`. Watch for a bumped `getbrevo/brevo-php` constraint that could
+   conflict with PHP 8.2 or the root project's dependencies.
+
+4. **Re-verify the `email()` override behavior** documented above still
+   holds — in particular, that `reply_name` and `attachments` remain
+   unsupported via the `email()` override (only available calling
+   `sendinblue()` directly). Diff the new `override.php`/`functions.php`
+   against the backup if anything seems off.
+
+5. **Smoke test before promoting to the next environment:** Admin → Plugins
+   → Brevo Sendinblue → Test Email, and a full password-reset flow (the
+   most common `email()` override call path in the app).
+
 ## Troubleshooting
 
 ### Emails Not Sending

--- a/docs/releases/RELEASE_NOTES_v2.29.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.0.md
@@ -10,6 +10,7 @@
 - **#1372 (paint-colors.php SEO):**
   - Run `npm run test:e2e` against the deployed test environment to validate the new Playwright title/description assertions against live Apache/PHP config
   - Manual: GSC → URL Inspection → Request Indexing for `https://elanregistry.org/docs/reference/paint-colors.php`
+- **#1394 (Sendinblue plugin update):** Applied on local dev only so far. Still needs the same manual update (Admin → Spice Shaker → Installed Plugins → Update) on test and production, followed by the Test Email + password-reset smoke tests on each — see `docs/development/EMAIL_SYSTEM.md#updating-the-plugin`.
 
 ## User-Facing Changes
 
@@ -38,7 +39,7 @@
 
 ### Improvements
 
-- **Sendinblue plugin update** ([#1394](https://github.com/elan-registry/registry/issues/1394)): Brevo/Sendinblue email plugin updated from 1.6.0 to 1.6.1.
+- **Sendinblue plugin update** ([#1394](https://github.com/elan-registry/registry/issues/1394)): Brevo/Sendinblue email plugin updated from 1.6.0 to 1.6.2 (a newer release than the 1.6.1 originally targeted was published upstream by the time the update was applied).
 - **maplibre-gl ESM migration** ([#1396](https://github.com/elan-registry/registry/issues/1396)): maplibre-gl migrated from vendored UMD bundle to ESM (v4 → v6).
 
 ## Issues Resolved
@@ -48,7 +49,7 @@
 - [#1371](https://github.com/elan-registry/registry/issues/1371) — feat: Schema.org Car JSON-LD structured data on details.php; noindex on factory.php and privacy.php; apple-touch-icon
 - [#1372](https://github.com/elan-registry/registry/issues/1372) — fix: verify paint-colors.php title and meta description; submit to GSC for indexing
 - [#1373](https://github.com/elan-registry/registry/issues/1373) — feat: create dynamic sitemap.xml for public car registry pages
-- [#1394](https://github.com/elan-registry/registry/issues/1394) — Chore: Update sendinblue plugin from 1.6.0 to 1.6.1
+- [#1394](https://github.com/elan-registry/registry/issues/1394) — Chore: Update sendinblue plugin from 1.6.0 to 1.6.2
 - [#1396](https://github.com/elan-registry/registry/issues/1396) — chore: migrate maplibre-gl from UMD script tag to ESM (v4 → v6)
 - [#1399](https://github.com/elan-registry/registry/issues/1399) — bug: DataTables length=-1 ("All" option) and negative start cause SQL error in cars/factory list endpoints
 - [#1400](https://github.com/elan-registry/registry/issues/1400) — fix: geocoding returns wrong city when multiple US cities share a name (Springfield OH → MO)


### PR DESCRIPTION
## Summary

- `usersc/plugins/sendinblue/` is gitignored, so this update has no code diff for the plugin itself — verified locally that `info.xml` now reports `1.6.2` (a newer release than the `1.6.1` originally targeted was published upstream by the time the update was applied), `hooks/loginbody.php` is unchanged (confirmed it's unmodified UserSpice boilerplate, not a project customization as the issue originally assumed), and `composer.lock` is unchanged (`getbrevo/brevo-php` still locked at `v1.0.2`, no `composer install` needed)
- Adds a new "Updating the Plugin" section to `docs/development/EMAIL_SYSTEM.md` documenting the manual Spice Shaker update procedure, backup convention, dependency-check step, and smoke tests — this gap existed before #1394 and will apply to every future plugin update
- Updates release notes with the corrected 1.6.2 version and a "Required Actions After Deployment" entry: test/prod still need the same manual update

Closes #1394

## Verification

- [x] Local dev: Spice Shaker update applied, `info.xml` confirms `1.6.2`
- [x] Local dev: Test Email (Admin → Plugins → Brevo Sendinblue) succeeded
- [x] Local dev: password-reset email flow completed end-to-end
- [ ] Test environment: same update + smoke tests (tracked in release notes' Required Actions After Deployment)
- [ ] Production: same update + smoke tests (tracked in release notes' Required Actions After Deployment)