### PR TITLE
test: isolate integration tests onto a dedicated test schema

### DIFF
--- a/.env.test.local.sample
+++ b/.env.test.local.sample
@@ -1,0 +1,5 @@
+DB_HOST=127.0.0.1:8889
+DB_PORT=8889
+DB_USER=elanregi_spice
+DB_NAME=elanregi_spice_test
+DB_PASS=your_test_db_password

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ ElanRegistry.code-workspace
 ########################################
 .env
 .env.local
-.env.testing
+.env.test.local
 .user.ini
 USER.INI
 usersc/vericode_secret.php

--- a/docs/development/ENVIRONMENT.md
+++ b/docs/development/ENVIRONMENT.md
@@ -48,7 +48,8 @@ The Elan Registry uses **vlucas/phpdotenv** v5 for environment variable loading 
 - `DB_HOST` - Database server hostname/IP (e.g., `localhost`)
 - `DB_USER` - Database username (e.g., `elan_registry_user`)
 - `DB_PASS` - Database password
-- `DB_NAME` - Database name (e.g., `elanregi_spice`)
+- `DB_NAME` - Database name (e.g., `elanregi_spice`). For development, use the dev database.
+  For integration tests, use a separate dedicated test schema (see "Test Database Isolation" below)
 
 ### Cloudflare Turnstile CAPTCHA
 
@@ -145,16 +146,58 @@ internally, setting the `X-Forwarded-Proto: https` header so `$is_https` is
    chmod 600 .env
    ```
 
-4. **Create `.env.local` for Integration Tests** (optional):
+4. **Set Up Integration Test Database**:
+
+   Integration tests run against a dedicated test schema to avoid damaging the dev database.
 
    ```bash
-   # Copy the test template
-   cp .env.local.sample .env.local
+   # Copy the test database template
+   cp .env.test.local.sample .env.test.local
 
-   # Edit with your test database credentials
-   # Uses DB_* names directly (not ELAN_DEV_DB_* prefix)
-   chmod 600 .env.local
+   # Edit with your test database password (other fields are pre-filled)
+   nano .env.test.local
+
+   # Set secure permissions
+   chmod 600 .env.test.local
+
+   # Create the test schema (clones dev database structure)
+   ./scripts/create-test-schema.sh
+
+   # Load reference data (car_models)
+   php tests/setup-test-database.php
+
+   # Run integration tests
+   composer test:integration
    ```
+
+### Test Database Isolation
+
+Integration tests are **destructive** — they insert, update, delete, and merge real database
+records to verify application logic end-to-end. To prevent accidental damage to the development
+database, the test suite requires a dedicated test schema:
+
+- **Separate Schema**: Tests run against `elanregi_spice_test` (or equivalent), never the dev database `elanregi_spice`.
+- **Mandatory Configuration**: `tests/bootstrap-integration.php` **fails immediately with an error message** if `.env.test.local` is missing or fails to load.
+- **Safety Guards**: Two layers of defense-in-depth in `tests/bootstrap-integration.php` — the loaded
+  `DB_NAME` value is checked before connecting, and the *actual* connected database is checked again
+  afterward (catching the case where `.env.test.local` omits a `DB_*` key and it gets silently
+  backfilled from the root `.env`). Either guard tripping aborts with `exit(1)`. Both guards check
+  against the literal name `elanregi_spice` — if the dev database is ever renamed, update these
+  checks accordingly.
+- Separately, `scripts/create-test-schema.sh` refuses to run at all if its source and target schema
+  names resolve to the same name (case-folded) — the guard protecting the one truly destructive
+  operation in this workflow, the `DROP DATABASE` on the test schema.
+
+**Files involved:**
+
+- `.env.test.local` — Test database credentials (gitignored, created once per developer)
+- `.env.test.local.sample` — Template with safe defaults (tracked in repo)
+- `scripts/create-test-schema.sh` — Structure-sync script; safe to rerun any time the dev schema
+  changes (e.g. after a migration) to resync the test schema's structure — it drops and recreates
+  only the test schema each run
+- `tests/setup-test-database.php` — Loads `car_models` reference data into whichever schema is configured
+
+After the initial setup, tests can be re-run safely and repeatedly against the test schema without risking the development database.
 
 ### Production Deployment
 
@@ -214,8 +257,11 @@ The `.env.local` file contains local development database credentials:
 - **Location**: Root directory (not committed to git)
 - **Permissions**: `chmod 600`
 - **Format**: Plain text key-value pairs using `DB_*` variable names
-- **Distribution**: Created locally or from `.env.local.sample` template
-- **Usage**: For local integration testing with MAMP or remote databases
+- **Distribution**: Created locally, following the format in `.env.example`
+- **Usage**: Local development against the dev database (`elanregi_spice`). Also used
+  as the source when cloning structure into the test schema — see
+  "Test Database Isolation" above; integration tests themselves use `.env.test.local`,
+  not `.env.local`.
 
 **Important**: Never commit `.env`, `.env.local`, or other environment files to version control. All are listed in `.gitignore`.
 

--- a/docs/releases/RELEASE_NOTES_v2.29.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.0.md
@@ -57,5 +57,6 @@
 - [#1406](https://github.com/elan-registry/registry/issues/1406) — security: fix account enumeration during registration (generic response + silent recovery email)
 - [#1409](https://github.com/elan-registry/registry/issues/1409) — fix: GSC 404 cleanup — legacy path redirects and PDF filename case mismatch
 - [#1424](https://github.com/elan-registry/registry/issues/1424) — feat: log deployment events to system log on each successful push
+- [#1436](https://github.com/elan-registry/registry/issues/1436) — test: isolate integration tests onto a dedicated test schema
 - [#1437](https://github.com/elan-registry/registry/issues/1437) — ci: run PHPUnit unit + regression suites on every PR
 - [#1470](https://github.com/elan-registry/registry/issues/1470) — bug: LocationService cache silently disabled when APCu is present but non-functional

--- a/scripts/create-test-schema.sh
+++ b/scripts/create-test-schema.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# create-test-schema.sh
+#
+# Clones the CURRENT structure (no data) of the dev database (elanregi_spice)
+# into the dedicated test schema (elanregi_spice_test) so that PHPUnit
+# integration tests can run in isolation and never mutate the dev database.
+#
+# This script is idempotent: it DROPs and re-CREATEs the TARGET (test) schema
+# every run, then reloads the structure from the source. It NEVER touches the
+# source (dev) database.
+#
+# Credentials are read from two repo-root env files:
+#   .env.local       — source/dev credentials (elanregi_spice)
+#   .env.test.local  — target/test credentials (elanregi_spice_test)
+#
+# After running this, load reference data with:
+#   php tests/setup-test-database.php
+#
+set -euo pipefail
+
+# Resolve repo root (this script lives in <repo>/scripts/).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Dev credentials: prefer .env.local (matches this bootstrap's own convention
+# elsewhere in the project), fall back to .env (the file the running app
+# actually loads per users/init.php) if .env.local doesn't exist.
+SOURCE_ENV="${REPO_ROOT}/.env.local"
+if [[ ! -f "${SOURCE_ENV}" && -f "${REPO_ROOT}/.env" ]]; then
+    SOURCE_ENV="${REPO_ROOT}/.env"
+fi
+TARGET_ENV="${REPO_ROOT}/.env.test.local"
+
+# MAMP MySQL 8 binaries (see docs/development/ENVIRONMENT.md).
+MYSQL_BIN="/Applications/MAMP/Library/bin/mysql80/bin/mysql"
+MYSQLDUMP_BIN="/Applications/MAMP/Library/bin/mysql80/bin/mysqldump"
+
+# --- Validate prerequisites --------------------------------------------------
+
+if [[ ! -f "${SOURCE_ENV}" ]]; then
+    echo "ERROR: source env file not found: ${SOURCE_ENV}" >&2
+    echo "       Neither .env.local nor .env exists in the repo root — complete the" >&2
+    echo "       setup steps in docs/development/ENVIRONMENT.md first." >&2
+    exit 1
+fi
+
+if [[ ! -f "${TARGET_ENV}" ]]; then
+    echo "ERROR: test env file not found: ${TARGET_ENV}" >&2
+    echo "       Run: cp .env.test.local.sample .env.test.local, then fill in DB_PASS." >&2
+    echo "       See docs/development/ENVIRONMENT.md for details." >&2
+    exit 1
+fi
+
+# --- Parse credentials -------------------------------------------------------
+# Env files are simple KEY=value lines with no quoting. Read a single key from
+# a given file. Fails loudly on a missing/empty key rather than letting `set -e`
+# kill the script silently — grep exits 1 on no match, and pipefail propagates
+# that through `| head | cut` even though both of those succeed, so an
+# unguarded call site would die with no output and no indication which key
+# or file was the problem.
+read_env() {
+    local file="$1" key="$2" value
+    value="$(grep -E "^${key}=" "${file}" | head -n1 | cut -d= -f2-)" || true
+    if [[ -z "${value}" ]]; then
+        echo "ERROR: ${key} not found (or empty) in ${file}" >&2
+        exit 1
+    fi
+    printf '%s' "${value}"
+}
+
+SOURCE_DB_NAME="$(read_env "${SOURCE_ENV}" DB_NAME)"
+SOURCE_DB_USER="$(read_env "${SOURCE_ENV}" DB_USER)"
+SOURCE_DB_PASS="$(read_env "${SOURCE_ENV}" DB_PASS)"
+
+TARGET_DB_NAME="$(read_env "${TARGET_ENV}" DB_NAME)"
+TARGET_DB_USER="$(read_env "${TARGET_ENV}" DB_USER)"
+TARGET_DB_PASS="$(read_env "${TARGET_ENV}" DB_PASS)"
+
+# Host/port come from .env.local — both files describe the same local MAMP MySQL.
+DB_HOST="$(read_env "${SOURCE_ENV}" DB_HOST)"
+DB_PORT="$(read_env "${SOURCE_ENV}" DB_PORT)"
+
+# DB_HOST may be in "host:port" form; strip any port so -h gets a bare host.
+DB_HOST="${DB_HOST%%:*}"
+
+# --- Critical safety guard ---------------------------------------------------
+# This MUST run before any DROP/CREATE DATABASE. It is the only thing preventing
+# this script from ever dropping the dev database if .env.test.local were ever
+# misconfigured to point at elanregi_spice. Case-folded: MAMP's MySQL runs with
+# lower_case_table_names=2 on macOS's case-insensitive filesystem, so a typo'd-case
+# name would otherwise slip past a naive string comparison.
+SOURCE_DB_NAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<< "${SOURCE_DB_NAME}")"
+TARGET_DB_NAME_LOWER="$(tr '[:upper:]' '[:lower:]' <<< "${TARGET_DB_NAME}")"
+if [[ "${SOURCE_DB_NAME_LOWER}" == "${TARGET_DB_NAME_LOWER}" ]]; then
+    echo "ERROR: source and target schema names are identical (${SOURCE_DB_NAME}) — refusing to run, this would target the dev database." >&2
+    exit 1
+fi
+
+# --- Clone structure ---------------------------------------------------------
+
+echo "Cloning structure of '${SOURCE_DB_NAME}' into '${TARGET_DB_NAME}' (no data)..."
+
+DUMP_FILE="$(mktemp -t elanregistry_test_schema.XXXXXX.sql)"
+trap 'rm -f "${DUMP_FILE}"' EXIT
+
+echo "  → Dumping structure from source..."
+MYSQL_PWD="${SOURCE_DB_PASS}" "${MYSQLDUMP_BIN}" \
+    -h "${DB_HOST}" -P "${DB_PORT}" \
+    -u "${SOURCE_DB_USER}" \
+    --no-data --no-tablespaces \
+    "${SOURCE_DB_NAME}" > "${DUMP_FILE}"
+
+# Strip DEFINER clauses mysqldump bakes into both triggers (`/*!50017
+# DEFINER=...*/`) and views (`/*!50013 DEFINER=... SQL SECURITY DEFINER */`).
+# Without this, these objects stay owned by the SOURCE user, and using them
+# under the TARGET user fails (e.g. "TRIGGER command denied") the moment a
+# test touches them — omitting DEFINER makes MySQL default it to whichever
+# user loads this file (TARGET_DB_USER), which is what we actually want.
+sed -i.bak -E \
+    -e 's/\/\*!50017 DEFINER=`[^`]*`@`[^`]*`\*\///g' \
+    -e 's/\/\*!50013 DEFINER=`[^`]*`@`[^`]*` SQL SECURITY DEFINER \*\///g' \
+    "${DUMP_FILE}"
+rm -f "${DUMP_FILE}.bak"
+
+echo "  → Recreating target schema '${TARGET_DB_NAME}'..."
+MYSQL_PWD="${TARGET_DB_PASS}" "${MYSQL_BIN}" \
+    -h "${DB_HOST}" -P "${DB_PORT}" \
+    -u "${TARGET_DB_USER}" \
+    -e "DROP DATABASE IF EXISTS \`${TARGET_DB_NAME}\`; CREATE DATABASE \`${TARGET_DB_NAME}\`;"
+
+echo "  → Loading structure into target..."
+MYSQL_PWD="${TARGET_DB_PASS}" "${MYSQL_BIN}" \
+    -h "${DB_HOST}" -P "${DB_PORT}" \
+    -u "${TARGET_DB_USER}" \
+    "${TARGET_DB_NAME}" < "${DUMP_FILE}"
+
+echo ""
+echo "Done. Test schema '${TARGET_DB_NAME}' now mirrors the structure of '${SOURCE_DB_NAME}'."
+echo "Next step: load reference data with:"
+echo "  php tests/setup-test-database.php"

--- a/tests/bootstrap-integration.php
+++ b/tests/bootstrap-integration.php
@@ -37,19 +37,44 @@ if (!file_exists($initPath)) {
     exit(1);
 }
 
-// Load test environment (.env.local overrides .env for local development).
+// Integration tests must run against a DEDICATED test schema, never the dev
+// database. We require .env.test.local (pointing at that schema) and refuse to
+// fall back to .env.local/.env, because a fallback risks running destructive
+// integration tests against the live development database.
+$envTestLocal = $projectRoot . '/.env.test.local';
+if (!file_exists($envTestLocal)) {
+    fwrite(STDERR, "ERROR: Integration test environment file not found at: {$envTestLocal}\n");
+    fwrite(STDERR, "Integration tests require .env.test.local pointing at a dedicated test schema (e.g. elanregi_spice_test).\n");
+    fwrite(STDERR, "This bootstrap intentionally does NOT fall back to .env.local or .env, because that risks\n");
+    fwrite(STDERR, "running destructive integration tests against the development database.\n");
+    fwrite(STDERR, "To set up: cp .env.test.local.sample .env.test.local, then fill in DB_PASS.\n");
+    fwrite(STDERR, "See docs/development/ENVIRONMENT.md for details.\n");
+    exit(1);
+}
+
 // The Dotenv class is available because vendor/autoload.php was loaded above.
 // createMutable() allows init.php's createImmutable() to read our test values from $_ENV.
-$envLocal = $projectRoot . '/.env.local';
-$envName  = file_exists($envLocal) ? '.env.local' : '.env';
-
 try {
-    \Dotenv\Dotenv::createMutable($projectRoot, $envName)->load();
-    fwrite(STDERR, "NOTE: Loaded test environment from {$envName}\n");
+    \Dotenv\Dotenv::createMutable($projectRoot, '.env.test.local')->load();
+    fwrite(STDERR, "NOTE: Loaded test environment from .env.test.local\n");
 } catch (\Dotenv\Exception\ExceptionInterface $e) {
-    fwrite(STDERR, "WARNING: Could not load {$envName}: {$e->getMessage()}\n");
-    fwrite(STDERR, "WARNING: All integration tests requiring a database will be skipped.\n");
-    fwrite(STDERR, "WARNING: To enable them, copy .env.local.sample to .env.local and fill in credentials.\n");
+    // A load failure here is fatal: we have no reliable way to know which
+    // database we would connect to, so proceeding at all would be unsafe.
+    fwrite(STDERR, "ERROR: Could not load .env.test.local: {$e->getMessage()}\n");
+    fwrite(STDERR, "Integration tests cannot run without a valid test environment. Aborting.\n");
+    exit(1);
+}
+
+// Defense-in-depth: refuse to proceed if the test environment points at the dev database.
+// Case-folded and trimmed because MAMP's MySQL runs with lower_case_table_names=2 on
+// macOS's case-insensitive filesystem, so ELANREGI_SPICE and elanregi_spice are the same
+// physical database — a naive === comparison would miss a typo'd-case DB_NAME.
+$configuredDbName = strtolower(trim($_ENV['DB_NAME'] ?? ''));
+if ($configuredDbName === 'elanregi_spice') {
+    fwrite(STDERR, "ERROR: .env.test.local is pointed at the development database (elanregi_spice).\n");
+    fwrite(STDERR, "Integration tests must use a dedicated test schema (e.g. elanregi_spice_test).\n");
+    fwrite(STDERR, "Update DB_NAME in .env.test.local before running integration tests. Aborting.\n");
+    exit(1);
 }
 
 // Suppress UserSpice initialization errors (especially database connection errors)
@@ -105,6 +130,32 @@ try {
         $result = $testDb->query("SELECT 1");
         fwrite(STDERR, "NOTE: Database connection verified for integration tests\n");
 
+        // Defense-in-depth: check the database ACTUALLY connected to, not just the
+        // $_ENV value read earlier. If .env.test.local omits DB_NAME (or any other
+        // DB_* key), users/init.php's own createImmutable()->safeLoad() of the root
+        // .env backfills the missing key(s) from the dev config — the earlier $_ENV
+        // guard can't see that, because it runs before init.php loads at all. This
+        // check reflects the connection as it truly resolved, closing that gap.
+        //
+        // This has its own try/catch (rather than sharing the outer one, which
+        // treats failure as a non-fatal "NOTE") because a failure HERE means we
+        // couldn't confirm which database we're connected to — that must abort,
+        // not be logged as a passive reconnection hiccup and continue anyway.
+        try {
+            $connectedDb = strtolower(trim((string)($testDb->query('SELECT DATABASE() AS name')->first()?->name ?? '')));
+        } catch (\Throwable $e) {
+            fwrite(STDERR, "ERROR: Could not verify the connected database's identity: {$e->getMessage()}\n");
+            fwrite(STDERR, "Refusing to proceed without confirming this is not the development database.\n");
+            exit(1);
+        }
+        if ($connectedDb === 'elanregi_spice') {
+            fwrite(STDERR, "ERROR: Integration tests connected to the development database (elanregi_spice).\n");
+            fwrite(STDERR, "This likely means .env.test.local is missing one or more DB_* keys, which were\n");
+            fwrite(STDERR, "backfilled from the root .env file. Ensure .env.test.local sets DB_HOST, DB_USER,\n");
+            fwrite(STDERR, "DB_NAME, and DB_PASS explicitly. Aborting.\n");
+            exit(1);
+        }
+
         // Re-initialize the global $db after configuration fixes
         // This ensures $db in tests uses the corrected configuration
         $GLOBALS['db'] = $testDb;
@@ -151,7 +202,7 @@ try {
 
                         // Verify loaded
                         $newCount = $db->query("SELECT COUNT(*) as cnt FROM car_models")->first();
-                        $loadedCount = $newCount ? $newCount->cnt : 0;
+                        $loadedCount = (int)($newCount?->cnt ?? 0);
 
                         fwrite(STDERR, "NOTE: Loaded {$loadedCount} car_models records for integration tests\n");
                     } else {
@@ -164,7 +215,7 @@ try {
                 fwrite(STDERR, "NOTE: Reference data file not found: {$refDataPath}\n");
             }
         } else {
-            $recordCount = $count ? $count->cnt : 0;
+            $recordCount = (int)($count?->cnt ?? 0);
             fwrite(STDERR, "NOTE: car_models table already populated with {$recordCount} records\n");
         }
     }

--- a/tests/setup-test-database.php
+++ b/tests/setup-test-database.php
@@ -31,7 +31,7 @@ try {
 // Check car_models table existence
 try {
     $count = $db->query("SELECT COUNT(*) as cnt FROM car_models")->first();
-    $currentCount = (int)$count->cnt;
+    $currentCount = (int)($count?->cnt ?? 0);
     echo "📊 Current car_models records: {$currentCount}\n";
 
     if ($currentCount > 0) {
@@ -81,7 +81,7 @@ try {
 
     // Verify the data was loaded
     $count = $db->query("SELECT COUNT(*) as cnt FROM car_models")->first();
-    $loadedCount = (int)$count->cnt;
+    $loadedCount = (int)($count?->cnt ?? 0);
 
     if ($loadedCount === 0) {
         fwrite(STDERR, "❌ ERROR: No records were inserted into car_models\n");


### PR DESCRIPTION
## Summary

- Replaces the `.env.local` → `.env` fallback in `tests/bootstrap-integration.php` with a required, dedicated `.env.test.local` tier — the destructive integration suite (deletion/merge/consolidation/archive tests) can no longer silently fall back to the real dev database (`elanregi_spice`).
- Adds two layers of defense-in-depth: the loaded `DB_NAME` value is checked before connecting, and the *actual* connected database (`SELECT DATABASE()`) is checked again afterward — closing a gap where an omitted `DB_*` key in `.env.test.local` could otherwise be silently backfilled from the root `.env`.
- Adds `scripts/create-test-schema.sh` — a rerunnable script that clones the dev database's current structure (via `mysqldump --no-data`) into the test schema, strips trigger/view `DEFINER` clauses (so they aren't orphaned under a different DB user), and refuses to run if source and target schema names resolve to the same name.
- Adds `.env.test.local.sample` (tracked template) and documents the full setup flow in `docs/development/ENVIRONMENT.md`.

## Verification

Verified end-to-end against a real local MySQL instance (not just unit-tested):

- Dev DB row counts (`cars`, `users`, `car_models`) confirmed byte-for-byte unchanged across repeated integration test runs against the isolated schema.
- Missing `.env.test.local` → aborts with a clear, actionable message (no silent fallback).
- `.env.test.local` misconfigured with `DB_NAME=elanregi_spice` → aborts with a clear message.
- `scripts/create-test-schema.sh` correctly clones structure (72 tables match source) and strips trigger `DEFINER`, confirmed via `information_schema.triggers`.
- Went through a full local `/review-pr` pass (code-reviewer, silent-failure-hunter, comment-analyzer) — all findings fixed and re-verified, including two reproducible bugs found during review: a `pipefail`+`grep` silent-death path in the credential-parsing helper, and a DB-identity guard that could be silently bypassed if wrapped in the wrong `catch` block.

## Follow-up work (not in scope here, tracked separately)

Running the full integration suite against the isolated schema surfaced two pre-existing issues, neither caused by this change:

- #1478 — several integration tests assume ambient dev-data exists (hardcoded user IDs, `LIMIT 1` lookups) instead of creating their own fixtures; silently masked until now by always running against a fully-populated dev DB.
- #1480 — the reference-data auto-load in bootstrap swallows failures as a non-fatal `NOTE` despite claiming graceful test handling; found during review, predates this branch.

Closes #1436