### PR TITLE
security: remove lat/lon/user_id from public car-history and DataTables payloads

### DIFF
--- a/tests/integration/CarDataTablesTest.php
+++ b/tests/integration/CarDataTablesTest.php
@@ -398,11 +398,14 @@ final class CarDataTablesTest extends IntegrationTestCase
 
     /**
      * DataTables response for the cars table must not expose email, lname, vericode,
-     * or last_verified, even when those fields are populated in the database.
+     * last_verified, user_id, lat, or lon, even when those fields are populated in the
+     * database.
      *
      * Pins the explicit SELECT column list in CarDataTablesService::getDataTablesData()
-     * that replaces SELECT * to prevent owner PII (email, lname) and internal fields
-     * (vericode, last_verified) from leaking to callers who should not see them.
+     * that replaces SELECT * to prevent owner PII (email, lname), precise owner
+     * coordinates (lat, lon), internal user IDs (user_id), and internal fields (vericode,
+     * last_verified) from leaking to callers who should not see them. lat/lon/user_id
+     * added for #1501.
      */
     #[Group('fast')]
     public function testCarDataTablesResponseExcludesPII(): void
@@ -416,6 +419,8 @@ final class CarDataTablesTest extends IntegrationTestCase
             'email' => "pii_test_{$uniqueSuffix}@example.com",
             'lname' => "PIITestLname{$uniqueSuffix}",
             'fname' => "PIIFirst",
+            'lat'   => 51.5074,
+            'lon'   => -0.1278,
         ]);
 
         $car     = new Car();
@@ -439,6 +444,12 @@ final class CarDataTablesTest extends IntegrationTestCase
                 'DataTables response must not expose vericode (internal field)');
             $this->assertArrayNotHasKey('last_verified', $rowArray,
                 'DataTables response must not expose last_verified (internal field)');
+            $this->assertArrayNotHasKey('user_id', $rowArray,
+                'DataTables response must not expose user_id (#1501)');
+            $this->assertArrayNotHasKey('lat', $rowArray,
+                'DataTables response must not expose lat (#1501)');
+            $this->assertArrayNotHasKey('lon', $rowArray,
+                'DataTables response must not expose lon (#1501)');
         }
     }
 
@@ -531,12 +542,14 @@ final class CarDataTablesTest extends IntegrationTestCase
     }
 
     /**
-     * History rows returned by getHistory() must not expose email or lname,
-     * even when those fields are populated in cars_hist.
+     * History rows returned by getHistory() must not expose email, lname, user_id, lat,
+     * or lon, even when those fields are populated in cars_hist.
      *
      * Anchors the behavioral contract independently of the SQL-capture unit test in
      * CarRepositoryTest — if getHistory() is refactored to use a query builder or
      * SELECT *, this test catches the PII regression at the return-value level.
+     * user_id/lat/lon added for #1501 — getHistory() backs the public, unauthenticated
+     * app/api/cars/history.php endpoint.
      */
     #[Group('fast')]
     public function testGetHistoryExcludesPIIFromReturnedRows(): void
@@ -559,6 +572,9 @@ final class CarDataTablesTest extends IntegrationTestCase
             'chassis'   => 'H' . substr($uniqueSuffix, -8),
             'email'     => "hist_pii_{$uniqueSuffix}@example.com",
             'lname'     => "HistPII{$uniqueSuffix}",
+            'user_id'   => $userId,
+            'lat'       => 51.5074,
+            'lon'       => -0.1278,
         ]);
 
         $repo    = new CarRepository($this->db);
@@ -572,6 +588,12 @@ final class CarDataTablesTest extends IntegrationTestCase
                 'getHistory() rows must not expose email (PII)');
             $this->assertArrayNotHasKey('lname', $rowArray,
                 'getHistory() rows must not expose lname (PII)');
+            $this->assertArrayNotHasKey('user_id', $rowArray,
+                'getHistory() rows must not expose user_id (#1501)');
+            $this->assertArrayNotHasKey('lat', $rowArray,
+                'getHistory() rows must not expose lat (#1501)');
+            $this->assertArrayNotHasKey('lon', $rowArray,
+                'getHistory() rows must not expose lon (#1501)');
         }
     }
 

--- a/tests/unit/cars/services/CarDataTablesServiceTest.php
+++ b/tests/unit/cars/services/CarDataTablesServiceTest.php
@@ -95,6 +95,24 @@ final class CarDataTablesServiceTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testValidateColumnNameRejectsUserId(): void
+    {
+        $result = $this->invokeValidateColumnName('user_id', 'cars');
+        $this->assertFalse($result);
+    }
+
+    public function testValidateColumnNameRejectsLat(): void
+    {
+        $result = $this->invokeValidateColumnName('lat', 'cars');
+        $this->assertFalse($result);
+    }
+
+    public function testValidateColumnNameRejectsLon(): void
+    {
+        $result = $this->invokeValidateColumnName('lon', 'cars');
+        $this->assertFalse($result);
+    }
+
     // ============================================================
     // getDataTablesData tests
     // ============================================================

--- a/tests/unit/cars/services/CarRepositoryTest.php
+++ b/tests/unit/cars/services/CarRepositoryTest.php
@@ -165,10 +165,11 @@ final class CarRepositoryTest extends TestCase
 
     public function testGetHistoryExcludesPII(): void
     {
-        // Security contract: email and lname must not appear in the SELECT clause.
-        // vericode and last_verified are not asserted here because cars_hist has no
-        // such columns — they exist only on the cars table and can never leak from
-        // this path even under SELECT *.
+        // Security contract: email, lname, user_id, lat, and lon must not appear in the
+        // SELECT clause — this method backs the public, unauthenticated
+        // app/api/cars/history.php endpoint (see #1501). vericode and last_verified are
+        // not asserted here because cars_hist has no such columns — they exist only on
+        // the cars table and can never leak from this path even under SELECT *.
         $capturedSql = null;
         $db = $this->makeDbMock();
         $db->expects($this->once())
@@ -190,6 +191,20 @@ final class CarRepositoryTest extends TestCase
         $this->assertStringNotContainsStringIgnoringCase(
             'lname', $capturedSql,
             'getHistory() SELECT must not include lname column (PII)'
+        );
+        $this->assertStringNotContainsStringIgnoringCase(
+            'user_id', $capturedSql,
+            'getHistory() SELECT must not include user_id column (#1501)'
+        );
+        // Word-boundary match, not substring: 'lat'/'lon' are short enough to
+        // false-positive against a future column like 'plate' or 'longitude'.
+        $this->assertDoesNotMatchRegularExpression(
+            '/\blat\b/i', $capturedSql,
+            'getHistory() SELECT must not include lat column (#1501)'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/\blon\b/i', $capturedSql,
+            'getHistory() SELECT must not include lon column (#1501)'
         );
     }
 

--- a/usersc/classes/Car/CarDataTablesService.php
+++ b/usersc/classes/Car/CarDataTablesService.php
@@ -27,13 +27,26 @@ class CarDataTablesService
         'factory' => 'elan_factory_info'
     ];
 
-    /** @var array<string, array<string>> Allowed columns per table */
+    /**
+     * Allowed columns per table — dual-purpose, read before editing.
+     *
+     * Used for BOTH (a) the SELECT list returned to unauthenticated DataTables
+     * clients (see getDataTablesData()) and (b) the ORDER BY / WHERE allowlist
+     * in validateColumnName(). Adding a column here exposes it publicly.
+     *
+     * Do not re-add user_id, lat, or lon (removed in #1501 — owner PII and
+     * internal identifiers). If a feature needs to sort or filter on a
+     * non-public column, split this into separate SELECT and FILTERABLE
+     * allowlists rather than widening this one.
+     *
+     * @var array<string, array<string>>
+     */
     private const ALLOWED_COLUMNS = [
         'cars' => [
             'id', 'ctime', 'mtime',
             'model', 'series', 'variant', 'year', 'type', 'chassis', 'color', 'engine',
-            'purchasedate', 'solddate', 'comments', 'image', 'user_id', 'fname',
-            'join_date', 'city', 'state', 'country', 'lat', 'lon', 'website'
+            'purchasedate', 'solddate', 'comments', 'image', 'fname',
+            'join_date', 'city', 'state', 'country', 'website'
         ],
         'elan_factory_info' => [
             'id', 'year', 'month', 'batch', 'type', 'serial', 'suffix',

--- a/usersc/classes/Car/CarRepository.php
+++ b/usersc/classes/Car/CarRepository.php
@@ -273,7 +273,7 @@ class CarRepository
             'SELECT id, car_id, ctime, mtime, timestamp, operation,
                     model, series, variant, year, type, chassis, chassis_override, color, engine,
                     purchasedate, solddate, comments, image,
-                    user_id, fname, join_date, city, state, country, lat, lon, website
+                    fname, join_date, city, state, country, website
              FROM cars_hist WHERE car_id = ? ORDER BY timestamp DESC',
             [$carId]
         )->results();


### PR DESCRIPTION
## Summary

- `CarRepository::getHistory()` no longer selects `user_id`, `lat`, or `lon` — this method backs the public, unauthenticated `app/api/cars/history.php` endpoint.
- `CarDataTablesService::ALLOWED_COLUMNS['cars']` no longer includes `user_id`, `lat`, or `lon` — this constant both builds the SELECT list and gates ORDER BY/WHERE for the public DataTables endpoints (`app/api/cars/list.php`, `factory-list.php`).
- Expanded the `ALLOWED_COLUMNS` docblock to document its dual SELECT/allowlist purpose and warn against re-adding these fields.

## Test plan

- Extended `CarRepositoryTest::testGetHistoryExcludesPII()` with SQL-string assertions for `user_id`/`lat`/`lon` (word-boundary regex for `lat`/`lon` to avoid false positives against columns like `plate`).
- Extended `CarDataTablesTest::testCarDataTablesResponseExcludesPII()` and `testGetHistoryExcludesPIIFromReturnedRows()` (integration, real DB) to seed and assert absence of `user_id`/`lat`/`lon` in actual response rows.
- Added `CarDataTablesServiceTest::testValidateColumnNameRejects{UserId,Lat,Lon}()` — fast, DB-free coverage mirroring the existing email/lname/vericode/last_verified pattern, so a future accidental re-addition is caught at `composer test:quick` speed.
- Verified no consumer (JS bindings, owner-details history table) relies on the removed fields.
- `vendor/bin/phpstan analyse` clean on both touched class files.
- Ran `/security-review` and a local multi-agent `/review-pr` (code-reviewer, pr-test-analyzer, comment-analyzer) — no Blocking findings.

Closes #1501

Claude-Session: https://claude.ai/code/session_018RYKgRUy5Bzdky9F5dLu77