### PR TITLE
ci: run PHPUnit unit + regression suites on every PR

### DIFF
--- a/.claude/commands/finish-issue.md
+++ b/.claude/commands/finish-issue.md
@@ -119,6 +119,9 @@ keep waiting.
 - CodeQL Analysis — security scanning
 - GitGuardian Security — secret detection
 - Claude Code Review — coding standards
+- PHPUnit Unit + Regression — behavioral test suite (`tests.yml`, added in #1437; not yet a
+  GitHub-required check, so `gh pr checks` is what actually surfaces its status here — this
+  step's polling already does that regardless of this list)
 
 ### Step 4: Handle check results
 

--- a/.claude/commands/finish-milestone.md
+++ b/.claude/commands/finish-milestone.md
@@ -314,6 +314,17 @@ Closes #NNN — Issue title (PR #NN)
 
 See `docs/releases/RELEASE_NOTES_v$ARGUMENTS.md` for complete release notes.
 
+<!-- Include this section ONLY if Step 3.5 found known-broken-tagged tests and the user
+     chose to proceed with them explicitly accepted (option (b) in that step). Omit entirely
+     if Step 3.5 found nothing, or everything was resolved/removed before this PR. -->
+
+## Known Test Exclusions
+
+The following tests are excluded from the CI-blocking run via `#[Group('known-broken')]` and
+were explicitly accepted as a known gap for this release (see Step 3.5):
+
+- `<test name>` (`<file path>`) — tracked by #`<issue number>` (`<open/closed>`)
+
 ## Test Plan
 
 - [ ] All issue PRs were reviewed and merged into milestone branch

--- a/.claude/commands/finish-milestone.md
+++ b/.claude/commands/finish-milestone.md
@@ -22,6 +22,7 @@ TaskCreate. Suggested task subjects:
 1. Verify the milestone branch exists
 2. Check for open issues still in the milestone
 3. Switch to milestone branch and ensure up to date
+3.5. Check for known-broken test exclusions still present
 4. Gather all merged PRs targeting the milestone branch
 5. Get the full diff against main
 6. Finalize release notes
@@ -58,6 +59,48 @@ gh api "repos/elan-registry/registry/issues?milestone=<MILESTONE_NUM>&state=open
 git checkout milestone/$ARGUMENTS
 git pull origin milestone/$ARGUMENTS
 ```
+
+### Step 3.5: Check for known-broken test exclusions still present
+
+`.github/workflows/tests.yml`'s CI-blocking check runs `composer test:quick:ci`, which
+excludes any test tagged `#[Group('known-broken')]` (see `tests/README.md`'s "CI vs. Local
+Test Runs" section). This tag exists so a pre-existing, unrelated, already-tracked bug never
+blocks landing an otherwise-unrelated PR — but it's meant to be temporary. A milestone should
+not finish with tests still silently excluded from its own "all CI gates pass" bar.
+
+Search for any remaining tags:
+
+```bash
+grep -rn "Group('known-broken')" tests/ || echo "None found"
+```
+
+**If none found**, proceed to Step 4.
+
+**If any are found:**
+
+1. For each match, extract the cited issue number from the inline comment (e.g.
+   `// #1470 — fails on Linux CI, root cause under investigation`).
+2. Check whether each cited issue is still open:
+
+   ```bash
+   gh issue view <NUMBER> --repo elan-registry/registry --json state,title
+   ```
+
+3. Present the full list to the user — test name, file, cited issue, and that issue's current
+   state (open/closed) — and **ask for explicit confirmation** before proceeding:
+
+   > "N test(s) are still excluded from CI via `#[Group('known-broken')]`, tracked by
+   > [issue list]. Finishing this milestone means it ships without full test coverage on
+   > these paths. Do you want to (a) resolve them first, (b) proceed anyway with this
+   > explicitly accepted, or (c) stop here?"
+
+4. **Do not proceed past this step without an explicit answer.** If the user chooses to
+   proceed anyway, record that decision in the milestone PR body (Step 10) under a
+   "Known Test Exclusions" note, so it's auditable later — matching Step 9.8's pattern for
+   explicitly-accepted risk.
+5. If a cited issue is already closed but the tag is still present in code, that's likely a
+   forgotten cleanup step, not an accepted risk — flag this distinctly and recommend removing
+   the tag now (quick fix) rather than treating it as a risk-acceptance decision.
 
 ### Step 4: Gather all merged PRs targeting the milestone branch
 
@@ -314,6 +357,7 @@ It will not re-run on every push — that keeps CI cost down.
 
 - The PR number and URL
 - List of merged issue PRs included
+- Known-broken test exclusions status (none found, or resolved, or explicitly accepted with issue references)
 - Release notes status (finalized or needs attention)
 - Wiki updates status (updated, committed, or skipped)
 - PRD update status (updated or skipped)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  unit-and-regression:
+    name: PHPUnit Unit + Regression
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql
+          coverage: none
+          tools: composer:v2
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Run unit tests
+        run: composer test:quick
+
+      - name: Run regression tests
+        run: composer test:regression

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,14 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Run unit tests
-        run: composer test:quick
+        # Excludes the 'known-broken' group: tests with a confirmed, tracked,
+        # pre-existing failure (see the #[Group('known-broken')] tag + issue
+        # comment on each affected test). `composer test:quick` (no exclusion)
+        # remains the local/default command so developers still see these
+        # failures — only the CI-blocking run skips them, and only until
+        # their tracking issue is resolved. See docs/development/CODING_STANDARDS.md
+        # for the full convention.
+        run: composer test:quick:ci
 
       - name: Run regression tests
         run: composer test:regression

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,9 @@ jobs:
         # comment on each affected test). `composer test:quick` (no exclusion)
         # remains the local/default command so developers still see these
         # failures — only the CI-blocking run skips them, and only until
-        # their tracking issue is resolved. See docs/development/CODING_STANDARDS.md
-        # for the full convention.
+        # their tracking issue is resolved. See tests/README.md's "CI vs.
+        # Local Test Runs, and the known-broken Group" section for the
+        # full convention.
         run: composer test:quick:ci
 
       - name: Run regression tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   unit-and-regression:
     name: PHPUnit Unit + Regression
@@ -50,4 +53,7 @@ jobs:
         run: composer test:quick:ci
 
       - name: Run regression tests
-        run: composer test:regression
+        # Same 'known-broken' exclusion as the unit run above, for consistency
+        # — a Regression test tagged known-broken must be excluded here too or
+        # the escape hatch silently wouldn't apply to it.
+        run: composer test:regression:ci

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "test:quick:ci": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit --exclude-group known-broken",
         "test:unit": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit",
         "test:regression": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Regression",
+        "test:regression:ci": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Regression --exclude-group known-broken",
         "test:unit:all": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml",
         "test:integration": "@php vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml --testsuite=Integration",
         "test:database": "@php vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml tests/integration/database",

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "scripts": {
         "_comment": "Unit tests (mocks, no database) vs Integration tests (real database)",
         "test:quick": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit",
+        "test:quick:ci": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit --exclude-group known-broken",
         "test:unit": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit",
         "test:regression": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Regression",
         "test:unit:all": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml",

--- a/docs/development/DEPLOYMENT.md
+++ b/docs/development/DEPLOYMENT.md
@@ -138,6 +138,25 @@ before merge, not by GitHub blocking the merge button itself (see issue #1437).
   - **Draft handling**: Marks issues as "in-progress" for draft PRs
 - **Status flow**: `status: in-progress` → `status: needs-review` → issue closed
 
+### Automated Test Execution
+
+#### 6. **PHPUnit Unit + Regression**
+
+- **What it does**: Runs the PHPUnit `Unit` and `Regression` testsuites (`composer test:quick:ci`
+  and `composer test:regression`) — mocked, no database or network required
+- **When it runs**: On every PR (open/synchronize) and on push to `main`
+  (`.github/workflows/tests.yml`)
+- **Scope**: `tests/unit/` and `tests/regression/`, excluding any test tagged
+  `#[Group('known-broken')]` (see `tests/README.md`'s "CI vs. Local Test Runs" section) — the
+  local `composer test:quick` command runs the same suite without that exclusion, so developers
+  always see the full picture locally
+- **Pass criteria**: All included tests pass
+- **Failure impact**: Not (yet) a GitHub-required status check — merge isn't blocked at the
+  platform level. Enforcement instead relies on `/finish-issue`'s CI-status gate, which polls
+  actual check status and requires explicit confirmation before merging. See
+  [#1437](https://github.com/elan-registry/registry/issues/1437) for the rationale.
+- **Configuration**: `.github/workflows/tests.yml`; PHP 8.3 via `shivammathur/setup-php`
+
 ### Milestone Release PRs
 
 When merging a milestone branch (e.g., `milestone/v2.14.0`) into `main`, the

--- a/docs/development/DEPLOYMENT.md
+++ b/docs/development/DEPLOYMENT.md
@@ -143,7 +143,7 @@ before merge, not by GitHub blocking the merge button itself (see issue #1437).
 #### 6. **PHPUnit Unit + Regression**
 
 - **What it does**: Runs the PHPUnit `Unit` and `Regression` testsuites (`composer test:quick:ci`
-  and `composer test:regression`) — mocked, no database or network required
+  and `composer test:regression:ci`) — mocked, no database or network required
 - **When it runs**: On every PR (open/synchronize) and on push to `main`
   (`.github/workflows/tests.yml`)
 - **Scope**: `tests/unit/` and `tests/regression/`, excluding any test tagged

--- a/docs/development/DEPLOYMENT.md
+++ b/docs/development/DEPLOYMENT.md
@@ -66,13 +66,17 @@ quality, security, and project management compliance.
 
 ### Quick Reference: PR Check Status
 
-| Check Name               | Purpose            | Blocks | Runs When          |
-| ------------------------ | ------------------ | ------ | ------------------ |
-| **CodeQL Analysis**      | Security scanning  | ✅ Yes | All PRs to main    |
-| **GitGuardian Security** | Secret detection   | ✅ Yes | All commits/PRs    |
-| **Claude Code Review**   | Coding standards   | ✅ Yes | PHP/JS/CSS changes |
-| **Issue Management**     | Auto-label issues  | ❌ No  | Issue events       |
-| **PR Management**        | Link PRs to issues | ❌ No  | PR events          |
+| Check Name                    | Purpose               | Blocks | Runs When          |
+| ----------------------------- | --------------------- | ------ | ------------------ |
+| **CodeQL Analysis**           | Security scanning     | ✅ Yes | All PRs to main    |
+| **GitGuardian Security**      | Secret detection      | ✅ Yes | All commits/PRs    |
+| **Claude Code Review**        | Coding standards      | ✅ Yes | PHP/JS/CSS changes |
+| **Issue Management**          | Auto-label issues     | ❌ No  | Issue events       |
+| **PR Management**             | Link PRs to issues    | ❌ No  | PR events          |
+| **PHPUnit Unit + Regression** | Behavioral test suite | ❌ No* | All PRs            |
+
+\* Not yet a GitHub-required status check — failures are caught by `/finish-issue`'s CI-status gate
+before merge, not by GitHub blocking the merge button itself (see issue #1437).
 
 ### Security & Code Quality Checks
 

--- a/docs/releases/RELEASE_NOTES_v2.29.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.0.md
@@ -36,6 +36,7 @@
 ### Bug Fixes
 
 - **DataTables pagination validation** ([#1399](https://github.com/elan-registry/registry/issues/1399)): Invalid pagination parameters (including the former "All" option, `length=-1`) now return a 422 error instead of a SQL 500. The "All" rows option has been removed from the cars and factory table menus; page size is capped at 100 server-side.
+- **Location service cache silently disabled when APCu is present but non-functional** ([#1470](https://github.com/elan-registry/registry/issues/1470)): `LocationService`'s geocoding cache and its own per-user geocoding rate limiter both silently stopped working whenever the `apcu` PHP extension was loaded but not actually functional for the running context (e.g. `apc.enable_cli=Off`, common in CLI/cron execution) — the code checked only whether the extension existed, not whether it actually succeeded, so it never fell through to its documented file-based fallback. Both now correctly fall back to file-based caching whenever an APCu operation doesn't succeed. Found while adding automated CI test execution ([#1437](https://github.com/elan-registry/registry/issues/1437)).
 
 ### Improvements
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -176,9 +176,11 @@ npm run playwright:test:ui       # UI consistency
 
 ## CI vs. Local Test Runs, and the `known-broken` Group
 
-`.github/workflows/tests.yml` runs `composer test:quick:ci` (not plain `test:quick`) for
-the CI-blocking check on every PR. `test:quick:ci` is identical to `test:quick` except it
-adds `--exclude-group known-broken`.
+`.github/workflows/tests.yml` runs `composer test:quick:ci` and `composer test:regression:ci`
+(not plain `test:quick`/`test:regression`) for the CI-blocking check on every PR. Each `:ci`
+variant is identical to its base command except it adds `--exclude-group known-broken` — both
+suites support the exclusion identically, so a tagged test is skipped in CI regardless of
+which suite it lives in.
 
 **Why this exists:** landing a new CI gate (`#1437`) should never be blocked indefinitely by
 an unrelated, already-tracked, pre-existing bug — but a bypass that's silent or permanent is
@@ -187,9 +189,9 @@ escape hatch:
 
 - Tag an affected test method with `#[Group('known-broken')]` **plus** an inline comment
   citing the tracking issue, e.g. `// #1470 — fails on Linux CI, root cause under investigation`.
-- `composer test:quick` (the default local/dev command, and `test:quick:ci`'s superset)
-  still runs and reports these failures — nobody loses visibility locally.
-- Only `test:quick:ci` (the CI-blocking command) skips them, and only until the tracking
+- `composer test:quick`/`composer test:regression` (the default local/dev commands, and each
+  `:ci` variant's superset) still run and report these failures — nobody loses visibility locally.
+- Only the `:ci` variants (the CI-blocking commands) skip them, and only until the tracking
   issue is resolved and the tag is removed.
 - `/finish-milestone` checks for any remaining `known-broken`-tagged tests and asks for
   explicit confirmation before finishing a milestone with known-excluded tests still present

--- a/tests/README.md
+++ b/tests/README.md
@@ -189,6 +189,10 @@ escape hatch:
 
 - Tag an affected test method with `#[Group('known-broken')]` **plus** an inline comment
   citing the tracking issue, e.g. `// #1470 — fails on Linux CI, root cause under investigation`.
+  **This comment format is load-bearing, not just documentation** — `/finish-milestone`'s
+  Step 3.5 greps for the tag and parses the issue number out of that free-text `// #NNN — ...`
+  comment to check whether it's still open. A tag added without a `#NNN` reference in that
+  exact form will silently defeat that check.
 - `composer test:quick`/`composer test:regression` (the default local/dev commands, and each
   `:ci` variant's superset) still run and report these failures — nobody loses visibility locally.
 - Only the `:ci` variants (the CI-blocking commands) skip them, and only until the tracking

--- a/tests/README.md
+++ b/tests/README.md
@@ -174,6 +174,33 @@ npm run playwright:test:security # Security suite
 npm run playwright:test:ui       # UI consistency
 ```
 
+## CI vs. Local Test Runs, and the `known-broken` Group
+
+`.github/workflows/tests.yml` runs `composer test:quick:ci` (not plain `test:quick`) for
+the CI-blocking check on every PR. `test:quick:ci` is identical to `test:quick` except it
+adds `--exclude-group known-broken`.
+
+**Why this exists:** landing a new CI gate (`#1437`) should never be blocked indefinitely by
+an unrelated, already-tracked, pre-existing bug — but a bypass that's silent or permanent is
+worse than no gate at all. The `known-broken` group is the explicit, visible, temporary
+escape hatch:
+
+- Tag an affected test method with `#[Group('known-broken')]` **plus** an inline comment
+  citing the tracking issue, e.g. `// #1470 — fails on Linux CI, root cause under investigation`.
+- `composer test:quick` (the default local/dev command, and `test:quick:ci`'s superset)
+  still runs and reports these failures — nobody loses visibility locally.
+- Only `test:quick:ci` (the CI-blocking command) skips them, and only until the tracking
+  issue is resolved and the tag is removed.
+- `/finish-milestone` checks for any remaining `known-broken`-tagged tests and asks for
+  explicit confirmation before finishing a milestone with known-excluded tests still present
+  — this prevents the escape hatch from silently becoming permanent.
+
+Do not use this group for a test you simply don't feel like fixing right now — it exists
+specifically for "this genuinely needs investigation, is tracked, and shouldn't block an
+unrelated PR" scenarios, discovered in practice when `tests.yml` first ran on a clean Linux
+CI checkout and surfaced pre-existing macOS-vs-Linux behavior differences invisible to local
+development.
+
 ## Writing New Tests
 
 ### Unit Test Example

--- a/tests/unit/location/LocationServiceCacheTest.php
+++ b/tests/unit/location/LocationServiceCacheTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/_apcu_namespace_overrides.php';
+
 use ElanRegistry\LocationService;
 use ElanRegistry\LogCategories;
 use PHPUnit\Framework\TestCase;
@@ -793,6 +795,63 @@ final class LocationServiceCacheTest extends TestCase
         // Cleanup the symlink (tearDown's glob won't catch it via is_file)
         if (is_link($cacheFile)) {
             unlink($cacheFile);
+        }
+    }
+
+    // =========================================================================
+    // Tests: APCu present-but-non-functional fallback (#1470)
+    //
+    // Strategy: $GLOBALS['mockApcuSimulateFailure'] (consumed by the
+    // namespace-scoped overrides in _apcu_namespace_overrides.php) forces
+    // function_exists('apcu_fetch'/'apcu_store') to report true while the
+    // calls themselves always fail — deterministically reproducing "extension
+    // loaded but non-functional" (e.g. apc.enable_cli=Off) regardless of the
+    // real environment's actual APCu state. Before the #1470 fix, this
+    // scenario made getCache()/setCache() silently skip the file-cache
+    // fallback entirely; this test would have failed against the pre-fix code
+    // on ANY machine, not just CI runners with that specific ini default.
+    // =========================================================================
+
+    protected function tearDownApcuSimulation(): void
+    {
+        unset($GLOBALS['mockApcuSimulateFailure']);
+    }
+
+    /**
+     * With APCu simulated as present-but-non-functional, setCache() then
+     * getCache() must still round-trip correctly via the file-cache fallback
+     * — deterministic regression coverage for the #1470 fix, independent of
+     * whatever the real environment's apc.enable_cli setting happens to be.
+     */
+    #[Group('fast')]
+    public function test_setCacheThenGetCache_roundTrip_whenApcuPresentButNonFunctional(): void
+    {
+        $GLOBALS['mockApcuSimulateFailure'] = true;
+
+        try {
+            $key     = 'apcu_fallback_roundtrip_key';
+            $payload = ['city' => 'Berlin', 'state' => '', 'country' => 'Germany'];
+
+            $service   = new LocationService();
+            $setMethod = $this->privateMethod($service, 'setCache');
+            $getMethod = $this->privateMethod($service, 'getCache');
+
+            $setMethod->invoke($service, $key, $payload);
+
+            $this->assertFileExists(
+                $this->cacheFilePath($key),
+                'setCache() must fall through to writing a file when APCu is present but every store fails.'
+            );
+
+            $result = $getMethod->invoke($service, $key);
+
+            $this->assertSame(
+                $payload,
+                $result,
+                'getCache() must fall through to reading the file cache when APCu is present but every fetch fails.'
+            );
+        } finally {
+            $this->tearDownApcuSimulation();
         }
     }
 

--- a/tests/unit/location/LocationServiceCacheTest.php
+++ b/tests/unit/location/LocationServiceCacheTest.php
@@ -228,6 +228,7 @@ final class LocationServiceCacheTest extends TestCase
      * returns null (no FileError branch reached).
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsNull_andDeletesExpiredFile_whenUnlinkSucceeds(): void
     {
         $key = 'rate_limit_unlink_ok';
@@ -306,6 +307,7 @@ final class LocationServiceCacheTest extends TestCase
      * and writes the cache file normally.
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_writesCacheFile_whenDirectoryAlreadyExists(): void
     {
         $key     = 'mkdir_ok_existing';
@@ -426,6 +428,7 @@ final class LocationServiceCacheTest extends TestCase
      * Verifies the happy path produces a valid, readable cache entry.
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_writesCacheFile_whenDirectoryIsWritable(): void
     {
         $key     = 'write_ok_key';
@@ -463,6 +466,7 @@ final class LocationServiceCacheTest extends TestCase
      * getCache() returns the cached value for a fresh (non-expired) entry.
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsCachedValue_forFreshEntry(): void
     {
         $key      = 'fresh_entry_test';
@@ -499,6 +503,7 @@ final class LocationServiceCacheTest extends TestCase
      * A value stored via setCache() can be retrieved correctly by getCache().
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCacheThenGetCache_roundTrip_returnsStoredValue(): void
     {
         $key     = 'roundtrip_key';
@@ -525,6 +530,7 @@ final class LocationServiceCacheTest extends TestCase
      * correct time.
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_respectsCustomTtl(): void
     {
         $key     = 'custom_ttl_key';
@@ -546,6 +552,7 @@ final class LocationServiceCacheTest extends TestCase
      * setCache() with a null TTL uses the default CACHE_TTL (300 seconds).
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_usesDefaultTtl_whenTtlIsNull(): void
     {
         $key     = 'default_ttl_key';
@@ -665,6 +672,7 @@ final class LocationServiceCacheTest extends TestCase
      * directory is writable.
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsNull_andDeletesFile_whenUnlinkSucceeds_missingExpiresKey(): void
     {
         $key       = 'missing_expires_unlink_ok';
@@ -729,6 +737,7 @@ final class LocationServiceCacheTest extends TestCase
      * A cache file with invalid JSON is deleted when the directory is writable.
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsNull_andDeletesFile_whenUnlinkSucceeds_corruptJson(): void
     {
         $key       = 'corrupt_json_unlink_ok';

--- a/tests/unit/location/LocationServiceCacheTest.php
+++ b/tests/unit/location/LocationServiceCacheTest.php
@@ -41,8 +41,17 @@ use PHPUnit\Framework\Attributes\Group;
  * All three code paths live in private methods, so they are exercised via
  * ReflectionMethod where needed to avoid requiring live HTTP endpoints.
  *
- * The file-cache path is active whenever APCu is unavailable.  PHPUnit does not
- * load the APCu extension in this project, so the file path is always taken.
+ * The file-cache path is active whenever APCu doesn't successfully store/fetch
+ * a value — not just when the extension isn't loaded. Originally, this file's
+ * docblock assumed "PHPUnit never loads APCu" was a safe, permanent assumption
+ * (true on macOS dev machines), but GitHub Actions' Linux CI runner does load
+ * it via shivammathur/setup-php's default extension bundle, with
+ * apc.enable_cli=Off (PHP's CLI-SAPI default) making every apcu_store()/
+ * apcu_fetch() call silently fail. LocationService::getCache()/setCache() now
+ * fall through to the file cache in that case too (previously they didn't —
+ * see the fix accompanying issue #1470), so this suite's file-path coverage
+ * is now environment-independent rather than relying on APCu simply not being
+ * present.
  *
  * @see usersc/classes/LocationService.php
  */
@@ -228,7 +237,6 @@ final class LocationServiceCacheTest extends TestCase
      * returns null (no FileError branch reached).
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsNull_andDeletesExpiredFile_whenUnlinkSucceeds(): void
     {
         $key = 'rate_limit_unlink_ok';
@@ -307,7 +315,6 @@ final class LocationServiceCacheTest extends TestCase
      * and writes the cache file normally.
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_writesCacheFile_whenDirectoryAlreadyExists(): void
     {
         $key     = 'mkdir_ok_existing';
@@ -342,7 +349,6 @@ final class LocationServiceCacheTest extends TestCase
      * and assert on it directly.
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_createsNoCacheFile_whenFileWriteFails(): void
     {
         if (posix_getuid() === 0) {
@@ -429,7 +435,6 @@ final class LocationServiceCacheTest extends TestCase
      * Verifies the happy path produces a valid, readable cache entry.
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_writesCacheFile_whenDirectoryIsWritable(): void
     {
         $key     = 'write_ok_key';
@@ -467,7 +472,6 @@ final class LocationServiceCacheTest extends TestCase
      * getCache() returns the cached value for a fresh (non-expired) entry.
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsCachedValue_forFreshEntry(): void
     {
         $key      = 'fresh_entry_test';
@@ -504,7 +508,6 @@ final class LocationServiceCacheTest extends TestCase
      * A value stored via setCache() can be retrieved correctly by getCache().
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCacheThenGetCache_roundTrip_returnsStoredValue(): void
     {
         $key     = 'roundtrip_key';
@@ -531,7 +534,6 @@ final class LocationServiceCacheTest extends TestCase
      * correct time.
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_respectsCustomTtl(): void
     {
         $key     = 'custom_ttl_key';
@@ -553,7 +555,6 @@ final class LocationServiceCacheTest extends TestCase
      * setCache() with a null TTL uses the default CACHE_TTL (300 seconds).
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_usesDefaultTtl_whenTtlIsNull(): void
     {
         $key     = 'default_ttl_key';
@@ -589,7 +590,6 @@ final class LocationServiceCacheTest extends TestCase
      * PHPUnit does not flag it as an unexpected warning.
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsNull_whenCacheFileIsUnreadable(): void
     {
         if (posix_getuid() === 0) {
@@ -674,7 +674,6 @@ final class LocationServiceCacheTest extends TestCase
      * directory is writable.
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsNull_andDeletesFile_whenUnlinkSucceeds_missingExpiresKey(): void
     {
         $key       = 'missing_expires_unlink_ok';
@@ -739,7 +738,6 @@ final class LocationServiceCacheTest extends TestCase
      * A cache file with invalid JSON is deleted when the directory is writable.
      */
     #[Group('fast')]
-    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsNull_andDeletesFile_whenUnlinkSucceeds_corruptJson(): void
     {
         $key       = 'corrupt_json_unlink_ok';

--- a/tests/unit/location/LocationServiceCacheTest.php
+++ b/tests/unit/location/LocationServiceCacheTest.php
@@ -342,6 +342,7 @@ final class LocationServiceCacheTest extends TestCase
      * and assert on it directly.
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_setCache_createsNoCacheFile_whenFileWriteFails(): void
     {
         if (posix_getuid() === 0) {
@@ -588,6 +589,7 @@ final class LocationServiceCacheTest extends TestCase
      * PHPUnit does not flag it as an unexpected warning.
      */
     #[Group('fast')]
+    #[Group('known-broken')] // #1470 — fails on Linux CI, root cause under investigation
     public function test_getCache_returnsNull_whenCacheFileIsUnreadable(): void
     {
         if (posix_getuid() === 0) {

--- a/tests/unit/location/_apcu_namespace_overrides.php
+++ b/tests/unit/location/_apcu_namespace_overrides.php
@@ -25,6 +25,15 @@ namespace ElanRegistry;
  * zero effect on any of this suite's other 19+ tests (or any other test
  * file) regardless of whether the real environment's apcu extension is
  * loaded, loaded-but-disabled, or absent entirely.
+ *
+ * IMPORTANT: PHP has no per-file function scoping — once this file is
+ * require_once'd, these three ElanRegistry\* symbols are declared for the
+ * rest of the PHPUnit process, not just this test file. Only one override
+ * source per function/namespace pair can exist across the whole suite; a
+ * second file attempting to redeclare any of these would fatal with
+ * "cannot redeclare". If a future test needs different simulated behavior
+ * for the same functions, extend this file's flag-driven logic rather than
+ * adding a second override file.
  */
 if (!\function_exists(__NAMESPACE__ . '\\function_exists')) {
     function function_exists(string $name): bool

--- a/tests/unit/location/_apcu_namespace_overrides.php
+++ b/tests/unit/location/_apcu_namespace_overrides.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElanRegistry;
+
+/**
+ * Namespace-scoped overrides for function_exists()/apcu_fetch()/apcu_store(),
+ * used only by LocationServiceCacheTest's APCu-fallback test to
+ * deterministically simulate "extension present but non-functional" (#1470)
+ * — the exact bug class LocationService::getCache()/setCache() were fixed
+ * to handle (function_exists() proves the extension is loaded, not that it
+ * actually works; apc.enable_cli=Off is PHP's CLI-SAPI default and makes
+ * every apcu_store()/apcu_fetch() call fail silently).
+ *
+ * PHP resolves unqualified function calls against the CURRENT namespace
+ * first, falling back to the global namespace only if nothing is defined
+ * here. usersc/classes/LocationService.php is also in the ElanRegistry
+ * namespace and calls all three functions unqualified, so these overrides
+ * take precedence over the real global ones there — without affecting any
+ * other file, since PHP namespace resolution is per-call-site, not global.
+ *
+ * Each override delegates transparently to the real global function unless
+ * $GLOBALS['mockApcuSimulateFailure'] is explicitly set true, so this has
+ * zero effect on any of this suite's other 19+ tests (or any other test
+ * file) regardless of whether the real environment's apcu extension is
+ * loaded, loaded-but-disabled, or absent entirely.
+ */
+if (!\function_exists(__NAMESPACE__ . '\\function_exists')) {
+    function function_exists(string $name): bool
+    {
+        if (($GLOBALS['mockApcuSimulateFailure'] ?? false) && \in_array($name, ['apcu_fetch', 'apcu_store'], true)) {
+            return true;
+        }
+        return \function_exists($name);
+    }
+}
+
+if (!\function_exists(__NAMESPACE__ . '\\apcu_fetch')) {
+    function apcu_fetch(string $key, &$success = null)
+    {
+        if ($GLOBALS['mockApcuSimulateFailure'] ?? false) {
+            $success = false;
+            return false;
+        }
+        return \apcu_fetch($key, $success);
+    }
+}
+
+if (!\function_exists(__NAMESPACE__ . '\\apcu_store')) {
+    function apcu_store(string $key, mixed $value, int $ttl = 0): bool
+    {
+        if ($GLOBALS['mockApcuSimulateFailure'] ?? false) {
+            return false;
+        }
+        return \apcu_store($key, $value, $ttl);
+    }
+}

--- a/tests/unit/system/RateLimitConfigTest.php
+++ b/tests/unit/system/RateLimitConfigTest.php
@@ -13,16 +13,16 @@ use PHPUnit\Framework\Attributes\Group;
  * recovery notification, so an entry must exist in the *actually active*
  * rate-limit config or that call silently no-ops at runtime.
  *
- * IMPORTANT: users/includes/rate_limits.php (upstream framework defaults) is
- * NOT the live config. Its final lines conditionally `include` the
- * project-owned usersc/includes/rate_limits.php, which reassigns
- * `$rateLimits = [...]` wholesale (not a merge) — so whatever is defined
- * there completely replaces the framework defaults. This test loads the
- * base file with $abs_us_root/$us_url_root pointed at the real project root
- * so that include actually fires, exercising the same resolution order the
- * app uses at runtime, and asserts against the resulting *merged* (in
- * practice, fully-overridden) array — i.e. usersc/includes/rate_limits.php's
- * values, since that's what a real request actually sees.
+ * IMPORTANT: at runtime, users/includes/rate_limits.php (upstream framework
+ * defaults — gitignored, environment-local, NOT present in a fresh checkout)
+ * conditionally `include`s the project-owned usersc/includes/rate_limits.php,
+ * which reassigns `$rateLimits = [...]` wholesale (not a merge) — so whatever
+ * is defined there completely replaces the framework defaults regardless of
+ * what the framework file itself contains. This test requires
+ * usersc/includes/rate_limits.php directly (the tracked file, always present
+ * in CI) rather than going through the untracked framework wrapper, since
+ * that wrapper's only relevant effect — the wholesale $rateLimits
+ * reassignment — is what this test actually needs to exercise.
  */
 #[Group('fast')]
 final class RateLimitConfigTest extends TestCase
@@ -31,12 +31,9 @@ final class RateLimitConfigTest extends TestCase
     {
         $projectRoot = dirname(__DIR__, 3);
 
-        $abs_us_root = $projectRoot . '/';
-        $us_url_root = '';
-
         /** @var array<string, array<string, int>> $rateLimits */
         $rateLimits = [];
-        require $projectRoot . '/users/includes/rate_limits.php';
+        require $projectRoot . '/usersc/includes/rate_limits.php';
 
         $this->assertIsArray($rateLimits);
         $this->assertArrayHasKey(

--- a/usersc/classes/LocationService.php
+++ b/usersc/classes/LocationService.php
@@ -505,14 +505,21 @@ class LocationService
      */
     private function getCache(string $key): mixed
     {
-        // Try APCu first
+        // Try APCu first, but fall through to the file cache on a miss rather
+        // than returning null immediately: function_exists('apcu_fetch') only
+        // proves the extension is loaded, not that it's actually functional.
+        // apc.enable_cli=Off (PHP's default for the CLI SAPI — the SAPI this
+        // code runs under during tests, and potentially in some CLI/cron
+        // execution contexts in production) makes every apcu_fetch() report
+        // failure even though the extension is present, which previously
+        // caused this method to silently skip its documented file-based
+        // fallback entirely.
         if (function_exists('apcu_fetch')) {
             $success = false;
             $value = apcu_fetch($key, $success);
             if ($success) {
                 return $value;
             }
-            return null;
         }
 
         // Fallback to file cache
@@ -568,9 +575,11 @@ class LocationService
     {
         $ttl = $ttl ?? self::CACHE_TTL;
 
-        // Try APCu first
-        if (function_exists('apcu_store')) {
-            apcu_store($key, $value, $ttl);
+        // Try APCu first, but fall through to the file cache if the store
+        // didn't actually succeed — see the matching comment in getCache()
+        // for why function_exists() alone isn't sufficient (apc.enable_cli=Off
+        // makes apcu_store() a silent no-op that returns false).
+        if (function_exists('apcu_store') && apcu_store($key, $value, $ttl)) {
             return;
         }
 

--- a/usersc/classes/LocationService.php
+++ b/usersc/classes/LocationService.php
@@ -522,7 +522,13 @@ class LocationService
             }
         }
 
-        // Fallback to file cache
+        // Fallback to file cache. Intentional: on a healthy, functional APCu
+        // host this still costs one extra file_exists() stat call per genuine
+        // cache miss (setCache() never dual-writes to both APCu and the file
+        // when APCu succeeds, so this check will always miss in that case) —
+        // there's no cheap way to distinguish "APCu miss" from "APCu broken"
+        // from here. Do not "optimize" this back to an early return; that's
+        // exactly the bug #1470 fixed.
         global $abs_us_root, $us_url_root;
         $cacheDir = $abs_us_root . $us_url_root . 'usersc/cache/';
         $cacheFile = $cacheDir . md5($key) . '.cache';


### PR DESCRIPTION
## Summary

Closes #1437, closes #1470. Adds `.github/workflows/tests.yml`, running `composer test:quick:ci` (PHPUnit `Unit` testsuite, CI-scoped) and `composer test:regression` (PHPUnit `Regression` testsuite) on every PR (open/synchronize) and on push to `main`. Today CI runs static analysis (PHPStan, coding standards, ESLint), CodeQL, Semgrep, and AI review — but zero automated tests execute in CI. The only place PHPUnit runs today is an opt-in, bypassable local pre-commit hook, so a PR that breaks the ~1,270-test behavioral suite currently merges green. This is finding P1 from the independent codebase assessment referenced in the issue.

The `Unit` and `Regression` suites use mocks exclusively — `tests/bootstrap-unit.php` defines its own in-memory mock `DB` class, no real database connection or network call is made — so this is a near-zero-cost CI job (~3 seconds locally).

The new workflow deliberately mirrors `.github/workflows/static-analysis.yml`'s `phpstan` job (same checkout/setup-php/composer-cache/install steps and versions) for consistency, but intentionally omits that job's `paths:` filter — this job runs on every PR unconditionally, since the acceptance criteria calls for that and the job is cheap enough not to need path-scoping.

Also updates `docs/development/DEPLOYMENT.md`'s "Quick Reference: PR Check Status" table with a row for the new check.

**Scope decision (confirmed with user during planning):** this PR does **not** configure GitHub branch-protection to make the new check a required/blocking status check — `/finish-issue`'s existing "all CI checks passed" gate already achieves the issue's real goal (stop merging something that breaks everything) without a separate, higher-consequence repo-settings change. Noted in a footnote in the DEPLOYMENT.md table.

## This is the first PR to ever run these suites on a clean Linux checkout

Landing the CI gate itself surfaced three real, pre-existing gaps invisible to local macOS development:

1. **`RateLimitConfigTest` fatal-errored** — it required the gitignored, environment-local `users/includes/rate_limits.php`, which never exists in a fresh CI checkout. Fixed by requiring the tracked `usersc/includes/rate_limits.php` directly.

2. **`LocationServiceCacheTest` — 11 failures, root cause found and fixed (closes #1470).** `LocationService::getCache()`/`setCache()` checked `function_exists('apcu_fetch'/'apcu_store')` to decide whether to use APCu, but that only proves the extension is loaded, not functional. GitHub Actions' Linux runner loads `apcu` via `setup-php`'s default bundle with `apc.enable_cli=Off` (PHP's CLI-SAPI default), so every APCu call silently failed — and the code never fell through to its documented file-cache fallback. **This is a genuine production defect, not a CI artifact**: any environment where APCu is present but non-functional for the active SAPI would silently and permanently disable this service's caching with zero errors logged. Fixed to fall through to the file cache whenever the APCu operation doesn't actually succeed. Verified via `act` running the real workflow in the same environment the bug manifested in: all 1273 tests now pass with zero exclusions.

3. **`SecurityHeadersTest::testUpstreamScriptHashesMatchActualFiles` silently performs zero assertions in CI** — reads three other gitignored upstream files; when absent, the assertion loop runs zero iterations and PHPUnit reports "risky" (not failed — doesn't block the build, but provides zero actual protection). Filed as **#1471**, milestoned to v2.29.0, since fixing it properly requires restructuring as an explicit-skip local-only maintenance check, not something to improvise inline.

## New `known-broken` PHPUnit group (general mechanism, kept even though nothing uses it now)

Added `composer test:quick:ci` (`test:quick` + `--exclude-group known-broken`) as the general escape hatch for landing a new CI gate without being blocked indefinitely by an unrelated, already-tracked, pre-existing bug — visible (tagged in source with an issue reference), temporary by convention, and paired with a new `/finish-milestone` Step 3.5 that greps for any remaining tags and requires explicit confirmation before a milestone finishes with tests still excluded. Documented in `tests/README.md`. Not currently used (the one thing it was tagging, `LocationServiceCacheTest`, got a real fix instead), but kept as durable project infrastructure for the next time this situation comes up.

## Test plan

- [x] `composer test:quick` — 1273 tests pass locally (macOS)
- [x] `composer test:quick:ci` — 1273 tests pass locally, identical to `test:quick` (no known-broken tags currently active)
- [x] `composer test:regression` — 174 tests pass locally
- [x] YAML syntax validated
- [x] Local multi-agent review (`/review-pr`) — clean
- [x] Verified via `act` running the actual `tests.yml` workflow in a Linux container matching GitHub's runner — confirmed the LocationService fix resolves all 11 originally-failing tests with zero exclusions
- [x] Confirmed on the real GitHub Actions run (not just `act` — which turned out to run as root, masking 2 of the 11 failures that only manifest on GitHub's actual non-root runner): `PHPUnit Unit + Regression` check passes
- [x] Per the issue's acceptance criteria ("a deliberately failing unit test causes the check to go red, verified once, then reverted"): implicitly verified — every fix iteration in this PR's history *was* exactly that scenario, watched live on real PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
