### PR TITLE
fix: prevent Claude Code Review from attempting agent delegation in CI

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -134,6 +134,9 @@ jobs:
 
             **You are the backstop.** Focus on what static tools cannot see.
 
+            Work through this directly yourself — only `Bash`, `Read`, `Grep`,
+            and `Glob` tools are available here, no agent-delegation mechanism.
+
             ## Scope
 
             Review only the diff on this PR:
@@ -328,6 +331,16 @@ jobs:
             is already done.
 
             Instead, focus on cross-issue and release-level concerns.
+
+            **Work through the tasks below directly and sequentially, yourself.**
+            Only `Bash`, `Read`, `Grep`, and `Glob` tools are available in this
+            environment — there is no agent-delegation or sub-investigation
+            mechanism here, and nothing else will report back to you. If you
+            find yourself about to say something like "the other investigations
+            are running" or "I'll compile this once the agents report back" —
+            stop: that means you've started planning a workflow this environment
+            can't run. Investigate and answer each numbered task directly instead,
+            then move on to posting the comment.
 
             ## Read the merged issue list
 


### PR DESCRIPTION
## Summary

Follow-up to #1530. After that fix landed and was re-triggered on PR #1529, the fallback-posting mechanism worked correctly — it posted *something* — but the job still failed, correctly this time: the posted text was a mid-task status update, not a real review:

> "All three investigations are running... I'll compile and post the PR comment once the agents report back."

Root cause: the Fable agent planned a multi-agent delegation strategy for `milestone-review`'s 5-part task list, but this CI environment only exposes `Bash`/`Read`/`Grep`/`Glob` — no Task/Agent tool exists here. Those delegation attempts were denied (matching the `permission_denials_count: 9` observed in the original failed run) and it never reached the actual analysis or posting step.

#1530's fixes worked exactly as designed: the fallback step posted the stub text, and the hard-fail-on-no-review check correctly recognized it wasn't a real review (no `## Strengths` heading) and failed loudly instead of passing silently.

## Changes

Adds an explicit instruction to both jobs' prompts: no agent-delegation mechanism exists in this environment, work through the numbered tasks directly and sequentially. Applied to both `pr-to-milestone-review` and `milestone-review` for consistency, though only the longer 5-task `milestone-review` prompt has shown this failure mode in practice.

## Test Plan

- [x] YAML syntax validated
- [ ] Re-trigger `milestone-review` via the `deep-review` label on PR #1529 after this merges, confirm a real structured review posts this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)