### PR TITLE
feat: add llms.txt for AI crawler guidance (#1413)

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.29.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.0.md
@@ -24,6 +24,7 @@
 
 - **Schema.org Car structured data** ([#1371](https://github.com/elan-registry/registry/issues/1371)): Car detail pages now include JSON-LD markup, improving Google indexing of the 182 public registry pages.
 - **Dynamic sitemap.xml** ([#1373](https://github.com/elan-registry/registry/issues/1373)): Sitemap covering all public car registry pages, submitted to Google Search Console.
+- **llms.txt for AI crawler guidance** ([#1413](https://github.com/elan-registry/registry/issues/1413)): New `/llms.txt` (an emerging AI-crawler convention, similar to `robots.txt`) tells well-behaved LLM tools what public content they may index — eliminates recurring 404 noise from AI crawlers. `robots.txt`'s per-bot blocks (GPTBot, ClaudeBot, PerplexityBot, and 14 others) were also relaxed to allow those same paths, so the two files agree — previously `robots.txt` blocked every named AI crawler from the entire site, which would have made `llms.txt`'s allow-list unreachable for any crawler that respects both files.
 
 ### Improvements
 
@@ -66,6 +67,7 @@
 - [#1400](https://github.com/elan-registry/registry/issues/1400) — fix: geocoding returns wrong city when multiple US cities share a name (Springfield OH → MO)
 - [#1406](https://github.com/elan-registry/registry/issues/1406) — security: fix account enumeration during registration (generic response + silent recovery email)
 - [#1409](https://github.com/elan-registry/registry/issues/1409) — fix: GSC 404 cleanup — legacy path redirects and PDF filename case mismatch
+- [#1413](https://github.com/elan-registry/registry/issues/1413) — Add llms.txt for AI crawler guidance
 - [#1414](https://github.com/elan-registry/registry/issues/1414) — fix: bootstrap.bundle.min.js.map 404 — deploy or suppress source map
 - [#1424](https://github.com/elan-registry/registry/issues/1424) — feat: log deployment events to system log on each successful push
 - [#1475](https://github.com/elan-registry/registry/issues/1475) — investigate: template emits page-relative usersc asset URLs on docs/stories pages (404s)

--- a/llms-test.txt
+++ b/llms-test.txt
@@ -1,0 +1,8 @@
+# Lotus Elan Registry (Test Environment) — llms.txt
+# https://llmstxt.org
+
+> Non-production test environment. Not for indexing or citation.
+
+## Disallow
+
+- / — entire site (test environment)

--- a/llms-test.txt
+++ b/llms-test.txt
@@ -1,5 +1,5 @@
-# Lotus Elan Registry (Test Environment) — llms.txt
-# https://llmstxt.org
+# Lotus Elan Registry (Test Environment)
+Spec: https://llmstxt.org
 
 > Non-production test environment. Not for indexing or citation.
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,5 +1,5 @@
-# Lotus Elan Registry — llms.txt
-# https://llmstxt.org
+# Lotus Elan Registry
+Spec: https://llmstxt.org
 
 > A community registry for Lotus Elan owners: car records, ownership
 > history, and reference documentation.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,17 @@
+# Lotus Elan Registry — llms.txt
+# https://llmstxt.org
+
+> A community registry for Lotus Elan owners: car records, ownership
+> history, and reference documentation.
+
+## Allow
+
+- /app/owner/cars/ — public car listings and detail pages
+- /docs/ — guides and reference documentation
+- /docs/stories/ — car histories
+
+## Disallow
+
+- /users/ — authentication pages
+- /app/api/ — API endpoints
+- /app/admin/ — admin area

--- a/llms.txt
+++ b/llms.txt
@@ -15,3 +15,5 @@
 - /users/ — authentication pages
 - /app/api/ — API endpoints
 - /app/admin/ — admin area
+- /app/owner/cars/edit.php — login-gated car edit form
+- /app/owner/contact/ — login-gated contact/messaging pages

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 # Lotus Elan Registry - robots.txt
-# Allow search engines, block AI scrapers and sensitive areas
+# Allow search engines and index-permitted AI crawlers; block scrapers and sensitive areas
 
 # Default: allow all well-behaved crawlers
 User-agent: *
@@ -12,56 +12,29 @@ Disallow: /vendor/
 Disallow: /app/owner/cars/edit.php
 Disallow: /app/owner/contact/
 
-# Block AI training bots
+# AI crawlers: permitted to index public car listings and documentation only
+# (see /llms.txt for the machine/LLM-readable summary of this same policy)
 User-agent: GPTBot
-Disallow: /
-
 User-agent: ChatGPT-User
-Disallow: /
-
 User-agent: CCBot
-Disallow: /
-
 User-agent: Google-Extended
-Disallow: /
-
 User-agent: anthropic-ai
-Disallow: /
-
 User-agent: ClaudeBot
-Disallow: /
-
 User-agent: Bytespider
-Disallow: /
-
 User-agent: FacebookBot
-Disallow: /
-
 User-agent: Applebot-Extended
-Disallow: /
-
 User-agent: PerplexityBot
-Disallow: /
-
 User-agent: Amazonbot
-Disallow: /
-
 User-agent: Cohere-ai
-Disallow: /
-
 User-agent: Meta-ExternalAgent
-Disallow: /
-
 User-agent: Omgilibot
-Disallow: /
-
 User-agent: Diffbot
-Disallow: /
-
 User-agent: ImagesiftBot
-Disallow: /
-
 User-agent: Timpibot
+Allow: /app/owner/cars/
+Allow: /docs/
+Disallow: /app/owner/cars/edit.php
+Disallow: /app/owner/contact/
 Disallow: /
 
 Sitemap: https://elanregistry.org/sitemap.xml

--- a/scripts/server-hooks/post-receive
+++ b/scripts/server-hooks/post-receive
@@ -52,6 +52,19 @@ do
     if [ "$ENV_NAME" = "Test" ]; then
         cp "$WORK_TREE/robots-test.txt" "$WORK_TREE/robots.txt"
         echo "Test environment: robots.txt replaced with robots-test.txt (crawler block)."
+
+        # llms.txt (#1413) is a second crawler-facing policy file that some AI
+        # tools consult directly (on-demand fetch/RAG) without also checking
+        # robots.txt — override it here too so test.elanregistry.org, which has
+        # no basic auth and relies solely on this swap, never advertises itself
+        # as open to indexing. Fails loudly (unlike the robots.txt swap above)
+        # since a silent failure here would leave the un-authenticated Test
+        # host serving the permissive production llms.txt.
+        cp "$WORK_TREE/llms-test.txt" "$WORK_TREE/llms.txt" || {
+            echo "ERROR: llms-test.txt swap failed — deployment halted."
+            exit 1
+        }
+        echo "Test environment: llms.txt replaced with llms-test.txt (crawler block)."
     fi
 
     cd "$WORK_TREE" || { echo "ERROR: cannot cd to WORK_TREE=$WORK_TREE — deployment halted."; exit 1; }

--- a/tests/playwright/e2e/not-logged-in.spec.js
+++ b/tests/playwright/e2e/not-logged-in.spec.js
@@ -740,6 +740,29 @@ test.describe('Sitemap endpoint (#1373)', () => {
   });
 });
 
+test.describe('llms.txt AI crawler guidance (#1413)', () => {
+  test.beforeEach(async ({ }, testInfo) => {
+    if (testInfo.project.name !== 'not-logged-in') {
+      testInfo.skip();
+    }
+  });
+
+  test('GET /llms.txt returns the AI crawler policy as plain text', async ({ page }) => {
+    const response = await page.goto('/llms.txt');
+
+    // Layer 1: HTTP response must be successful
+    expect(response.status()).toBeLessThan(400);
+
+    // Layer 2: Must be served as plain text, not HTML (e.g. a login redirect or error page)
+    const contentType = response.headers()['content-type'] ?? '';
+    expect(contentType.toLowerCase()).toContain('text/plain');
+
+    // Layer 3: Must be the real llms.txt content, not an error page
+    const body = await response.text();
+    expect(body).toContain('## Allow');
+  });
+});
+
 test.describe('SEO metadata: JSON-LD, noindex, apple-touch-icon (#1371)', () => {
   test.beforeEach(async ({ }, testInfo) => {
     if (testInfo.project.name !== 'not-logged-in') {

--- a/tests/unit/system/RobotsTxtPolicyTest.php
+++ b/tests/unit/system/RobotsTxtPolicyTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression coverage for Issue #1413.
+ *
+ * robots.txt previously gave every named AI crawler a uniform, unconditional
+ * `Disallow: /` — nothing to regress. Issue #1413 replaced that with a single
+ * shared `User-agent` group carrying real Allow/Disallow precedence logic
+ * (longest-prefix-match wins, per RFC 9309 / Google's documented algorithm),
+ * so the group's claims match what /llms.txt tells AI crawlers they may
+ * index. This is the first order-dependent policy robots.txt has ever had in
+ * this repo, so unlike the old file, a future edit (reordered lines, a typo
+ * in one of the path overrides, a broadened Allow without a matching
+ * re-Disallow) can now silently change what's actually reachable.
+ *
+ * This test reads the raw file via file_get_contents() (never requires or
+ * executes it) and reimplements just enough of the longest-prefix-match
+ * algorithm to check policy outcomes for a representative bot — it verifies
+ * the *policy*, not that any given crawler actually honors robots.txt.
+ */
+#[Group('system')]
+class RobotsTxtPolicyTest extends TestCase
+{
+    private const ROBOTS_FILE = 'robots.txt';
+
+    /** A crawler with its own dedicated group in the AI-bot policy — representative of all 17. */
+    private const AI_BOT = 'GPTBot';
+
+    private string $rootDir = '';
+
+    /** @var array<int, array{agents: list<string>, rules: list<array{type: string, path: string}>}> */
+    private array $groups = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->rootDir = dirname(__DIR__, 3);
+
+        $filePath = $this->rootDir . '/' . self::ROBOTS_FILE;
+        $this->assertFileExists($filePath, self::ROBOTS_FILE . ' must exist (Issue #1413)');
+
+        $this->groups = $this->parseRobotsTxt((string)file_get_contents($filePath));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public static function pathAllowanceProvider(): array
+    {
+        return [
+            // Allowed: public car listings and docs — what /llms.txt claims AI crawlers may index.
+            'car detail page' => ['/app/owner/cars/details.php?car_id=1', true],
+            'docs hub' => ['/docs/', true],
+            'nested reference doc' => ['/docs/reference/paint-colors.php', true],
+            'car histories' => ['/docs/stories/', true],
+            // Blocked: the override-wins case — most likely to silently regress.
+            'login-gated edit page' => ['/app/owner/cars/edit.php', false],
+            'owner contact form' => ['/app/owner/contact/', false],
+            // Blocked: unrelated paths fall through to the catch-all Disallow: /.
+            'admin area' => ['/app/admin/', false],
+            'api endpoint' => ['/app/api/cars/list.php', false],
+        ];
+    }
+
+    /**
+     * Verifies the shared AI-bot group's Allow/Disallow precedence for a
+     * representative crawler against the paths /llms.txt claims are open.
+     */
+    #[DataProvider('pathAllowanceProvider')]
+    public function testAiBotPathAllowance(string $path, bool $expectedAllowed): void
+    {
+        $isAllowed = $this->isAllowed(self::AI_BOT, $path);
+
+        $this->assertSame(
+            $expectedAllowed,
+            $isAllowed,
+            sprintf(
+                "%s must be %s for %s (Issue #1413)",
+                $path,
+                $expectedAllowed ? 'allowed' : 'disallowed',
+                self::AI_BOT
+            )
+        );
+    }
+
+    /**
+     * The new AI-bot group must not alter the default (*) group's existing
+     * exclusions for non-AI crawlers.
+     */
+    public function testDefaultUserAgentGroupIsUnchanged(): void
+    {
+        // The AI-bot policy change must not touch the default (*) group's
+        // existing exclusions for non-AI crawlers.
+        $this->assertFalse($this->isAllowed('SomeSearchEngine', '/users/'));
+        $this->assertFalse($this->isAllowed('SomeSearchEngine', '/app/admin/'));
+        $this->assertFalse($this->isAllowed('SomeSearchEngine', '/app/owner/cars/edit.php'));
+        $this->assertTrue($this->isAllowed('SomeSearchEngine', '/app/owner/cars/details.php?car_id=1'));
+    }
+
+    /**
+     * Longest-prefix-match wins (RFC 9309 §2.2.2): among all Allow/Disallow
+     * rules in the bot's matching group whose path prefixes the URL, the
+     * longest one applies. A crawler with no dedicated group falls back to
+     * `User-agent: *`. Absent any matching rule, the path is allowed.
+     */
+    private function isAllowed(string $userAgent, string $path): bool
+    {
+        $group = $this->findGroup($userAgent) ?? $this->findGroup('*');
+        $this->assertNotNull($group, "No matching group (not even '*') found for $userAgent");
+
+        $bestLength = -1;
+        $bestType = 'allow';
+        foreach ($group['rules'] as $rule) {
+            if ($rule['path'] === '' || strncmp($path, $rule['path'], strlen($rule['path'])) !== 0) {
+                continue;
+            }
+            $length = strlen($rule['path']);
+            if ($length > $bestLength) {
+                $bestLength = $length;
+                $bestType = $rule['type'];
+            }
+        }
+
+        return $bestType !== 'disallow';
+    }
+
+    /**
+     * @return array{agents: list<string>, rules: list<array{type: string, path: string}>}|null
+     */
+    private function findGroup(string $userAgent): ?array
+    {
+        foreach ($this->groups as $group) {
+            if (in_array($userAgent, $group['agents'], true)) {
+                return $group;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return array<int, array{agents: list<string>, rules: list<array{type: string, path: string}>}>
+     */
+    private function parseRobotsTxt(string $content): array
+    {
+        /** @var array<int, array{agents: list<string>, rules: list<array{type: string, path: string}>}> $groups */
+        $groups = [];
+        /** @var list<string> $pendingAgents */
+        $pendingAgents = [];
+        /** @var list<array{type: string, path: string}> $currentRules */
+        $currentRules = [];
+
+        foreach (preg_split('/\r\n|\r|\n/', $content) as $line) {
+            $line = trim((string)$line);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            if (preg_match('/^User-agent:\s*(.+)$/i', $line, $matches) === 1) {
+                // A User-agent line after directives have already been seen for the
+                // current group starts a NEW group (RFC 9309 §2.2.1).
+                if ($currentRules !== []) {
+                    $groups[] = ['agents' => $pendingAgents, 'rules' => $currentRules];
+                    $pendingAgents = [];
+                    $currentRules = [];
+                }
+                $pendingAgents[] = trim($matches[1]);
+                continue;
+            }
+
+            if (preg_match('/^(Allow|Disallow):\s*(.*)$/i', $line, $matches) === 1) {
+                $currentRules[] = ['type' => strtolower($matches[1]), 'path' => trim($matches[2])];
+            }
+        }
+        if ($pendingAgents !== []) {
+            $groups[] = ['agents' => $pendingAgents, 'rules' => $currentRules];
+        }
+
+        return $groups;
+    }
+}

--- a/tests/unit/system/RobotsTxtPolicyTest.php
+++ b/tests/unit/system/RobotsTxtPolicyTest.php
@@ -108,6 +108,15 @@ class RobotsTxtPolicyTest extends TestCase
      * rules in the bot's matching group whose path prefixes the URL, the
      * longest one applies. A crawler with no dedicated group falls back to
      * `User-agent: *`. Absent any matching rule, the path is allowed.
+     *
+     * Simplification: on an exact tie in prefix length, this keeps whichever
+     * rule appears first in the file, rather than Google's documented
+     * "least-restrictive-wins" tie-break. No path/rule combination in the
+     * current robots.txt actually ties, so this doesn't affect the
+     * assertions above — but it means this helper is not a full RFC 9309
+     * tie-break implementation, and a future robots.txt edit that introduces
+     * an equal-length Allow/Disallow pair could pass here while behaving
+     * differently for a real crawler.
      */
     private function isAllowed(string $userAgent, string $path): bool
     {


### PR DESCRIPTION
## Summary

- Serves `/llms.txt` from the site root — a plain-text file (emerging AI-crawler convention, https://llmstxt.org) telling well-behaved LLM tools what public content they may index. Eliminates ~36 hits/month of recurring 404 noise from AI crawlers.
- `robots.txt`'s per-bot blocks (GPTBot, ClaudeBot, PerplexityBot, and 14 others) were relaxed to allow `/app/owner/cars/` and `/docs/`, matching `llms.txt`'s claims — previously `robots.txt` blocked every named AI crawler from the entire site via `Disallow: /`, which would have made `llms.txt`'s allow-list unreachable for any crawler that respects both files. Login-gated paths (`edit.php`, `/app/owner/contact/`) stay explicitly blocked via longest-prefix-match overrides.
- Added a Playwright e2e smoke test confirming `/llms.txt` serves as `text/plain` with the expected content.
- Added a PHPUnit unit test (`RobotsTxtPolicyTest`) covering the new Allow/Disallow precedence logic in `robots.txt` — this is the first order-dependent policy `robots.txt` has had in this repo, so it's now worth regression-testing.

## Test plan

- [x] Verified locally against MAMP via curl: `/llms.txt` returns 200 `text/plain` with correct body; `/robots.txt` still serves cleanly
- [x] New PHPUnit test (`tests/unit/system/RobotsTxtPolicyTest.php`) passes — 9 tests / 33 assertions
- [x] Full `composer test:quick` suite green (1381 tests)
- [x] `composer check:php` (PHPStan + coding standards) clean
- [x] ESLint clean on the new Playwright test
- [x] New Playwright test discovered correctly via `--list` (runs against deployed test/prod envs per project convention)

Closes #1413