### PR TITLE
fix: $pageTitle set after header render has no effect on 3 admin pages

### DIFF
--- a/app/admin/design-system.php
+++ b/app/admin/design-system.php
@@ -13,14 +13,15 @@ declare(strict_types=1);
  * usersc/templates/customizer.css.
  */
 
+$pageTitle = 'Color Preview — Elan Registry Token System';
+$pageDescription = 'Preview of the Elan Registry design system color tokens and UI components.';
+
 require_once '../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
 if (!securePage($php_self)) {
     die();
 }
-
-$pageTitle = 'Color Preview — Elan Registry Token System';
 ?>
 
 <style nonce="<?= htmlspecialchars($userspice_nonce ?? '') ?>">

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -27,6 +27,19 @@ use ElanRegistry\Transfer\CarTransferRepository;
  * @copyright 2025
  */
 
+// Tab routing - determine which tab to show
+$validTabs = [
+    'car-mgmt' => 'Car/Owner Relationships',
+    'manage-cars' => 'Manage Cars',
+    'owner-mgmt' => 'Manage Owners',
+    'account-cleanup' => 'Account Cleanup',
+];
+
+$activeTab = isset($_GET['tab']) && is_string($_GET['tab']) && array_key_exists($_GET['tab'], $validTabs)
+    ? $_GET['tab'] : 'car-mgmt';
+$pageTitle = 'Registry Management - ' . $validTabs[$activeTab];
+$pageDescription = 'Admin tools for managing car and owner relationships in the Lotus Elan Registry.';
+
 require_once '../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
@@ -69,17 +82,6 @@ try {
     Redirect::to($us_url_root . 'users/login.php');
     die();
 }
-
-// Tab routing - determine which tab to show
-$validTabs = [
-    'car-mgmt' => 'Car/Owner Relationships',
-    'manage-cars' => 'Manage Cars',
-    'owner-mgmt' => 'Manage Owners',
-    'account-cleanup' => 'Account Cleanup',
-];
-
-$activeTab = isset($_GET['tab']) && array_key_exists($_GET['tab'], $validTabs) ? $_GET['tab'] : 'car-mgmt';
-$pageTitle = 'Registry Management - ' . $validTabs[$activeTab];
 
 // Generate CSRF token for forms
 $csrfToken = Token::generate();
@@ -358,7 +360,7 @@ if (ElanInput::existsPost()) {
 
 <div class="page-wrapper">
     <!-- Hidden CSRF token for AJAX requests -->
-    <input type="hidden" name="csrf" value="<?= $csrfToken ?>" />
+    <input type="hidden" name="csrf" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>" />
 
     <div class="container-fluid">
         <div class="page-container">
@@ -473,7 +475,7 @@ if (ElanInput::existsPost()) {
                                 <?php include 'includes/partials/js-data-island.php'; ?>
                                 <?php
                                 // Include the appropriate tab content
-                                $tabFile = 'includes/tab-' . str_replace('-', '_', $activeTab) . '.php';
+                                $tabFile = 'includes/tab-' . str_replace('-', '_', $activeTab) . '.php'; // $activeTab already whitelist-validated above
                                 $tabPath = __DIR__ . '/' . $tabFile;
 
                                 if (file_exists($tabPath)) {
@@ -772,7 +774,7 @@ if (ElanInput::existsPost()) {
                     </div>
 
                     <!-- Hidden fields -->
-                    <input type="hidden" name="csrf" value="<?= Token::generate(); ?>" />
+                    <input type="hidden" name="csrf" value="<?= htmlspecialchars(Token::generate(), ENT_QUOTES, 'UTF-8') ?>" />
                     <input type="hidden" name="action" value="admin_contact_owner" />
                     <input type="hidden" name="car_id" id="contactCarId" value="" />
                     <input type="hidden" name="owner_id" id="contactOwnerId" value="" />

--- a/app/admin/maintenance.php
+++ b/app/admin/maintenance.php
@@ -24,6 +24,17 @@ use ElanRegistry\LogCategories;
  * @copyright 2025
  */
 
+$validTabs = [
+    'health'      => 'Health',
+    'maintenance' => 'Maintenance',
+    'settings'    => 'Configuration',
+];
+
+$activeTab = isset($_GET['tab']) && is_string($_GET['tab']) && array_key_exists($_GET['tab'], $validTabs)
+    ? $_GET['tab'] : 'health';
+$pageTitle = 'Registry Maintenance - ' . $validTabs[$activeTab];
+$pageDescription = 'Admin tools for registry maintenance, health checks, and system configuration.';
+
 require_once '../../users/init.php';
 require_once $abs_us_root . $us_url_root . 'usersc/includes/elanregistry_prep.php';
 
@@ -47,15 +58,6 @@ try {
     Redirect::to($us_url_root . 'users/login.php');
     die();
 }
-
-$validTabs = [
-    'health'      => 'Health',
-    'maintenance' => 'Maintenance',
-    'settings'    => 'Configuration',
-];
-
-$activeTab = isset($_GET['tab']) && array_key_exists($_GET['tab'], $validTabs) ? $_GET['tab'] : 'health';
-$pageTitle = 'Registry Maintenance - ' . $validTabs[$activeTab];
 
 // Generate CSRF token for AJAX requests
 $csrfToken = Token::generate();

--- a/docs/releases/RELEASE_NOTES_v2.29.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.0.md
@@ -40,6 +40,7 @@
 
 ### Bug Fixes
 
+- **Admin page browser tab titles** ([#1430](https://github.com/elan-registry/registry/issues/1430)): `app/admin/index.php`, `maintenance.php`, and `design-system.php` now show their page-specific browser tab title (e.g. "Registry Maintenance - Health") instead of the generic site title — the `$pageTitle` variable was being set after the point the header template reads it, so the assignment silently had no effect. Cosmetic only; these pages are admin-only and not search-indexed.
 - **DataTables pagination validation** ([#1399](https://github.com/elan-registry/registry/issues/1399)): Invalid pagination parameters (including the former "All" option, `length=-1`) now return a 422 error instead of a SQL 500. The "All" rows option has been removed from the cars and factory table menus; page size is capped at 100 server-side.
 - **Location service cache silently disabled when APCu is present but non-functional** ([#1470](https://github.com/elan-registry/registry/issues/1470)): `LocationService`'s geocoding cache and its own per-user geocoding rate limiter both silently stopped working whenever the `apcu` PHP extension was loaded but not actually functional for the running context (e.g. `apc.enable_cli=Off`, common in CLI/cron execution) — the code checked only whether the extension existed, not whether it actually succeeded, so it never fell through to its documented file-based fallback. Both now correctly fall back to file-based caching whenever an APCu operation doesn't succeed. Found while adding automated CI test execution ([#1437](https://github.com/elan-registry/registry/issues/1437)).
 
@@ -62,6 +63,7 @@
 - [#1406](https://github.com/elan-registry/registry/issues/1406) — security: fix account enumeration during registration (generic response + silent recovery email)
 - [#1409](https://github.com/elan-registry/registry/issues/1409) — fix: GSC 404 cleanup — legacy path redirects and PDF filename case mismatch
 - [#1424](https://github.com/elan-registry/registry/issues/1424) — feat: log deployment events to system log on each successful push
+- [#1430](https://github.com/elan-registry/registry/issues/1430) — bug: $pageTitle set after header render has no effect on 3 admin pages
 - [#1432](https://github.com/elan-registry/registry/issues/1432) — feat: page-specific title/description convention rollout to 11 top-value pages; fix og:title/twitter:title; close #1431 (superseded)
 - [#1436](https://github.com/elan-registry/registry/issues/1436) — test: isolate integration tests onto a dedicated test schema
 - [#1437](https://github.com/elan-registry/registry/issues/1437) — ci: run PHPUnit unit + regression suites on every PR

--- a/tests/playwright/admin-page-titles.spec.js
+++ b/tests/playwright/admin-page-titles.spec.js
@@ -1,0 +1,78 @@
+// tests/playwright/admin-page-titles.spec.js
+//
+// Behavioral verification for #1430: app/admin/index.php,
+// app/admin/maintenance.php, and app/admin/design-system.php set
+// $pageTitle/$pageDescription before requiring users/init.php (previously
+// they were set after, so the page-specific title never took effect and the
+// generic site title rendered instead). This confirms the actual rendered
+// <title> now reflects the page-specific title for each tab.
+//
+// Requires local MAMP at http://localhost:9999/elan-registry
+
+const { test, expect } = require('@playwright/test');
+const { ensureLoggedIn } = require('./auth-helper.js');
+
+// ---------------------------------------------------------------------------
+// Area 1: index.php — Registry Management tabs
+// ---------------------------------------------------------------------------
+
+test.describe('Admin page titles — index (#1430)', () => {
+    test.beforeEach(async ({ page }) => {
+        await ensureLoggedIn(page);
+    });
+
+    test('default tab (car-mgmt) renders page-specific title', async ({ page }) => {
+        await page.goto('app/admin/index.php', { waitUntil: 'networkidle' });
+        // The <title> tag appends " {site_name}" after $pageTitle (see
+        // users/template/header1_must_include.php), so this is a partial
+        // (contains) match rather than an exact one.
+        await expect(page).toHaveTitle(/Registry Management - Car\/Owner Relationships/);
+    });
+
+    test('manage-cars tab renders page-specific title', async ({ page }) => {
+        await page.goto('app/admin/index.php?tab=manage-cars', { waitUntil: 'networkidle' });
+        await expect(page).toHaveTitle(/Registry Management - Manage Cars/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Area 2: maintenance.php — Registry Maintenance tabs
+// ---------------------------------------------------------------------------
+
+test.describe('Admin page titles — maintenance (#1430)', () => {
+    test.beforeEach(async ({ page }) => {
+        await ensureLoggedIn(page);
+    });
+
+    test('default tab (health) renders page-specific title', async ({ page }) => {
+        await page.goto('app/admin/maintenance.php', { waitUntil: 'networkidle' });
+        await expect(page).toHaveTitle(/Registry Maintenance - Health/);
+    });
+
+    test('settings tab renders page-specific title', async ({ page }) => {
+        await page.goto('app/admin/maintenance.php?tab=settings', { waitUntil: 'networkidle' });
+        await expect(page).toHaveTitle(/Registry Maintenance - Configuration/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Area 3: design-system.php — static page-specific title
+// ---------------------------------------------------------------------------
+
+test.describe('Admin page titles — design system (#1430)', () => {
+    test.beforeEach(async ({ page }) => {
+        await ensureLoggedIn(page);
+    });
+
+    test('renders page-specific title and description', async ({ page }) => {
+        await page.goto('app/admin/design-system.php', { waitUntil: 'networkidle' });
+        await expect(page).toHaveTitle(/Color Preview — Elan Registry Token System/);
+
+        // $pageDescription's timing isn't strictly required (head_tags.php reads it
+        // at render time, unlike $pageTitle), but its VALUE should still reach the
+        // meta tag correctly — this is the one page in the set with an easy static
+        // value to assert against.
+        const description = await page.locator('meta[name="description"]').getAttribute('content');
+        expect(description).toBe('Preview of the Elan Registry design system color tokens and UI components.');
+    });
+});

--- a/tests/unit/system/PageMetadataCompletenessTest.php
+++ b/tests/unit/system/PageMetadataCompletenessTest.php
@@ -22,8 +22,9 @@ use PHPUnit\Framework\Attributes\Group;
  * This test is a pure static-text scan: it reads each file's raw source
  * via file_get_contents() and never requires/executes it, so it needs no
  * database and no bootstrapped UserSpice environment. It covers the 11
- * pages added under #1432 plus the original #1372 page, so a future
- * regression on any of these 12 files is caught immediately.
+ * pages added under #1432 plus the original #1372 page and the 3 admin
+ * pages fixed in #1430, so a future regression on any of these 15 files
+ * is caught immediately.
  */
 #[Group('system')]
 #[Group('page-metadata')]
@@ -42,6 +43,9 @@ class PageMetadataCompletenessTest extends TestCase
         'app/owner/cars/index.php',
         'app/owner/cars/factory.php',
         'app/owner/reports/statistics.php',
+        'app/admin/index.php',
+        'app/admin/maintenance.php',
+        'app/admin/design-system.php',
     ];
 
     private string $rootDir = '';


### PR DESCRIPTION
## Summary

- `app/admin/index.php`, `maintenance.php`, and `design-system.php` set `$pageTitle` (and now `$pageDescription`, added for consistency with the #1372/#1432 convention) **after** `require_once '../../users/init.php'` — by which point the header template has already rendered `<title>`, so the assignment silently had no effect. The browser tab always showed the generic site title instead of the page-specific one.
- **Corrects the issue's own suggested fix location**: the issue said to move the block before the `elanregistry_prep.php` require, but that require is actually a no-op by then (PHP dedupes `require_once` by resolved path, and `init.php`'s own require chain already pulled the same file in). The block must precede `require_once '../../users/init.php'` itself.

## Bug Escape Analysis

- **Root cause**: the require order was copied from before the `$pageTitle` convention existed on these pages.
- **Testing gap**: no test covered these 3 pages' titles at all until now.
- **Preventive measure**: extended `tests/unit/system/PageMetadataCompletenessTest.php` (added in #1432, whose docblock already anticipated this exact fix) to these 3 files, plus a new Playwright spec (`tests/playwright/admin-page-titles.spec.js`) verifying the actual rendered `<title>` across tabs.

## Found in passing (folded into this PR — in-scope files, low severity, quick fixes)

- `app/admin/index.php` had two CSRF token outputs missing `htmlspecialchars()` — one caught during this issue's own security review, the second by `/review-pr`'s code-reviewer pass on the committed diff.
- `/review-pr`'s code-reviewer also caught a real regression I introduced: relocating the `$_GET['tab']`-derived tab-routing block ahead of `securePage()` widened its reachability from "authenticated admin only" to "anyone," and moved it in front of UserSpice's error handler — a non-string `$_GET['tab']` (e.g. `?tab[]=x`) would throw an uncaught `TypeError` on `array_key_exists()`. Added an `is_string()` guard; verified empirically (reproduced the throw before the fix, confirmed it's prevented after).

## Verification

- `composer test:quick` — 1334 tests pass (up from 1322 pre-#1430), including 60 `PageMetadataCompletenessTest` assertions covering all 15 convention pages.
- PHPStan clean, ESLint clean.
- Empirically reproduced and verified the fix for the `TypeError` regression via a standalone PHP repro script.
- Security review: clean on the core relocation (whitelist-only title-building pattern confirmed preserved, no new pre-auth side effects from the *intended* logic).
- Full `/review-pr` pass (code, comments, tests agents) — all findings addressed.

## Cannot be verified from this session

The new Playwright spec requires a running MAMP instance + admin login (`npm run playwright:test`) — written but not executed locally in this environment.

Closes #1430