### PR TITLE
feat: create dynamic sitemap.xml for public car registry pages

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -84,6 +84,10 @@ RewriteCond %{HTTP_HOST} ^test\.elanregistry\.org [NC,OR]
 RewriteCond %{SERVER_NAME} ^test\.elanregistry\.org [NC]
 RewriteRule ^robots\.txt$ /robots-test.txt [L]
 
+# Public sitemap.xml for search engine discovery (#1373)
+# Internal rewrite (no redirect) - crawler-visible URL stays /sitemap.xml
+RewriteRule ^sitemap\.xml$ /app/api/shared/sitemap.php [L]
+
 # Soft 404 fix: embed.php (removed) and pdf-viewer.php single-param ?doc= format (#1369)
 # All referenced PDFs confirmed in docs/reference/assets/
 # NE preserves URL encoding in filenames with spaces/parens; QSD drops the original query string

--- a/app/api/shared/sitemap.php
+++ b/app/api/shared/sitemap.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use ElanRegistry\Car\CarRepository;
+use ElanRegistry\LogCategories;
+use ElanRegistry\SitemapService;
+
+/**
+ * Public sitemap.xml (#1373) — served at /sitemap.xml via an .htaccess
+ * internal rewrite (no redirect; crawler-visible URL stays /sitemap.xml).
+ *
+ * No auth, no CSRF, no rate limit: this must be freely, repeatedly fetchable
+ * by search-engine crawlers, unlike every other file in app/api/shared/.
+ */
+
+require_once '../../../users/init.php';
+
+try {
+    $service = new SitemapService(new CarRepository($db));
+    $xml = $service->buildXml($current_origin);
+
+    header('Content-Type: application/xml; charset=UTF-8');
+    echo $xml;
+} catch (\Throwable $e) {
+    http_response_code(500);
+    header('Content-Type: application/xml; charset=UTF-8');
+    logger(0, LogCategories::LOG_CATEGORY_SYSTEM_ERROR, 'sitemap.xml generation failed: ' . $e->getMessage());
+    echo '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>';
+}

--- a/robots.txt
+++ b/robots.txt
@@ -63,3 +63,5 @@ Disallow: /
 
 User-agent: Timpibot
 Disallow: /
+
+Sitemap: https://elanregistry.org/sitemap.xml

--- a/tests/playwright/e2e/not-logged-in.spec.js
+++ b/tests/playwright/e2e/not-logged-in.spec.js
@@ -713,6 +713,33 @@ test.describe('GSC 404 cleanup redirects (#1409)', () => {
   });
 });
 
+test.describe('Sitemap endpoint (#1373)', () => {
+  test.beforeEach(async ({ }, testInfo) => {
+    if (testInfo.project.name !== 'not-logged-in') {
+      testInfo.skip();
+    }
+  });
+
+  test('GET /sitemap.xml returns a valid sitemap with at least one car entry', async ({ page }) => {
+    const response = await page.goto('/sitemap.xml');
+
+    // Layer 1: HTTP response must be successful
+    expect(response.status()).toBeLessThan(400);
+
+    // Layer 2: Must be served as XML, not HTML (e.g. a login redirect or error page)
+    const contentType = response.headers()['content-type'] ?? '';
+    expect(contentType.toLowerCase()).toContain('application/xml');
+
+    // Layer 3: Must be a real sitemap document, not an error page
+    const body = await response.text();
+    expect(body).toContain('<urlset');
+
+    // Layer 4: Must include at least one car entry — this registry always
+    // has cars in its test/prod data, so this should never be empty.
+    expect(body).toContain('details.php?car_id=');
+  });
+});
+
 test.describe('Location picker city disambiguation (#1400)', () => {
   test.beforeEach(async ({ }, testInfo) => {
     if (testInfo.project.name !== 'not-logged-in') {

--- a/tests/unit/SitemapServiceTest.php
+++ b/tests/unit/SitemapServiceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use ElanRegistry\Car\CarRepository;
+use ElanRegistry\SitemapService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SitemapService (#1373)
+ */
+#[Group('fast')]
+#[Group('unit')]
+final class SitemapServiceTest extends TestCase
+{
+    private const BASE_URL = 'https://elanregistry.org';
+
+    /**
+     * @param list<object{id: int, mtime: string}> $cars
+     */
+    private function makeService(array $cars = []): SitemapService
+    {
+        $stubRepo = $this->createStub(CarRepository::class);
+        $stubRepo->method('getAllForSitemap')->willReturn($cars);
+
+        return new SitemapService($stubRepo);
+    }
+
+    public function testBuildXmlProducesWellFormedXmlDocument(): void
+    {
+        $service = $this->makeService();
+        $xml     = $service->buildXml(self::BASE_URL);
+
+        $this->assertStringStartsWith('<?xml version="1.0"', $xml);
+        $this->assertNotFalse(simplexml_load_string($xml), 'Sitemap output must be well-formed XML');
+    }
+
+    public function testBuildXmlIncludesAllStaticPages(): void
+    {
+        $service = $this->makeService();
+        $xml     = $service->buildXml(self::BASE_URL);
+
+        $this->assertStringContainsString(
+            '<loc>' . self::BASE_URL . '/app/owner/cars/index.php</loc>',
+            $xml,
+        );
+        $this->assertStringContainsString(
+            '<loc>' . self::BASE_URL . '/docs/guides/index.php</loc>',
+            $xml,
+        );
+        $this->assertStringContainsString(
+            '<loc>' . self::BASE_URL . '/app/owner/reports/statistics.php</loc>',
+            $xml,
+        );
+
+        $sitemap = simplexml_load_string($xml);
+        $this->assertNotFalse($sitemap);
+        $sitemap->registerXPathNamespace('s', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $urls = $sitemap->xpath('//s:url');
+        // 6 static pages + 0 cars in this scenario
+        $this->assertCount(6, $urls);
+    }
+
+    public function testBuildXmlIncludesOneUrlPerCar(): void
+    {
+        $cars = [
+            (object) ['id' => 101, 'mtime' => '2026-03-15 10:30:00'],
+            (object) ['id' => 202, 'mtime' => '2025-12-01 00:00:00'],
+            (object) ['id' => 303, 'mtime' => '2024-07-04 23:59:59'],
+        ];
+        $service = $this->makeService($cars);
+        $xml     = $service->buildXml(self::BASE_URL);
+
+        foreach ($cars as $car) {
+            $this->assertStringContainsString(
+                '<loc>' . self::BASE_URL . '/app/owner/cars/details.php?car_id=' . $car->id . '</loc>',
+                $xml,
+            );
+        }
+
+        $this->assertStringContainsString('<lastmod>2026-03-15</lastmod>', $xml);
+        $this->assertStringContainsString('<lastmod>2025-12-01</lastmod>', $xml);
+        $this->assertStringContainsString('<lastmod>2024-07-04</lastmod>', $xml);
+
+        $sitemap = simplexml_load_string($xml);
+        $this->assertNotFalse($sitemap);
+        $sitemap->registerXPathNamespace('s', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $urls = $sitemap->xpath('//s:url');
+        // 6 static pages + 3 cars
+        $this->assertCount(9, $urls);
+    }
+
+    public function testBuildXmlExcludesFactoryAndPrivacyPages(): void
+    {
+        $cars = [
+            (object) ['id' => 1, 'mtime' => '2026-01-01 00:00:00'],
+        ];
+        $service = $this->makeService($cars);
+        $xml     = $service->buildXml(self::BASE_URL);
+
+        $this->assertStringNotContainsString('factory.php', $xml);
+        $this->assertStringNotContainsString('privacy.php', $xml);
+    }
+
+    public function testBuildXmlWithNoCarsProducesOnlyStaticPages(): void
+    {
+        $service = $this->makeService([]);
+        $xml     = $service->buildXml(self::BASE_URL);
+
+        $sitemap = simplexml_load_string($xml);
+        $this->assertNotFalse($sitemap, 'Sitemap output must be well-formed XML even with zero cars');
+        $sitemap->registerXPathNamespace('s', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $urls = $sitemap->xpath('//s:url');
+
+        $this->assertCount(6, $urls);
+        $this->assertStringNotContainsString('details.php?car_id=', $xml);
+    }
+
+    public function testCarEntryHasMonthlyChangefreqAndPointEightPriority(): void
+    {
+        $cars = [
+            (object) ['id' => 42, 'mtime' => '2026-05-20 12:00:00'],
+        ];
+        $service = $this->makeService($cars);
+        $xml     = $service->buildXml(self::BASE_URL);
+
+        $sitemap = simplexml_load_string($xml);
+        $this->assertNotFalse($sitemap);
+        $sitemap->registerXPathNamespace('s', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $carUrls = $sitemap->xpath('//s:url[s:loc="' . self::BASE_URL . '/app/owner/cars/details.php?car_id=42"]');
+
+        $this->assertCount(1, $carUrls);
+        $carUrl = $carUrls[0];
+        $this->assertSame('monthly', (string) $carUrl->changefreq);
+        $this->assertSame('0.8', (string) $carUrl->priority);
+    }
+}

--- a/tests/unit/cars/services/CarRepositoryTest.php
+++ b/tests/unit/cars/services/CarRepositoryTest.php
@@ -432,4 +432,26 @@ final class CarRepositoryTest extends TestCase
         $this->expectException(CarDatabaseException::class);
         $repo->findByIdForUpdate(1);
     }
+
+    // =========================================================================
+    // getAllForSitemap tests (issue #1373)
+    // =========================================================================
+
+    /**
+     * getAllForSitemap() throws CarDatabaseException when the query fails, rather than
+     * silently returning an empty array — a real DB outage must produce a visible 500 via
+     * sitemap.php's catch block, not a healthy-looking sitemap missing every car.
+     */
+    public function testGetAllForSitemapThrowsCarDatabaseExceptionOnQueryError(): void
+    {
+        $db = $this->makeDbMock();
+        $db->expects($this->once())->method('query')->willReturn(new QueryResult([]));
+        $db->method('error')->willReturn(true);
+        $db->method('errorString')->willReturn('Connection lost');
+
+        $repo = new CarRepository($db);
+
+        $this->expectException(CarDatabaseException::class);
+        $repo->getAllForSitemap();
+    }
 }

--- a/usersc/classes/Car/CarRepository.php
+++ b/usersc/classes/Car/CarRepository.php
@@ -232,11 +232,15 @@ class CarRepository
      * Get all cars for sitemap generation
      *
      * @return list<object{id: int, mtime: string}>
+     * @throws CarDatabaseException If query fails
      */
     public function getAllForSitemap(): array
     {
         $this->db->query('SELECT id, mtime FROM cars ORDER BY id');
-        return $this->db->error() ? [] : $this->db->results();
+        if ($this->db->error()) {
+            throw new CarDatabaseException('Failed to query cars for sitemap generation: ' . $this->db->errorString());
+        }
+        return $this->db->results();
     }
 
     /**

--- a/usersc/classes/Car/CarRepository.php
+++ b/usersc/classes/Car/CarRepository.php
@@ -229,6 +229,17 @@ class CarRepository
     }
 
     /**
+     * Get all cars for sitemap generation
+     *
+     * @return list<object{id: int, mtime: string}>
+     */
+    public function getAllForSitemap(): array
+    {
+        $this->db->query('SELECT id, mtime FROM cars ORDER BY id');
+        return $this->db->error() ? [] : $this->db->results();
+    }
+
+    /**
      * Find car IDs owned by a specific user
      *
      * @param int $ownerId Owner user ID

--- a/usersc/classes/SitemapService.php
+++ b/usersc/classes/SitemapService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElanRegistry;
+
+use ElanRegistry\Car\CarRepository;
+
+/**
+ * Builds the public sitemap.xml body for elanregistry.org (#1373).
+ */
+class SitemapService
+{
+    /** @var list<array{path: string, changefreq: string, priority: string}> */
+    private const STATIC_PAGES = [
+        ['path' => '/app/owner/cars/index.php', 'changefreq' => 'weekly', 'priority' => '0.9'],
+        ['path' => '/app/owner/reports/statistics.php', 'changefreq' => 'monthly', 'priority' => '0.6'],
+        ['path' => '/docs/reference/paint-colors.php', 'changefreq' => 'yearly', 'priority' => '0.7'],
+        ['path' => '/docs/reference/index.php', 'changefreq' => 'monthly', 'priority' => '0.6'],
+        ['path' => '/docs/reference/identification-guide.php', 'changefreq' => 'yearly', 'priority' => '0.6'],
+        ['path' => '/docs/guides/index.php', 'changefreq' => 'monthly', 'priority' => '0.5'],
+    ];
+
+    public function __construct(private CarRepository $carRepository) {}
+
+    /**
+     * @param string $baseUrl Origin to prefix every URL with (e.g. https://elanregistry.org)
+     * @return string Well-formed sitemap.xml document body
+     */
+    public function buildXml(string $baseUrl): string
+    {
+        $xml = new \XMLWriter();
+        $xml->openMemory();
+        $xml->setIndent(true);
+        $xml->startDocument('1.0', 'UTF-8');
+        $xml->startElement('urlset');
+        $xml->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+
+        foreach (self::STATIC_PAGES as $page) {
+            $this->writeUrl($xml, $baseUrl . $page['path'], $page['changefreq'], $page['priority']);
+        }
+
+        foreach ($this->carRepository->getAllForSitemap() as $car) {
+            $this->writeUrl(
+                $xml,
+                $baseUrl . '/app/owner/cars/details.php?car_id=' . $car->id,
+                'monthly',
+                '0.8',
+                $car->mtime,
+            );
+        }
+
+        $xml->endElement();
+        $xml->endDocument();
+        return $xml->outputMemory();
+    }
+
+    private function writeUrl(\XMLWriter $xml, string $loc, string $changefreq, string $priority, ?string $lastmod = null): void
+    {
+        $xml->startElement('url');
+        $xml->writeElement('loc', $loc);
+        if ($lastmod !== null) {
+            $xml->writeElement('lastmod', date('Y-m-d', strtotime($lastmod)));
+        }
+        $xml->writeElement('changefreq', $changefreq);
+        $xml->writeElement('priority', $priority);
+        $xml->endElement();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1373

- Adds `/sitemap.xml`, served via an `.htaccess` internal rewrite (no redirect — crawler-visible URL stays `/sitemap.xml`) to `app/api/shared/sitemap.php`. Dynamic/DB-driven per the issue's own resolved decision (Option A) — no static file to regenerate, stays current as owners add/edit cars.
- `SitemapService` (new, `usersc/classes/SitemapService.php`) builds the XML body using PHP's built-in `XMLWriter` — correct escaping guaranteed, no new composer dependency (checked first: the standard package for this, `icamys/php-sitemap-generator`, mainly earns its keep past 50k URLs; irrelevant at this registry's ~1600-URL scale).
- Lists 6 static pages (car index, statistics, docs/guides pages) plus one `<url>` per row in `cars` (no `is_public`/`deleted_at` column exists — every car is implicitly public). Car entries include `<lastmod>` sourced from `cars.mtime` (auto-updates on every row change); static pages intentionally omit `<lastmod>` — no trustworthy per-page freshness signal exists for them, and per Google's own guidance an incorrect date is worse than none.
- `factory.php` and `privacy.php` are intentionally excluded (both carry `noindex` per #1371).
- `robots.txt` now includes a `Sitemap:` directive.
- No auth, no CSRF, no rate limit on the endpoint — intentional; it must be freely, repeatedly fetchable by search-engine crawlers, unlike every other file in `app/api/shared/`.

## Verification

- **End-to-end curl test against a real local DB caught and fixed a genuine bug**: `CarRepository::getAllForSitemap()` originally did `(array) $result` on the `DB` wrapper object itself (casting its internal properties) instead of calling `->results()` to extract actual rows — produced dozens of PHP warnings and silently broke the `Content-Type` header. Neither PHPStan, the coding-standards checker, nor the PHPUnit test (which mocks `CarRepository` at the interface boundary) could have caught this; a real HTTP request against a real DB did. Fixed to match `findByIdForUpdate()`'s exact pattern in the same file. Re-verified via curl: well-formed XML, correct `Content-Type: application/xml; charset=UTF-8`, 1596 `<url>` entries (6 static + 1590 real cars), correct `<lastmod>` formatting, zero warnings.
- **`/review-pr` caught and fixed a second bug**: `getAllForSitemap()` silently returned `[]` on a DB query error instead of throwing — since the `DB` wrapper doesn't throw on error itself, this bypassed `sitemap.php`'s `catch (\Throwable)` block entirely, meaning a real DB outage would have produced an unlogged HTTP 200 with a car-less sitemap. Fixed to throw `CarDatabaseException`, routing through the existing catch block (500 + logged via `LOG_CATEGORY_SYSTEM_ERROR`).
- `composer test:quick` — new `SitemapServiceTest.php` (6 tests, 24 assertions) passes; full unit suite (1340 tests) unaffected.
- `vendor/bin/phpstan analyse` clean on all touched/new PHP files.
- New Playwright smoke test added to `tests/playwright/e2e/not-logged-in.spec.js` (status, content-type, `<urlset>` structural check, at least one car entry) — lint clean, listed successfully by Playwright; live execution against a deployed environment still needs `npm run test:e2e`/`test:e2e:test`.

## Manual step after deploy (not part of this PR)

Submit `https://elanregistry.org/sitemap.xml` via GSC → Sitemaps → Add a new sitemap, per the issue's acceptance criteria.

Claude-Session: https://claude.ai/code/session_018RYKgRUy5Bzdky9F5dLu77