### PR TITLE
test: fix SecurityHeadersTest silent zero-assertion CSP hash check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "scripts": {
         "_comment": "Unit tests (mocks, no database) vs Integration tests (real database)",
         "test:quick": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit",
-        "test:quick:ci": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit --exclude-group known-broken",
+        "test:quick:ci": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit --exclude-group known-broken --exclude-group requires-upstream-install",
         "test:unit": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Unit",
         "test:regression": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Regression",
         "test:regression:ci": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --testsuite=Regression --exclude-group known-broken",

--- a/tests/README.md
+++ b/tests/README.md
@@ -178,9 +178,16 @@ npm run playwright:test:ui       # UI consistency
 
 `.github/workflows/tests.yml` runs `composer test:quick:ci` and `composer test:regression:ci`
 (not plain `test:quick`/`test:regression`) for the CI-blocking check on every PR. Each `:ci`
-variant is identical to its base command except it adds `--exclude-group known-broken` — both
-suites support the exclusion identically, so a tagged test is skipped in CI regardless of
+variant is identical to its base command except it adds one or more `--exclude-group` flags —
+both suites support the exclusion identically, so a tagged test is skipped in CI regardless of
 which suite it lives in.
+
+**PHPUnit CLI gotcha:** `--exclude-group` does **not** accept a comma-separated list of groups
+in a single flag (e.g. `--exclude-group foo,bar` silently excludes nothing, since PHPUnit treats
+the whole comma-joined string as one literal group name that matches no test). To exclude
+multiple groups, repeat the flag: `--exclude-group foo --exclude-group bar`. Verified empirically
+while adding the `requires-upstream-install` group (#1471) — the comma form ran the excluded
+test anyway with no error or warning, so this is easy to get wrong silently.
 
 **Why this exists:** landing a new CI gate (`#1437`) should never be blocked indefinitely by
 an unrelated, already-tracked, pre-existing bug — but a bypass that's silent or permanent is
@@ -206,6 +213,26 @@ specifically for "this genuinely needs investigation, is tracked, and shouldn't 
 unrelated PR" scenarios, discovered in practice when `tests.yml` first ran on a clean Linux
 CI checkout and surfaced pre-existing macOS-vs-Linux behavior differences invisible to local
 development.
+
+## The `requires-upstream-install` Group — a Different Concept From `known-broken`
+
+A second `--exclude-group` tag exists in `test:quick:ci`: `requires-upstream-install`. Unlike
+`known-broken`, this is **not** a temporary bypass for a tracked, resolvable bug — it's a
+permanent, environment-conditional classification for a test that structurally cannot assert
+anything without a real local UserSpice install (e.g. `SecurityHeadersTest::testUpstreamScriptHashesMatchActualFiles()`,
+which verifies CSP hashes against gitignored, environment-local upstream files that never
+exist in a fresh checkout — see CLAUDE.md's Template Customization Rules for why those files
+aren't tracked).
+
+- Not tied to any GitHub issue, not expected to ever be "resolved" or removed.
+- Such a test must `markTestSkipped(...)` with a clear reason when its required local files are
+  absent, rather than silently completing with zero assertions (PHPUnit reports a zero-assertion
+  test as "risky," not "skipped" — risky tests don't fail the build by default and are easy to
+  miss in CI output; an explicit skip is visible and self-explanatory).
+- `composer test:quick`/`composer test:regression` (no `:ci` suffix) still run these tests, so a
+  developer with a full local UserSpice install gets real verification when running the full suite.
+- `/finish-milestone`'s known-broken check does **not** apply to this group — there's nothing to
+  resolve or report on, it's a standing, intentional environment split.
 
 ## Writing New Tests
 

--- a/tests/unit/security/SecurityHeadersTest.php
+++ b/tests/unit/security/SecurityHeadersTest.php
@@ -308,7 +308,22 @@ class SecurityHeadersTest extends TestCase
      * IMPORTANT: this method must not contain the literal two-char PHP closing sequence
      * in any comment or string, or PHP will exit its own parsing mode mid-file.
      * We construct it dynamically: chr(63).chr(62) = question-mark + greater-than.
+     *
+     * This is a LOCAL-ONLY maintenance check, not a CI regression gate: the 3 upstream
+     * files it reads are gitignored, environment-local UserSpice files (see CLAUDE.md's
+     * Template Customization Rules) that never exist in a fresh checkout. Run this on a
+     * machine with a full UserSpice install after updating those files, before committing
+     * the resulting hash change to security_headers.php. In CI (or any checkout without
+     * them) it skips by design — see the #[Group('requires-upstream-install')] exclusion
+     * in composer.json's test:quick:ci script — not because of a zero-assertion accident.
+     *
+     * Known limitation: the skip below only fires when NONE of the 3 files are found —
+     * a partial local install (or an extraction pattern that fails to match within a
+     * present file) still runs and passes with fewer than 5 assertions, silently
+     * under-verifying. See #1486, a live instance of this (one block is never extracted
+     * due to a line-ending mismatch), for the case this doesn't catch.
      */
+    #[Group('requires-upstream-install')]
     public function testUpstreamScriptHashesMatchActualFiles(): void
     {
         $root = dirname(__DIR__, 3);
@@ -318,6 +333,16 @@ class SecurityHeadersTest extends TestCase
         $phpClose = chr(63) . chr(62);
 
         $bodies = $this->extractUpstreamScriptBodies($root, $phpClose);
+
+        if ($bodies === []) {
+            $this->markTestSkipped(
+                'None of the 3 upstream UserSpice files this test verifies exist in this ' .
+                'checkout (they are gitignored, environment-local files — see CLAUDE.md\'s ' .
+                'Template Customization Rules). This is a local-only maintenance check: run ' .
+                'it on a machine with a full UserSpice install after updating those files, ' .
+                'before committing the resulting hash change to security_headers.php.'
+            );
+        }
 
         foreach ($bodies as $label => $body) {
             $hash = base64_encode(hash('sha256', $body, true));


### PR DESCRIPTION
## Summary

- `SecurityHeadersTest::testUpstreamScriptHashesMatchActualFiles()` verifies CSP hashes against 3 gitignored, environment-local upstream UserSpice files. In a fresh CI checkout none of those files exist, so the extraction helper returns `[]` and the `foreach` loop ran zero iterations — PHPUnit reports this as "risky" (silent zero-assertion pass), not skipped, so it silently provided zero protection with no visible signal in CI output.
- Adds an explicit `markTestSkipped()` when no upstream files are found, with a clear message explaining this is a local-only maintenance check (run after updating UserSpice locally, before committing a hash change).
- Tags the method `#[Group('requires-upstream-install')]` — a new, permanent, environment-conditional classification distinct from the existing `known-broken` group (which is a temporary, tracked-bug bypass). Excludes the new group from `composer.json`'s `test:quick:ci` script.
- Documents a PHPUnit CLI gotcha discovered while wiring this up: `--exclude-group` does not support comma-separated multiple groups in one flag — verified empirically (comma form silently ran the excluded test anyway; the fix uses a repeated `--exclude-group` flag instead).

## Verification

- `composer test:quick` (upstream files present): 1334 tests, real assertions still run for this test.
- `composer test:quick:ci`: 1333 tests — confirms the new exclude-group entry works.
- Manually verified the skip fires with the correct message when the 3 upstream files are absent (moved them aside, ran the test, confirmed "Skipped: 1", restored files, confirmed 4 assertions resume).
- PHPStan clean on the touched file; no baseline entries needed clearing.
- markdownlint clean on `tests/README.md`.

## Found in passing

Two pre-existing, out-of-scope issues surfaced during verification (both filed separately per the containment+severity triage — out of scope + Low severity → `triage` label only, no milestone):

- **#1486** — the same test's extraction helper silently verifies only 4 of its 5 documented hash blocks, due to a CRLF-vs-LF mismatch in one file's `strpos()` match. Independently re-confirmed by three review agents during `/review-pr`; I additionally verified this is **not** a live production/security issue — the declared hash matches the LF-normalized body exactly, consistent with browsers normalizing CRLF→LF during HTML parsing before computing CSP hashes. Purely a gap in this test's own extraction logic.
- **#1487** — an unrelated pre-existing PHP warning (`Attempt to read property "count" on false`) in `CarDataTablesServiceTest`, surfaced while running the full unit suite.

A `/review-pr` pass also caught and fixed one inaccurate citation in `tests/README.md` (a doc reference that didn't actually support its claim) and added a "known limitation" note to the docblock disclosing that the fix's skip only fires on *zero* extracted blocks, not partial extraction — pointing at #1486 as a live instance of that narrower case.

Closes #1471

Claude-Session: https://claude.ai/code/session_018RYKgRUy5Bzdky9F5dLu77