### PR TITLE
fix: deploy hook deletes server backups on every push

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -70,9 +70,6 @@ instructions.txt
 # Database migrations (run automatically by post-receive hook, not served)
 database/
 
-# Local backups (server maintains its own; don't overwrite with git checkout)
-backups/
-
 # Dev-only scripts and utilities
 utilities/
 

--- a/docs/development/DEPLOYMENT.md
+++ b/docs/development/DEPLOYMENT.md
@@ -305,6 +305,13 @@ Test and production servers have a single shared post-receive hook
 3. Run `composer install --no-dev --optimize-autoloader`
 4. Run `php vendor/bin/phinx migrate` (halts deployment on failure)
 5. Self-update the installed hook from the newly deployed working tree
+6. Remove dev-only paths listed in `.deployignore` (e.g. `tests/`, `scripts/`,
+   `utilities/`, `wiki/`) via `rm -rf`, then remove `.deployignore` itself
+
+**Important:** Never list a persistent, server-writable directory in
+`.deployignore` (e.g. `backups/`) — step 6's `rm -rf` would delete it wholesale
+on every subsequent push. See #1479, where this happened to the server's
+backup directory.
 
 **Development:**
 

--- a/docs/releases/RELEASE_NOTES_v2.29.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.0.md
@@ -11,6 +11,7 @@
   - Run `npm run test:e2e` against the deployed test environment to validate the new Playwright title/description assertions against live Apache/PHP config
   - Manual: GSC → URL Inspection → Request Indexing for `https://elanregistry.org/docs/reference/paint-colors.php`
 - **#1394 (Sendinblue plugin update):** Applied on local dev only so far. Still needs the same manual update (Admin → Spice Shaker → Installed Plugins → Update) on test and production, followed by the Test Email + password-reset smoke tests on each — see `docs/development/EMAIL_SYSTEM.md#updating-the-plugin`.
+- **#1479 (backups wiped on every deploy):** After deploying, verify on the test server that a file placed in `backups/automated/` survives a subsequent deploy, and confirm `https://elanregistry.org/backups/` (and a direct file URL under it) return 403 on prod. Watch the next scheduled monitoring run for zero new `cleanupOldBackups` `realpath()` failures.
 
 ## User-Facing Changes
 
@@ -60,3 +61,4 @@
 - [#1436](https://github.com/elan-registry/registry/issues/1436) — test: isolate integration tests onto a dedicated test schema
 - [#1437](https://github.com/elan-registry/registry/issues/1437) — ci: run PHPUnit unit + regression suites on every PR
 - [#1470](https://github.com/elan-registry/registry/issues/1470) — bug: LocationService cache silently disabled when APCu is present but non-functional
+- [#1479](https://github.com/elan-registry/registry/issues/1479) — fix: deploy hook deletes server backups on every push — remove backups/ from .deployignore


### PR DESCRIPTION
## Summary

- Removes `backups/` from `.deployignore` — this line caused the post-receive deploy hook to `rm -rf` the server's persistent `backups/` directory on every deploy. Confirmed on prod: `backups/` has had zero persistent backups since the line was added, and every `cleanupOldBackups()` `realpath()` failure tracked in #1472 was this, not a one-off.
- Documents the previously-undocumented `.deployignore` cleanup step in `docs/development/DEPLOYMENT.md` (it runs last, after checkout/VERSION/composer install/migrate/self-update), with a callout against ever listing a stateful, server-writable directory there again.
- Adds release-notes entries: a "Required Actions After Deployment" verification checklist and the "Issues Resolved" line.

## Bug Escape Analysis

- **Root cause:** The `backups/` line was batched incidentally into an unrelated doc-reorg PR's list of dev-only paths (`git blame` → `c2d8af60e`), alongside genuinely static paths like `FIX/` and `utilities/`, and never revisited for the fact that `backups/` is stateful and server-writable, unlike its neighbors in that list.
- **Testing gap:** No test coverage of the server-side deploy hook itself exists (it's a bash script that only runs on the live test/prod servers), so nothing in CI could have caught this.
- **Preventive measure:** The acceptance criteria's live verification on the test server (backup file survives a deploy) is the only practical check — tracked as required post-deploy verification in the release notes, not something automatable from this repo alone.

## Verification

- `.deployignore` no longer contains `backups/` (verified via `grep`).
- `git ls-files backups/` confirms the tracked `.gitkeep` skeleton is untouched.
- Security review: clean — confirmed the `.htaccess:77` web-block (`RewriteRule ^backups/ - [F,L]`) is independent of `.deployignore` and unaffected; confirmed this fix targets the actual live `BACKUP_BASE_DIR` the app writes to (`usersc/includes/config.php`).
- Local `/review-pr` pass (code-reviewer, comment-analyzer): both clean, all documentation claims verified against the actual `post-receive` hook source.

## Cannot be verified from this session

The acceptance criteria's live checks require an actual deploy (`git push test main`), which is a manual, separate step per CLAUDE.md:
- Backup file placed in `backups/automated/` survives a subsequent deploy on test.
- `https://elanregistry.org/backups/` returns 403 on prod after the fix deploys.
- Next monitoring run shows zero new `cleanupOldBackups` realpath failures.

Closes #1479