### PR TITLE
test: dynamic completeness gate for page-title/description convention

### DIFF
--- a/tests/unit/system/PageMetadataCompletenessTest.php
+++ b/tests/unit/system/PageMetadataCompletenessTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Completeness gate for Issue #1432.
+ * Completeness gate for Issues #1432 and #1484.
  *
  * Per the ElanRegistry page-title/description convention (see
  * usersc/plugins/ai_prompts/custom_prompts/elanregistry_overrides.md.php,
@@ -21,32 +21,73 @@ use PHPUnit\Framework\Attributes\Group;
  *
  * This test is a pure static-text scan: it reads each file's raw source
  * via file_get_contents() and never requires/executes it, so it needs no
- * database and no bootstrapped UserSpice environment. It covers the 11
- * pages added under #1432 plus the original #1372 page, the 3 admin
- * pages fixed in #1430, and the car details page fixed in #1371, so a
- * future regression on any of these 16 files is caught immediately.
+ * database and no bootstrapped UserSpice environment.
+ *
+ * Dynamic discovery (#1484): rather than a hardcoded page list that has no
+ * awareness of pages outside it, the set of pages requiring the convention
+ * (`pagesRequiringMetadata()`) is derived by scanning `app/` and `docs/` for
+ * every file that actually calls
+ * `securePage()` (excluding action handlers, fix/maintenance scripts, and
+ * API endpoints — see NON_PAGE_DIRECTORIES — none of which render a page
+ * for a human), then subtracting the checked-in EXPECTED_INCOMPLETE_PAGES
+ * exemption list. This means:
+ *
+ *  - A brand-new page added WITHOUT the convention is automatically picked
+ *    up by testDiscoveredIncompletePagesMatchExpectedSnapshot() as an
+ *    unexpected gap — the test fails until the author either adds the
+ *    convention or consciously adds the file to the exemption list (a
+ *    visible, reviewable decision in the PR diff).
+ *  - A brand-new page added WITH the convention needs no exemption-list
+ *    change at all — it's automatically picked up by
+ *    pagesRequiringMetadata()/pagesProvider() and covered by every test
+ *    below, including the before-init.php timing check that catches the
+ *    exact #1430 bug class on day one.
+ *  - An exemption-list entry that stops being incomplete (someone added
+ *    the convention but forgot to remove it from the list) also fails the
+ *    snapshot test — the list can't silently drift stale.
  */
 #[Group('system')]
 #[Group('page-metadata')]
 class PageMetadataCompletenessTest extends TestCase
 {
-    private const PAGES_REQUIRING_METADATA = [
-        'docs/reference/paint-colors.php',
-        'docs/reference/index.php',
-        'docs/reference/identification-guide.php',
-        'docs/reference/workshop.php',
-        'docs/reference/chassis-validation.php',
-        'docs/reference/technical-articles.php',
-        'docs/index.php',
-        'docs/car-stories.php',
-        'docs/guides/index.php',
-        'app/owner/cars/index.php',
-        'app/owner/cars/factory.php',
-        'app/owner/cars/details.php',
-        'app/owner/reports/statistics.php',
-        'app/admin/index.php',
-        'app/admin/maintenance.php',
-        'app/admin/design-system.php',
+    /**
+     * Directory prefixes (relative to project root) excluded from page
+     * discovery even though files under them may call securePage() —
+     * form/action handlers, backend operation scripts, one-time/maintenance
+     * fix scripts, and AJAX endpoints, none of which render a page for a
+     * human.
+     *
+     * @var list<string>
+     */
+    private const NON_PAGE_DIRECTORIES = [
+        'app/admin/includes/',
+        'app/admin/scripts/',
+        'app/api/',
+    ];
+
+    /**
+     * Checked-in snapshot of pages that call securePage() but do not yet
+     * set $pageTitle. Verified against the live tree at the time #1484 was
+     * implemented. Migrating one of these to the convention is tracked
+     * opportunistically (touch a page, add the convention) — remove its
+     * entry here when that happens, or testDiscoveredIncompletePagesMatchExpectedSnapshot()
+     * will fail.
+     *
+     * @var list<string>
+     */
+    private const EXPECTED_INCOMPLETE_PAGES = [
+        'app/admin/verify/index.php',
+        'app/admin/verify/send_email.php',
+        'app/admin/verify/verify_car.php',
+        'app/owner/cars/edit.php',
+        'app/owner/contact/index.php',
+        'app/owner/contact/owner.php',
+        'app/owner/privacy.php',
+        'docs/guides/car-transfer-faq.php',
+        'docs/pdf-viewer.php',
+        'docs/stories/brian_walton/index.php',
+        'docs/stories/SGO_2F/index.php',
+        'docs/stories/type26register.php',
     ];
 
     private string $rootDir = '';
@@ -54,9 +95,12 @@ class PageMetadataCompletenessTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->rootDir = dirname(__DIR__, 3);
+        $this->rootDir = self::projectRootDir();
     }
 
+    /**
+     * Asserts a page requiring the convention (see class docblock) sets $pageTitle somewhere in its source.
+     */
     #[DataProvider('pagesProvider')]
     public function testPageHasPageTitleAssignment(string $relativePath): void
     {
@@ -66,15 +110,15 @@ class PageMetadataCompletenessTest extends TestCase
         // completeness gate must go red, not silently green.
         $this->assertFileExists($filePath, "$relativePath must exist (Issue #1432)");
 
-        $content = (string)file_get_contents($filePath);
-
-        $this->assertSame(
-            1,
-            preg_match('/\$pageTitle\s*=/', $content),
+        $this->assertTrue(
+            self::hasPageTitleAssignment($filePath),
             "$relativePath must set \$pageTitle (Issue #1432)"
         );
     }
 
+    /**
+     * Asserts a page requiring the convention (see class docblock) sets $pageDescription somewhere in its source.
+     */
     #[DataProvider('pagesProvider')]
     public function testPageHasPageDescriptionAssignment(string $relativePath): void
     {
@@ -106,10 +150,44 @@ class PageMetadataCompletenessTest extends TestCase
         $this->assertVariableAssignmentPrecedesInitRequire($relativePath, 'pageTitle');
     }
 
+    /**
+     * Same timing rationale as testPageTitleAssignmentPrecedesInitRequire() above.
+     */
     #[DataProvider('pagesProvider')]
     public function testPageDescriptionAssignmentPrecedesInitRequire(string $relativePath): void
     {
         $this->assertVariableAssignmentPrecedesInitRequire($relativePath, 'pageDescription');
+    }
+
+    /**
+     * The regression gate itself (#1484). Discovers every page file, computes
+     * which ones currently lack $pageTitle, and asserts that set exactly
+     * matches EXPECTED_INCOMPLETE_PAGES — see class docblock for what each
+     * direction of mismatch means and how to fix it.
+     */
+    public function testDiscoveredIncompletePagesMatchExpectedSnapshot(): void
+    {
+        $actualIncomplete = [];
+        foreach (self::discoverPageFiles($this->rootDir) as $relativePath) {
+            if (!self::hasPageTitleAssignment($this->rootDir . '/' . $relativePath)) {
+                $actualIncomplete[] = $relativePath;
+            }
+        }
+        sort($actualIncomplete);
+
+        $expectedIncomplete = self::EXPECTED_INCOMPLETE_PAGES;
+        sort($expectedIncomplete);
+
+        $this->assertSame(
+            $expectedIncomplete,
+            $actualIncomplete,
+            'Discovered pages lacking $pageTitle no longer match EXPECTED_INCOMPLETE_PAGES (Issue #1484). '
+            . 'If this list GREW: a new (or newly-discovered) page is missing the $pageTitle/$pageDescription '
+            . 'convention — either add it (see elanregistry_overrides.md.php section 6) or add the file to '
+            . 'EXPECTED_INCOMPLETE_PAGES as a conscious decision. '
+            . 'If this list SHRANK: a page that used to lack $pageTitle now has it — remove its entry from '
+            . 'EXPECTED_INCOMPLETE_PAGES so it stays covered by the other tests in this class.'
+        );
     }
 
     private function assertVariableAssignmentPrecedesInitRequire(string $relativePath, string $variableName): void
@@ -144,12 +222,88 @@ class PageMetadataCompletenessTest extends TestCase
         );
     }
 
+    /**
+     * @return array<string, array{0: string}> Pages requiring the convention, keyed by path.
+     */
     public static function pagesProvider(): array
     {
         $data = [];
-        foreach (self::PAGES_REQUIRING_METADATA as $file) {
+        foreach (self::pagesRequiringMetadata(self::projectRootDir()) as $file) {
             $data[$file] = [$file];
         }
         return $data;
+    }
+
+    /**
+     * Project root, shared by setUp() (instance context) and pagesProvider()
+     * (static context, since PHPUnit invokes data providers before the test
+     * instance exists).
+     */
+    private static function projectRootDir(): string
+    {
+        return dirname(__DIR__, 3);
+    }
+
+    /**
+     * @return list<string> Discovered page files minus EXPECTED_INCOMPLETE_PAGES —
+     *                       i.e. pages that must currently satisfy the convention.
+     */
+    private static function pagesRequiringMetadata(string $rootDir): array
+    {
+        return array_values(array_diff(
+            self::discoverPageFiles($rootDir),
+            self::EXPECTED_INCOMPLETE_PAGES
+        ));
+    }
+
+    private static function hasPageTitleAssignment(string $filePath): bool
+    {
+        $content = (string)file_get_contents($filePath);
+        return preg_match('/\$pageTitle\s*=/', $content) === 1;
+    }
+
+    /**
+     * Recursively scans app/ and docs/ for every .php file that actually calls
+     * securePage() (the precise `if (!securePage(` call pattern, not a bare
+     * substring match — defends against a file that merely *mentions*
+     * "securePage()" in a comment or docblock being misclassified as a page;
+     * app/admin/includes/fix-script-core.php does exactly this today, though
+     * it's also excluded via NON_PAGE_DIRECTORIES regardless, so the precise
+     * pattern is a second, independent safeguard rather than the only one),
+     * then excludes anything under NON_PAGE_DIRECTORIES.
+     *
+     * @return list<string> Sorted paths relative to $rootDir
+     */
+    private static function discoverPageFiles(string $rootDir): array
+    {
+        $files = [];
+
+        foreach (['app', 'docs'] as $topLevelDir) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($rootDir . '/' . $topLevelDir, FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $fileInfo) {
+                if ($fileInfo->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $relativePath = substr($fileInfo->getPathname(), strlen($rootDir) + 1);
+
+                foreach (self::NON_PAGE_DIRECTORIES as $excludedPrefix) {
+                    if (str_starts_with($relativePath, $excludedPrefix)) {
+                        continue 2;
+                    }
+                }
+
+                $content = (string)file_get_contents($fileInfo->getPathname());
+                if (preg_match('/if\s*\(\s*!\s*securePage\(/', $content) === 1) {
+                    $files[] = $relativePath;
+                }
+            }
+        }
+
+        sort($files);
+        return $files;
     }
 }

--- a/tests/unit/system/PageMetadataCompletenessTest.php
+++ b/tests/unit/system/PageMetadataCompletenessTest.php
@@ -25,12 +25,13 @@ use PHPUnit\Framework\Attributes\Group;
  *
  * Dynamic discovery (#1484): rather than a hardcoded page list that has no
  * awareness of pages outside it, the set of pages requiring the convention
- * (`pagesRequiringMetadata()`) is derived by scanning `app/` and `docs/` for
- * every file that actually calls
- * `securePage()` (excluding action handlers, fix/maintenance scripts, and
- * API endpoints — see NON_PAGE_DIRECTORIES — none of which render a page
- * for a human), then subtracting the checked-in EXPECTED_INCOMPLETE_PAGES
- * exemption list. This means:
+ * (`pagesRequiringMetadata()`) is derived by scanning every project-owned
+ * location that can plausibly render a page — see PAGE_SCAN_DIRECTORIES and
+ * PAGE_SCAN_FILES, which mirror phpstan.neon's project-owned path list — for
+ * every file that actually calls `securePage()` (excluding action handlers,
+ * fix/maintenance scripts, and API endpoints — see NON_PAGE_DIRECTORIES —
+ * none of which render a page for a human), then subtracting the checked-in
+ * EXPECTED_INCOMPLETE_PAGES exemption list. This means:
  *
  *  - A brand-new page added WITHOUT the convention is automatically picked
  *    up by testDiscoveredIncompletePagesMatchExpectedSnapshot() as an
@@ -66,6 +67,36 @@ class PageMetadataCompletenessTest extends TestCase
     ];
 
     /**
+     * Directories (relative to project root) recursively scanned for page files.
+     * Deliberately narrower than "everything phpstan.neon scans" — usersc/ holds
+     * mostly non-page content (classes, includes, plugin internals, templates,
+     * views, widgets) that would need its own exclusion logic to scan safely, so
+     * individual project-owned page files that live directly in usersc/ or the
+     * project root are listed explicitly in PAGE_SCAN_FILES instead.
+     *
+     * @var list<string>
+     */
+    private const PAGE_SCAN_DIRECTORIES = ['app', 'docs', 'error'];
+
+    /**
+     * Individual project-owned files outside PAGE_SCAN_DIRECTORIES that may
+     * render a page — mirrors the page-plausible subset of phpstan.neon's
+     * project-owned path list. Found via #1493 PR review: the original #1484
+     * scan covered only app/ and docs/, silently missing index.php (site
+     * homepage) and two usersc/ pages, undercutting the whole point of this
+     * gate (closing exactly this class of blind spot).
+     *
+     * @var list<string>
+     */
+    private const PAGE_SCAN_FILES = [
+        'index.php',
+        'usersc/account.php',
+        'usersc/join.php',
+        'usersc/login.php',
+        'usersc/user_settings.php',
+    ];
+
+    /**
      * Checked-in snapshot of pages that call securePage() but do not yet
      * set $pageTitle. Verified against the live tree at the time #1484 was
      * implemented. Migrating one of these to the convention is tracked
@@ -88,6 +119,9 @@ class PageMetadataCompletenessTest extends TestCase
         'docs/stories/brian_walton/index.php',
         'docs/stories/SGO_2F/index.php',
         'docs/stories/type26register.php',
+        'index.php',
+        'usersc/account.php',
+        'usersc/user_settings.php',
     ];
 
     private string $rootDir = '';
@@ -125,11 +159,8 @@ class PageMetadataCompletenessTest extends TestCase
         $filePath = $this->rootDir . '/' . $relativePath;
         $this->assertFileExists($filePath, "$relativePath must exist (Issue #1432)");
 
-        $content = (string)file_get_contents($filePath);
-
-        $this->assertSame(
-            1,
-            preg_match('/\$pageDescription\s*=/', $content),
+        $this->assertTrue(
+            self::hasPageDescriptionAssignment($filePath),
             "$relativePath must set \$pageDescription (Issue #1432)"
         );
     }
@@ -262,15 +293,21 @@ class PageMetadataCompletenessTest extends TestCase
         return preg_match('/\$pageTitle\s*=/', $content) === 1;
     }
 
+    private static function hasPageDescriptionAssignment(string $filePath): bool
+    {
+        $content = (string)file_get_contents($filePath);
+        return preg_match('/\$pageDescription\s*=/', $content) === 1;
+    }
+
     /**
-     * Recursively scans app/ and docs/ for every .php file that actually calls
-     * securePage() (the precise `if (!securePage(` call pattern, not a bare
-     * substring match — defends against a file that merely *mentions*
-     * "securePage()" in a comment or docblock being misclassified as a page;
-     * app/admin/includes/fix-script-core.php does exactly this today, though
-     * it's also excluded via NON_PAGE_DIRECTORIES regardless, so the precise
-     * pattern is a second, independent safeguard rather than the only one),
-     * then excludes anything under NON_PAGE_DIRECTORIES.
+     * Scans PAGE_SCAN_DIRECTORIES (recursively) and PAGE_SCAN_FILES (individually)
+     * for every .php file that actually calls securePage() (the precise
+     * `if (!securePage(` call pattern, not a bare substring match — defends
+     * against a file that merely *mentions* "securePage()" in a comment or
+     * docblock being misclassified as a page; app/admin/includes/fix-script-core.php
+     * does exactly this today, though it's also excluded via NON_PAGE_DIRECTORIES
+     * regardless, so the precise pattern is a second, independent safeguard
+     * rather than the only one), excluding anything under NON_PAGE_DIRECTORIES.
      *
      * @return list<string> Sorted paths relative to $rootDir
      */
@@ -278,7 +315,7 @@ class PageMetadataCompletenessTest extends TestCase
     {
         $files = [];
 
-        foreach (['app', 'docs'] as $topLevelDir) {
+        foreach (self::PAGE_SCAN_DIRECTORIES as $topLevelDir) {
             $iterator = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($rootDir . '/' . $topLevelDir, FilesystemIterator::SKIP_DOTS)
             );
@@ -289,21 +326,32 @@ class PageMetadataCompletenessTest extends TestCase
                 }
 
                 $relativePath = substr($fileInfo->getPathname(), strlen($rootDir) + 1);
-
-                foreach (self::NON_PAGE_DIRECTORIES as $excludedPrefix) {
-                    if (str_starts_with($relativePath, $excludedPrefix)) {
-                        continue 2;
-                    }
-                }
-
-                $content = (string)file_get_contents($fileInfo->getPathname());
-                if (preg_match('/if\s*\(\s*!\s*securePage\(/', $content) === 1) {
-                    $files[] = $relativePath;
-                }
+                self::addIfPage($files, $rootDir, $relativePath);
             }
+        }
+
+        foreach (self::PAGE_SCAN_FILES as $relativePath) {
+            self::addIfPage($files, $rootDir, $relativePath);
         }
 
         sort($files);
         return $files;
+    }
+
+    /**
+     * @param list<string> $files Appended to by reference when $relativePath is a page.
+     */
+    private static function addIfPage(array &$files, string $rootDir, string $relativePath): void
+    {
+        foreach (self::NON_PAGE_DIRECTORIES as $excludedPrefix) {
+            if (str_starts_with($relativePath, $excludedPrefix)) {
+                return;
+            }
+        }
+
+        $content = (string)file_get_contents($rootDir . '/' . $relativePath);
+        if (preg_match('/if\s*\(\s*!\s*securePage\(/', $content) === 1) {
+            $files[] = $relativePath;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1484

Reworks `tests/unit/system/PageMetadataCompletenessTest.php` from a hardcoded 16-page whitelist (added in #1432) into a dynamic completeness gate, per the issue's own proposed approach:

- `discoverPageFiles()` scans `app/` and `docs/` for every file calling `securePage()` — the precise `if (!securePage(` call pattern, not a bare substring match, to avoid a confirmed real false positive (`app/admin/includes/fix-script-core.php` mentions `securePage()` in a comment without calling it) — excluding `app/admin/includes/`, `app/admin/scripts/`, `app/api/` (action handlers, fix/maintenance scripts, AJAX endpoints — none render a page for a human).
- `pagesRequiringMetadata()` derives the set that must satisfy the convention by subtracting a checked-in `EXPECTED_INCOMPLETE_PAGES` exemption snapshot (12 pages, independently verified against the live tree via direct grep/PHP scripts, not just taken from the issue text).
- New `testDiscoveredIncompletePagesMatchExpectedSnapshot()` is the regression gate itself, asserting the actual incomplete set matches the snapshot in both directions.

**Design choice beyond the issue's literal proposal**: rather than adding a second, parallel snapshot-comparison mechanism alongside the existing hardcoded list, `PAGES_REQUIRING_METADATA` is **derived** (discovered pages minus the exemption list) and `pagesProvider()` now consumes it. This means the existing 4 tests (title/description presence + before-`init.php` timing) automatically cover any newly-discovered "complete" page — directly satisfying the issue's own Step 5 suggestion ("should the timing check also apply gate-wide") for free, instead of as separate follow-up work, with one code path instead of two doing overlapping jobs.

## Verification

Simulated all 3 acceptance-criteria scenarios using real scratch files this session (created and removed, not committed):
- New page **without** the convention → 5 clear test failures (presence ×2, timing ×2, snapshot mismatch with an explicit "here's what grew/shrank and what to do" message).
- New page **with** the convention (correct timing) → passes cleanly, zero exemption-list changes needed.
- Both the issue's claimed counts (51 total `securePage()` files, 35 "incomplete") and my own refined counts (28 real pages after excluding non-page directories, 12 incomplete) were independently verified against the live tree — the issue's raw 51-file count matches exactly; the refined 28/12 split correctly excludes fix scripts/action handlers/API endpoints the issue itself says should be out of scope.

## Review

`/review-pr` (3 agents) caught one real blocking issue: a code-simplifier pass (during `/simplify`) renamed the old `PAGES_REQUIRING_METADATA` constant to a `pagesRequiringMetadata()` method, but the class docblock's two references to the old name weren't updated — fixed. Also addressed: missing PHPDoc on `pagesProvider()`, and a docblock example that cited a false-positive case already covered by directory exclusion regardless (reworded to correctly frame the regex precision as a second, independent safeguard rather than the only defense).

Three lower-priority recommendations (all explicitly self-rated low-priority, one matching the issue's own "Out of Scope" note about opportunistic migration) were reviewed and left as-is: `NON_PAGE_DIRECTORIES` is enumerative rather than structural (any misclassification surfaces as a loud test failure, not a silent gap, by the gate's own design); no isolated fixture-based test of the discovery algorithm itself (only exercised against the live tree); `EXPECTED_INCOMPLETE_PAGES` has no `known-broken`-style periodic-review enforcement.

- `composer test:quick` — 1372 tests passing, full suite unaffected; 65 tests / 193 assertions in this file specifically.
- `vendor/bin/phpstan analyse` — clean project-wide.
- Coding standards checker — clean on this file (fixed 3 pre-existing "missing PHPDoc block" issues on methods I preserved verbatim from the original file, since this checker has no baseline-suppression for pre-existing debt like PHPStan does — leaving them would have blocked this very commit).

## Out of scope (per the issue)

- Migrating any of the 12 currently-incomplete pages to the convention (tracked opportunistically).
- Fixing #1430-class timing bugs on existing pages (already closed; this gate catches *new* regressions of that class going forward).
- Extending the SEO-quality title/description push to admin pages (#1432 deliberately excluded that).

Claude-Session: https://claude.ai/code/session_018RYKgRUy5Bzdky9F5dLu77