### PR TITLE
test: make the integration test harness honest

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -152,6 +152,65 @@ ELAN REGISTRY TEST DATABASE SETUP
 | `tests/integration/cars/services/CarValidatorModelTest.php` | Yes | ✅ |
 | Other integration tests | No | N/A |
 
+## Test Data Isolation
+
+Integration tests run against a dedicated, isolated test schema (see #1436).
+A **freshly cloned** schema (`scripts/create-test-schema.sh`) starts completely
+empty — no ambient cars, users, or other rows. Two different lifecycles apply
+after that:
+
+- **Per-test fixtures** — anything a test creates (via `createTestUser()`,
+  `createTestCar()`, or a direct insert like a `profiles`/`car_transfer_requests`
+  row) is torn down after *that test* in `tearDown()`. Every test starts and
+  ends with none of its own data left behind.
+- **Schema-level reference/config data** — `car_models` and `settings` are
+  auto-seeded once by `tests/bootstrap-integration.php` the first time either
+  is found empty, then **persist across every subsequent run** (they are never
+  torn down). This mirrors a real install, which configures these once, not
+  per test. Re-running `scripts/create-test-schema.sh` resets them along with
+  everything else.
+
+So "starts empty" describes a fresh clone's initial state, not every run's
+steady state — after the first run, `car_models` and `settings` will already
+be populated, and the bootstrap logs `NOTE: ... already present/populated`
+instead of re-seeding.
+
+The auto-seeded `settings` row uses placeholder values (see the seeding logic
+in `tests/bootstrap-integration.php`), not production values — if a test
+depends on a specific setting, set it explicitly in that test rather than
+assuming the seeded default matches a real install.
+
+Every test must create the fixtures it depends on and must never assume
+pre-existing data exists. Tests that relied on ambient data in the old shared
+dev database (1590+ cars, 1763+ users) will fail or pass for the wrong reason
+against an empty schema.
+
+**Don't** hardcode assumed IDs, grab "whatever exists", or assert on
+registry-wide counts:
+
+```php
+// Assumes car/user 1 exists, or that a row is "just lying around"
+$owner = new Owner($userId = 1);
+$row = $this->db->query('SELECT * FROM cars LIMIT 1')->first();
+$count = $this->db->query('SELECT COUNT(*) AS c FROM cars')->first();
+$this->assertGreaterThan(0, $count->c);
+```
+
+**Do** create the fixtures the test needs, then assert against them:
+
+```php
+$userId = $this->createTestUser();
+$carId = $this->createTestCar($userId, ['chassis' => 'EL12345S']);
+
+$car = $this->db->query('SELECT * FROM cars WHERE id = ?', [$carId])->first();
+$this->assertSame($userId, (int) $car->user_id);
+```
+
+Use `IntegrationTestCase::createTestUser()` and `createTestCar()`
+(`tests/integration/IntegrationTestCase.php`) to create fixture rows — both
+generate unique, non-colliding data and are automatically cleaned up in
+`tearDown()`.
+
 ## Quick Reference
 
 ```bash

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,10 +175,15 @@ steady state — after the first run, `car_models` and `settings` will already
 be populated, and the bootstrap logs `NOTE: ... already present/populated`
 instead of re-seeding.
 
-The auto-seeded `settings` row uses placeholder values (see the seeding logic
-in `tests/bootstrap-integration.php`), not production values — if a test
-depends on a specific setting, set it explicitly in that test rather than
-assuming the seeded default matches a real install.
+The auto-seeded `settings` row layers real values over generic type-based
+placeholders (`''`/`0`) for the remaining NOT NULL columns with no default —
+see `$elanDefaults` in `tests/bootstrap-integration.php`. Most of these
+(`site_name`, `permission_restriction`, `session_manager`, `req_cap`/`req_num`,
+`email_login`, etc.) come from the real ElanRegistry production configuration
+in `database/3-configuration.sql`; a few (`min_pw`/`max_pw`/`min_un`/`max_un`)
+are standard UserSpice defaults not tracked in that file. Don't assume a
+setting *not* in `$elanDefaults` matches production — set it explicitly in
+your test if it does.
 
 Every test must create the fixtures it depends on and must never assume
 pre-existing data exists. Tests that relied on ambient data in the old shared

--- a/tests/bootstrap-integration.php
+++ b/tests/bootstrap-integration.php
@@ -347,6 +347,7 @@ try {
             $insertColumns = ['id'];
             $placeholders = ['?'];
             $bindings = [1];
+            $unmatchedDefaults = array_keys($elanDefaults);
 
             foreach ($columns as $col) {
                 $name = $col->COLUMN_NAME;
@@ -362,6 +363,7 @@ try {
                     $insertColumns[] = $quotedName;
                     $placeholders[] = '?';
                     $bindings[] = $elanDefaults[$name];
+                    $unmatchedDefaults = array_diff($unmatchedDefaults, [$name]);
                     continue;
                 }
 
@@ -390,6 +392,17 @@ try {
                 $insertColumns[] = $quotedName;
                 $placeholders[] = '?';
                 $bindings[] = $placeholderValue;
+            }
+
+            // A key in $elanDefaults that never matched an actual settings column (renamed,
+            // typo'd, or a future schema change) would otherwise be silently dropped — the
+            // column falls through to a generic placeholder with no error, undercutting the
+            // whole point of layering in real values. Fail loudly instead.
+            if ($unmatchedDefaults) {
+                abortBootstrap(
+                    "ERROR: \$elanDefaults keys not found as settings columns: " . implode(', ', $unmatchedDefaults),
+                    "Update \$elanDefaults in this file to match the current settings schema. Aborting."
+                );
             }
 
             $seedSql = 'INSERT INTO `settings` (' . implode(', ', $insertColumns) . ') VALUES ('

--- a/tests/bootstrap-integration.php
+++ b/tests/bootstrap-integration.php
@@ -165,6 +165,23 @@ try {
     fwrite(STDERR, "NOTE: Database reconnection attempt failed: {$e->getMessage()}\n");
 }
 
+/**
+ * Write each message line to STDERR and exit(1).
+ *
+ * Consolidates the repeated "fwrite(STDERR, ...); ...; exit(1);" pattern used
+ * throughout the reference-data and settings auto-load blocks below, which
+ * fail loudly rather than let tests run against a silently broken environment.
+ *
+ * @param string ...$lines Message lines, printed in order (no trailing "\n" needed).
+ */
+function abortBootstrap(string ...$lines): never
+{
+    foreach ($lines as $line) {
+        fwrite(STDERR, $line . "\n");
+    }
+    exit(1);
+}
+
 // ============================================================
 // Auto-load Reference Data for Integration Tests
 // ============================================================
@@ -205,32 +222,36 @@ try {
                         $loadedCount = (int)($newCount?->cnt ?? 0);
 
                         if ($loadedCount === 0) {
-                            fwrite(STDERR, "ERROR: car_models INSERT ran but the table is still empty.\n");
-                            fwrite(STDERR, "Integration tests that depend on car_models cannot run. Aborting.\n");
-                            fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
-                            exit(1);
+                            abortBootstrap(
+                                "ERROR: car_models INSERT ran but the table is still empty.",
+                                "Integration tests that depend on car_models cannot run. Aborting.",
+                                "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests."
+                            );
                         }
 
                         fwrite(STDERR, "NOTE: Loaded {$loadedCount} car_models records for integration tests\n");
                     } else {
-                        fwrite(STDERR, "ERROR: Could not parse the car_models INSERT from {$refDataPath}.\n");
-                        fwrite(STDERR, "The file's format may have changed and this bootstrap's parsing regex needs updating. Aborting.\n");
-                        fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
-                        fwrite(STDERR, "If that does not help, database/2-reference-data.sql or the bootstrap regex needs attention.\n");
-                        exit(1);
+                        abortBootstrap(
+                            "ERROR: Could not parse the car_models INSERT from {$refDataPath}.",
+                            "The file's format may have changed and this bootstrap's parsing regex needs updating. Aborting.",
+                            "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.",
+                            "If that does not help, database/2-reference-data.sql or the bootstrap regex needs attention."
+                        );
                     }
                 } else {
-                    fwrite(STDERR, "ERROR: Failed to read reference data file: {$refDataPath}\n");
-                    fwrite(STDERR, "Check the file's permissions and readability. Aborting.\n");
-                    fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
-                    exit(1);
+                    abortBootstrap(
+                        "ERROR: Failed to read reference data file: {$refDataPath}",
+                        "Check the file's permissions and readability. Aborting.",
+                        "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests."
+                    );
                 }
             } else {
-                fwrite(STDERR, "ERROR: Reference data file not found: {$refDataPath}\n");
-                fwrite(STDERR, "car_models cannot be populated and integration tests would fail confusingly. Aborting.\n");
-                fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
-                fwrite(STDERR, "If that does not help, database/2-reference-data.sql itself may be missing or misnamed.\n");
-                exit(1);
+                abortBootstrap(
+                    "ERROR: Reference data file not found: {$refDataPath}",
+                    "car_models cannot be populated and integration tests would fail confusingly. Aborting.",
+                    "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.",
+                    "If that does not help, database/2-reference-data.sql itself may be missing or misnamed."
+                );
             }
         } else {
             $recordCount = (int)($count?->cnt ?? 0);
@@ -238,10 +259,11 @@ try {
         }
     }
 } catch (Throwable $e) {
-    fwrite(STDERR, "ERROR: Failed to load reference data: {$e->getMessage()}\n");
-    fwrite(STDERR, "Integration tests that depend on car_models cannot run. Aborting.\n");
-    fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
-    exit(1);
+    abortBootstrap(
+        "ERROR: Failed to load reference data: {$e->getMessage()}",
+        "Integration tests that depend on car_models cannot run. Aborting.",
+        "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests."
+    );
 }
 
 // ============================================================
@@ -269,9 +291,10 @@ try {
         $settingsCount = $db->query("SELECT COUNT(*) as cnt FROM settings WHERE id = 1")->first();
 
         if (!is_object($settingsCount) || !property_exists($settingsCount, 'cnt')) {
-            fwrite(STDERR, "ERROR: Could not query the settings table: {$db->errorString()}\n");
-            fwrite(STDERR, "Code that depends on settings (e.g. Car::__construct()) would silently misbehave. Aborting.\n");
-            exit(1);
+            abortBootstrap(
+                "ERROR: Could not query the settings table: {$db->errorString()}",
+                "Code that depends on settings (e.g. Car::__construct()) would silently misbehave. Aborting."
+            );
         }
 
         if ((int) $settingsCount->cnt === 0) {
@@ -284,10 +307,11 @@ try {
             )->results();
 
             if (!$columns) {
-                fwrite(STDERR, "ERROR: Could not introspect the settings table's columns (query returned no rows).\n");
-                fwrite(STDERR, "The settings table may be missing entirely — check that scripts/create-test-schema.sh\n");
-                fwrite(STDERR, "was run and cloned the settings table structure. Aborting.\n");
-                exit(1);
+                abortBootstrap(
+                    "ERROR: Could not introspect the settings table's columns (query returned no rows).",
+                    "The settings table may be missing entirely — check that scripts/create-test-schema.sh",
+                    "was run and cloned the settings table structure. Aborting."
+                );
             }
 
             $textTypes = ['varchar', 'char', 'text', 'tinytext', 'mediumtext', 'longtext'];
@@ -356,10 +380,11 @@ try {
                 } elseif (in_array($col->DATA_TYPE, $numericTypes, true)) {
                     $placeholderValue = 0;
                 } else {
-                    fwrite(STDERR, "ERROR: settings column `{$name}` is NOT NULL with no default and an\n");
-                    fwrite(STDERR, "unhandled type ({$col->DATA_TYPE}) — no safe placeholder value is known.\n");
-                    fwrite(STDERR, "Add it to \$elanDefaults or \$textTypes/\$numericTypes above. Aborting.\n");
-                    exit(1);
+                    abortBootstrap(
+                        "ERROR: settings column `{$name}` is NOT NULL with no default and an",
+                        "unhandled type ({$col->DATA_TYPE}) — no safe placeholder value is known.",
+                        "Add it to \$elanDefaults or \$textTypes/\$numericTypes above. Aborting."
+                    );
                 }
 
                 $insertColumns[] = $quotedName;
@@ -374,9 +399,10 @@ try {
 
             $verify = $db->query("SELECT COUNT(*) as cnt FROM settings WHERE id = 1")->first();
             if (!$verify || (int) $verify->cnt === 0) {
-                fwrite(STDERR, "ERROR: settings row INSERT ran but id=1 still does not exist.\n");
-                fwrite(STDERR, "Car::__construct() and other code silently skip loading data without this row. Aborting.\n");
-                exit(1);
+                abortBootstrap(
+                    "ERROR: settings row INSERT ran but id=1 still does not exist.",
+                    "Car::__construct() and other code silently skip loading data without this row. Aborting."
+                );
             }
 
             fwrite(STDERR, "NOTE: Seeded settings row (id=1) for integration tests\n");
@@ -385,7 +411,8 @@ try {
         }
     }
 } catch (Throwable $e) {
-    fwrite(STDERR, "ERROR: Failed to seed the settings row: {$e->getMessage()}\n");
-    fwrite(STDERR, "Code that depends on settings (e.g. Car::__construct()) would silently misbehave. Aborting.\n");
-    exit(1);
+    abortBootstrap(
+        "ERROR: Failed to seed the settings row: {$e->getMessage()}",
+        "Code that depends on settings (e.g. Car::__construct()) would silently misbehave. Aborting."
+    );
 }

--- a/tests/bootstrap-integration.php
+++ b/tests/bootstrap-integration.php
@@ -87,6 +87,13 @@ set_error_handler(function ($errno, $errstr, $errfile, $errline) {
 // Start output buffering to catch any die() output messages
 ob_start();
 
+// Intentionally non-fatal: users/init.php performs framework setup that can throw before
+// the DB connection this bootstrap actually needs is established (e.g. plugin/session
+// init that assumes a fully-configured environment). IntegrationTestCase::setUp() has its
+// own DB connectivity check and skips gracefully via requireDatabase() if the database
+// this init failure may have affected genuinely isn't reachable — that's the real signal,
+// not this early framework noise. A hard abort here would be too coarse: it can't tell
+// framework startup quirks apart from failures that actually block testing.
 try {
     require_once $initPath;
 } catch (Throwable $e) {
@@ -104,6 +111,12 @@ restore_error_handler();
 
 // Ensure $user global is properly initialized for getSettings() calls
 // If users/init.php didn't fully initialize $user, create a minimal User object
+//
+// Intentionally non-fatal: a failure here means only that this fallback couldn't create
+// an empty User() shell (e.g. the User class itself has a constructor issue) — most
+// integration tests set up their own authenticated $user explicitly in setUp() and don't
+// depend on this fallback existing at all. Aborting the whole run over an unused fallback
+// would block tests that never needed it.
 if (!isset($GLOBALS['user']) || $GLOBALS['user'] === null) {
     if (class_exists('User')) {
         try {
@@ -162,6 +175,12 @@ try {
         fwrite(STDERR, "NOTE: Re-initialized global \$db for integration tests\n");
     }
 } catch (Throwable $e) {
+    // Intentionally non-fatal (unlike the stricter inner catch above at the database-identity
+    // check, which does abort): this outer catch covers the DB-singleton-cache reset and
+    // reconnection attempt itself. If those steps fail, IntegrationTestCase::setUp()'s own
+    // DB::getInstance() + requireDatabase() will independently detect the same unreachable
+    // database and skip tests gracefully — that's the authoritative check, this is just an
+    // earlier best-effort reconnection step whose failure the real check will catch anyway.
     fwrite(STDERR, "NOTE: Database reconnection attempt failed: {$e->getMessage()}\n");
 }
 

--- a/tests/bootstrap-integration.php
+++ b/tests/bootstrap-integration.php
@@ -204,15 +204,33 @@ try {
                         $newCount = $db->query("SELECT COUNT(*) as cnt FROM car_models")->first();
                         $loadedCount = (int)($newCount?->cnt ?? 0);
 
+                        if ($loadedCount === 0) {
+                            fwrite(STDERR, "ERROR: car_models INSERT ran but the table is still empty.\n");
+                            fwrite(STDERR, "Integration tests that depend on car_models cannot run. Aborting.\n");
+                            fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
+                            exit(1);
+                        }
+
                         fwrite(STDERR, "NOTE: Loaded {$loadedCount} car_models records for integration tests\n");
                     } else {
-                        fwrite(STDERR, "NOTE: Could not parse car_models INSERT from reference data file\n");
+                        fwrite(STDERR, "ERROR: Could not parse the car_models INSERT from {$refDataPath}.\n");
+                        fwrite(STDERR, "The file's format may have changed and this bootstrap's parsing regex needs updating. Aborting.\n");
+                        fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
+                        fwrite(STDERR, "If that does not help, database/2-reference-data.sql or the bootstrap regex needs attention.\n");
+                        exit(1);
                     }
                 } else {
-                    fwrite(STDERR, "NOTE: Failed to read reference data file\n");
+                    fwrite(STDERR, "ERROR: Failed to read reference data file: {$refDataPath}\n");
+                    fwrite(STDERR, "Check the file's permissions and readability. Aborting.\n");
+                    fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
+                    exit(1);
                 }
             } else {
-                fwrite(STDERR, "NOTE: Reference data file not found: {$refDataPath}\n");
+                fwrite(STDERR, "ERROR: Reference data file not found: {$refDataPath}\n");
+                fwrite(STDERR, "car_models cannot be populated and integration tests would fail confusingly. Aborting.\n");
+                fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
+                fwrite(STDERR, "If that does not help, database/2-reference-data.sql itself may be missing or misnamed.\n");
+                exit(1);
             }
         } else {
             $recordCount = (int)($count?->cnt ?? 0);
@@ -220,6 +238,154 @@ try {
         }
     }
 } catch (Throwable $e) {
-    fwrite(STDERR, "NOTE: Failed to load reference data: {$e->getMessage()}\n");
-    // Non-fatal: tests requiring car_models will handle gracefully
+    fwrite(STDERR, "ERROR: Failed to load reference data: {$e->getMessage()}\n");
+    fwrite(STDERR, "Integration tests that depend on car_models cannot run. Aborting.\n");
+    fwrite(STDERR, "Run: ./scripts/create-test-schema.sh to reset the test schema, then re-run tests.\n");
+    exit(1);
+}
+
+// ============================================================
+// Auto-seed the settings row for Integration Tests
+// ============================================================
+// Car::__construct() and other framework code call getSettings()/query
+// `settings WHERE id = 1` and silently no-op (never loading real data) if
+// that lookup returns nothing — so a missing settings row doesn't throw, it
+// makes unrelated code paths behave as if the row being looked up doesn't
+// exist either. The `settings` table has ~100 UserSpice-core columns with no
+// canonical INSERT tracked in this repo (it's normally created by the
+// UserSpice installer, which isn't part of this checkout). Rather than
+// hand-maintain a giant literal INSERT that drifts from the schema, build
+// one dynamically: satisfy every NOT NULL column with a type-appropriate
+// placeholder, then layer in the real ElanRegistry values that application
+// code actually depends on (documented in database/3-configuration.sql).
+// This also keeps the test DB privacy-safe — a synthetic row avoids ever
+// copying real secrets (gsecret, fbsecret, spice_api, elan_admin_emails, etc.)
+// from a live settings row into a test schema.
+
+try {
+    if (class_exists('DB')) {
+        $db = DB::getInstance();
+
+        $settingsCount = $db->query("SELECT COUNT(*) as cnt FROM settings WHERE id = 1")->first();
+
+        if (!is_object($settingsCount) || !property_exists($settingsCount, 'cnt')) {
+            fwrite(STDERR, "ERROR: Could not query the settings table: {$db->errorString()}\n");
+            fwrite(STDERR, "Code that depends on settings (e.g. Car::__construct()) would silently misbehave. Aborting.\n");
+            exit(1);
+        }
+
+        if ((int) $settingsCount->cnt === 0) {
+            fwrite(STDERR, "NOTE: settings row (id=1) is missing, seeding minimal test settings...\n");
+
+            $columns = $db->query(
+                "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT
+                 FROM information_schema.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'settings'"
+            )->results();
+
+            if (!$columns) {
+                fwrite(STDERR, "ERROR: Could not introspect the settings table's columns (query returned no rows).\n");
+                fwrite(STDERR, "The settings table may be missing entirely — check that scripts/create-test-schema.sh\n");
+                fwrite(STDERR, "was run and cloned the settings table structure. Aborting.\n");
+                exit(1);
+            }
+
+            $textTypes = ['varchar', 'char', 'text', 'tinytext', 'mediumtext', 'longtext'];
+            $numericTypes = ['int', 'tinyint', 'smallint', 'mediumint', 'bigint'];
+
+            // Real ElanRegistry values app code depends on (source: database/3-configuration.sql,
+            // the canonical "UPDATE settings SET ..." for a fresh install). Includes the
+            // security-relevant settings so tests exercise the same permission/session/rate-limit
+            // posture as a real install, not a permissive all-zero fallback.
+            $elanDefaults = [
+                'site_name'              => 'Lotus Elan Registry',
+                'template'               => 'customizer',
+                'copyright'              => 'Lotus Elan Registry and UniBrain',
+                'navigation_type'        => 0,
+                'elan_image_dir'         => 'userimages/',
+                'elan_image_max'         => 6,
+                'permission_restriction' => 1,
+                'session_manager'        => 1,
+                'recaptcha'              => 0,
+                'req_cap'                => 1,
+                'req_num'                => 1,
+                'email_login'            => 2,
+                // Length-range settings validated by users/join.php, user_settings.php, and
+                // forgot_password_reset.php — a 0/0 range would reject every username/password
+                // ("must be at most 0 characters"), silently breaking any test that registers
+                // or resets a user. Standard UserSpice defaults.
+                'min_pw' => 5,
+                'max_pw' => 32,
+                'min_un' => 5,
+                'max_un' => 20,
+            ];
+
+            $insertColumns = ['id'];
+            $placeholders = ['?'];
+            $bindings = [1];
+
+            foreach ($columns as $col) {
+                $name = $col->COLUMN_NAME;
+                if ($name === 'id') {
+                    continue;
+                }
+
+                // Column names come from information_schema (a trusted system catalog scoped to
+                // this exact table), never external input — but quote defensively regardless.
+                $quotedName = '`' . str_replace('`', '``', $name) . '`';
+
+                if (array_key_exists($name, $elanDefaults)) {
+                    $insertColumns[] = $quotedName;
+                    $placeholders[] = '?';
+                    $bindings[] = $elanDefaults[$name];
+                    continue;
+                }
+
+                // Columns that are nullable, or have their own DB default, don't need a value.
+                if ($col->IS_NULLABLE === 'YES' || $col->COLUMN_DEFAULT !== null) {
+                    continue;
+                }
+
+                // Only fill types where '' or 0 is unambiguously safe. A NOT NULL `datetime`,
+                // `enum`, `decimal`, `json`, etc. could reject or misinterpret either placeholder
+                // (e.g. 0 into a strict-mode `datetime` errors; the equivalent enum member may not
+                // exist) — abort instead of guessing, consistent with this block failing loudly
+                // rather than seeding a row that looks valid but silently misbehaves.
+                if (in_array($col->DATA_TYPE, $textTypes, true)) {
+                    $placeholderValue = '';
+                } elseif (in_array($col->DATA_TYPE, $numericTypes, true)) {
+                    $placeholderValue = 0;
+                } else {
+                    fwrite(STDERR, "ERROR: settings column `{$name}` is NOT NULL with no default and an\n");
+                    fwrite(STDERR, "unhandled type ({$col->DATA_TYPE}) — no safe placeholder value is known.\n");
+                    fwrite(STDERR, "Add it to \$elanDefaults or \$textTypes/\$numericTypes above. Aborting.\n");
+                    exit(1);
+                }
+
+                $insertColumns[] = $quotedName;
+                $placeholders[] = '?';
+                $bindings[] = $placeholderValue;
+            }
+
+            $seedSql = 'INSERT INTO `settings` (' . implode(', ', $insertColumns) . ') VALUES ('
+                . implode(', ', $placeholders) . ')';
+
+            $db->query($seedSql, $bindings);
+
+            $verify = $db->query("SELECT COUNT(*) as cnt FROM settings WHERE id = 1")->first();
+            if (!$verify || (int) $verify->cnt === 0) {
+                fwrite(STDERR, "ERROR: settings row INSERT ran but id=1 still does not exist.\n");
+                fwrite(STDERR, "Car::__construct() and other code silently skip loading data without this row. Aborting.\n");
+                exit(1);
+            }
+
+            fwrite(STDERR, "NOTE: Seeded settings row (id=1) for integration tests\n");
+        } else {
+            fwrite(STDERR, "NOTE: settings row (id=1) already present\n");
+        }
+    }
+} catch (Throwable $e) {
+    fwrite(STDERR, "ERROR: Failed to seed the settings row: {$e->getMessage()}\n");
+    fwrite(STDERR, "Code that depends on settings (e.g. Car::__construct()) would silently misbehave. Aborting.\n");
+    exit(1);
 }

--- a/tests/integration/AdminAjaxEndpointsTest.php
+++ b/tests/integration/AdminAjaxEndpointsTest.php
@@ -22,13 +22,8 @@ class AdminAjaxEndpointsTest extends IntegrationTestCase
         parent::setUp();
         $this->requireDatabase();
 
-        // Find test car data
-        $car = $this->db->query("SELECT id FROM cars LIMIT 1")->first();
-        $this->testCarId = $car ? $car->id : null;
-
-        // Find test user data
-        $user = $this->db->query("SELECT id FROM users WHERE active = 1 LIMIT 1")->first();
-        $this->testUserId = $user ? $user->id : null;
+        $this->testUserId = $this->createTestUser();
+        $this->testCarId = $this->createTestCar($this->testUserId);
     }
 
     // =========================================================================
@@ -152,144 +147,6 @@ class AdminAjaxEndpointsTest extends IntegrationTestCase
     }
 
     // =========================================================================
-    // Integration Tests - Endpoint Response Format
-    // =========================================================================
-
-    /**
-     * Test that endpoints follow ApiResponse pattern
-     * Success responses should have: success, message, data fields
-     */
-    public function testApiResponseSuccessFormat(): void
-    {
-        // This test validates the ApiResponse pattern structure
-        // Expected success response format:
-        // {
-        //   "success": true,
-        //   "message": "...",
-        //   "car": { ... } or "user": { ... }
-        // }
-
-        $this->assertTrue(true, 'ApiResponse pattern validation placeholder');
-    }
-
-    /**
-     * Test that error responses include message field
-     * Error responses should have: success=false, message field (not error)
-     */
-    public function testApiResponseErrorFormat(): void
-    {
-        // This test validates error response uses "message" not "error"
-        // Expected error response format:
-        // {
-        //   "success": false,
-        //   "message": "Error description"
-        // }
-
-        $this->assertTrue(true, 'Error response format validation placeholder');
-    }
-
-    // =========================================================================
-    // Security Tests
-    // =========================================================================
-
-    /**
-     * Test that endpoints require authentication
-     * Unauthenticated requests should return 403 Forbidden
-     */
-    public function testCarDetailsRequiresAuthentication(): void
-    {
-        // This test would verify that unauthenticated access is rejected
-        // Expected: ApiResponse::forbidden() - HTTP 403
-
-        $this->assertTrue(true, 'Authentication requirement validation placeholder');
-    }
-
-    /**
-     * Test that endpoints require admin permission
-     * Non-admin authenticated requests should return 403 Forbidden
-     */
-    public function testCarDetailsRequiresAdminPermission(): void
-    {
-        // This test would verify that non-admin users cannot access endpoints
-        // Expected: ApiResponse::forbidden() - HTTP 403
-
-        $this->assertTrue(true, 'Admin permission validation placeholder');
-    }
-
-    /**
-     * Test that endpoints validate CSRF tokens
-     * Requests with invalid CSRF should return 400 Bad Request
-     */
-    public function testCarDetailsValidatesCsrf(): void
-    {
-        // This test would verify CSRF token validation
-        // Expected: ApiResponse::error(..., 400) - HTTP 400
-
-        $this->assertTrue(true, 'CSRF validation placeholder');
-    }
-
-    /**
-     * Test that endpoints validate input parameters
-     * Requests with invalid car_id should return 400 Bad Request
-     */
-    public function testCarDetailsValidatesInput(): void
-    {
-        // This test would verify input validation
-        // Expected: ApiResponse::error(..., 400) - HTTP 400
-
-        $this->assertTrue(true, 'Input validation placeholder');
-    }
-
-    // =========================================================================
-    // HTTP Status Code Tests
-    // =========================================================================
-
-    /**
-     * Test that valid requests return 200 OK
-     */
-    public function testSuccessfulRequestReturnsOk(): void
-    {
-        // Expected HTTP status: 200
-        $this->assertTrue(true, 'HTTP 200 validation placeholder');
-    }
-
-    /**
-     * Test that missing resources return 404 Not Found
-     */
-    public function testMissingResourceReturns404(): void
-    {
-        // Expected HTTP status: 404 for non-existent car/user
-        $this->assertTrue(true, 'HTTP 404 validation placeholder');
-    }
-
-    /**
-     * Test that invalid requests return 400 Bad Request
-     */
-    public function testInvalidRequestReturns400(): void
-    {
-        // Expected HTTP status: 400 for invalid input
-        $this->assertTrue(true, 'HTTP 400 validation placeholder');
-    }
-
-    /**
-     * Test that unauthorized requests return 403 Forbidden
-     */
-    public function testUnauthorizedRequestReturns403(): void
-    {
-        // Expected HTTP status: 403 for unauthorized access
-        $this->assertTrue(true, 'HTTP 403 validation placeholder');
-    }
-
-    /**
-     * Test that server errors return 500 Internal Server Error
-     */
-    public function testServerErrorReturns500(): void
-    {
-        // Expected HTTP status: 500 for database errors
-        $this->assertTrue(true, 'HTTP 500 validation placeholder');
-    }
-
-    // =========================================================================
     // Data Consistency Tests
     // =========================================================================
 
@@ -316,45 +173,4 @@ class AdminAjaxEndpointsTest extends IntegrationTestCase
         $this->assertNotNull($user, "User should exist in database");
         $this->assertEquals($this->testUserId, $user->id, "User ID should match");
     }
-
-    // =========================================================================
-    // Logging Tests
-    // =========================================================================
-
-    /**
-     * Test that security violations are logged
-     * Unauthorized access attempts should create audit log entries
-     */
-    public function testSecurityViolationsAreLogged(): void
-    {
-        // This test validates that security errors trigger logging
-        // Expected: UserSpice logger entries for SecurityError category
-
-        $this->assertTrue(true, 'Security logging validation placeholder');
-    }
-
-    /**
-     * Test that database errors are logged
-     * Query failures should create audit log entries
-     */
-    public function testDatabaseErrorsAreLogged(): void
-    {
-        // This test validates that database errors trigger logging
-        // Expected: UserSpice logger entries for DatabaseError category
-
-        $this->assertTrue(true, 'Error logging validation placeholder');
-    }
-
-    /**
-     * Test that successful read operations don't create unnecessary logs
-     * Successful car/user lookups should not log (read-only operations)
-     */
-    public function testSuccessfulReadOperationsNotLogged(): void
-    {
-        // This test validates that successful reads don't clutter the audit log
-        // Expected: No log entry for successful read-only operations
-
-        $this->assertTrue(true, 'Read operation logging validation placeholder');
-    }
 }
-?>

--- a/tests/integration/AdminAjaxEndpointsTest.php
+++ b/tests/integration/AdminAjaxEndpointsTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 require_once __DIR__ . '/IntegrationTestCase.php';
 
 /**
- * Integration tests for Admin AJAX endpoints
+ * Integration tests for Admin AJAX endpoint data
  *
- * Tests process-car-details.php and process-user-details.php
- * Validates ApiResponse pattern implementation, security checks, and error handling
+ * Verifies the car/user data process-car-details.php and process-user-details.php
+ * read from the database: existence, required fields, and consistency with what
+ * was inserted.
  */
 class AdminAjaxEndpointsTest extends IntegrationTestCase
 {
@@ -15,7 +16,7 @@ class AdminAjaxEndpointsTest extends IntegrationTestCase
     private $testUserId;
 
     /**
-     * Set up test database connection and find test data
+     * Create a fixture user and car for the tests to query
      */
     protected function setUp(): void
     {

--- a/tests/integration/CarDataTablesTest.php
+++ b/tests/integration/CarDataTablesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use ElanRegistry\Car\Car;
 use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\CarValidationException;
 use PHPUnit\Framework\Attributes\Group;

--- a/tests/integration/CarDeletionTest.php
+++ b/tests/integration/CarDeletionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use ElanRegistry\Car\Car;
 use ElanRegistry\Exceptions\CarDeletionException;
 use ElanRegistry\Exceptions\CarNotFoundException;
 
@@ -19,16 +20,19 @@ use PHPUnit\Framework\Attributes\Group;
 final class CarDeletionTest extends IntegrationTestCase
 {
     private $testCarId;
+    private $testUserId;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->requireDatabase();
 
+        $this->testUserId = $this->createTestUser();
+
         // Set up authenticated user context for deletion operations
         global $user;
         $user = new User();
-        $user->find(1);  // Load user ID 1
+        $user->find($this->testUserId);
 
         // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
         // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
@@ -40,7 +44,7 @@ final class CarDeletionTest extends IntegrationTestCase
 
         // Create unique test car for this test
         try {
-            $this->testCarId = $this->createTestCar(1, [
+            $this->testCarId = $this->createTestCar($this->testUserId, [
                 'chassis' => 'DEL' . uniqid()
             ]);
         } catch (RuntimeException $e) {
@@ -58,7 +62,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->assertTrue($car->exists());
 
         $token = Token::generate();
-        $result = $car->delete('Test deletion', $token, 1);
+        $result = $car->delete('Test deletion', $token, $this->testUserId);
 
         $this->assertTrue($result);
         $this->assertFalse($car->exists());
@@ -73,7 +77,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->expectException(CarDeletionException::class);
 
         $car = new Car($this->testCarId);
-        $car->delete('Test deletion', 'invalid-token-12345', 1);
+        $car->delete('Test deletion', 'invalid-token-12345', $this->testUserId);
     }
 
     /**
@@ -85,7 +89,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->expectException(CarDeletionException::class);
 
         $car = new Car($this->testCarId);
-        $car->delete('Test deletion', '', 1);
+        $car->delete('Test deletion', '', $this->testUserId);
     }
 
     /**
@@ -97,7 +101,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->expectException(CarNotFoundException::class);
 
         $car = new Car(99999);
-        $car->delete('Test deletion', Token::generate(), 1);
+        $car->delete('Test deletion', Token::generate(), $this->testUserId);
     }
 
     /**
@@ -112,7 +116,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $car = new Car($this->testCarId);
         $carId = $car->data()->id;
 
-        $result = $car->delete('Test deletion for audit', Token::generate(), 1);
+        $result = $car->delete('Test deletion for audit', Token::generate(), $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -135,7 +139,7 @@ final class CarDeletionTest extends IntegrationTestCase
     {
         // First deletion — must succeed
         $car = new Car($this->testCarId);
-        $car->delete('First deletion', Token::generate(), 1);
+        $car->delete('First deletion', Token::generate(), $this->testUserId);
 
         // tearDown will attempt to clean up $this->testCarId; if the car is
         // already gone the cleanup silently ignores the missing row.
@@ -143,7 +147,7 @@ final class CarDeletionTest extends IntegrationTestCase
         // Second deletion on the same ID — car no longer exists
         $this->expectException(CarNotFoundException::class);
         $car2 = new Car($this->testCarId);
-        $car2->delete('Second deletion', Token::generate(), 1);
+        $car2->delete('Second deletion', Token::generate(), $this->testUserId);
     }
 
     /**
@@ -153,13 +157,16 @@ final class CarDeletionTest extends IntegrationTestCase
     #[Group('fast')]
     public function testDeleteHonorsExplicitActingUserIdWithoutGlobalUser(): void
     {
+        // Car::__construct() needs a global $user (via getSettings()), so construct before
+        // unsetting it — only delete() itself must not fall back to a global $user internally.
+        $car = new Car($this->testCarId);
+
         $savedUser = $GLOBALS['user'] ?? null;
         unset($GLOBALS['user']);
 
         try {
-            $car = new Car($this->testCarId);
             $token = Token::generate();
-            $result = $car->delete('Explicit actingUserId test', $token, 1);
+            $result = $car->delete('Explicit actingUserId test', $token, $this->testUserId);
             $this->assertTrue($result);
         } finally {
             if ($savedUser !== null) {

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use ElanRegistry\Car\Car;
 use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\CarNotFoundException;
 use ElanRegistry\Exceptions\CarValidationException;
@@ -21,16 +22,19 @@ final class CarMergeTest extends IntegrationTestCase
 {
     private $testCarId;
     private $testMergeCarId;
+    private $testUserId;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->requireDatabase();
 
+        $this->testUserId = $this->createTestUser();
+
         // Set up authenticated user context for merge operations
         global $user;
         $user = new User();
-        $user->find(1);  // Load user ID 1
+        $user->find($this->testUserId);
 
         // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
         // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
@@ -42,10 +46,10 @@ final class CarMergeTest extends IntegrationTestCase
 
         // Create unique test cars for this test
         try {
-            $this->testCarId = $this->createTestCar(1, [
+            $this->testCarId = $this->createTestCar($this->testUserId, [
                 'chassis' => 'MG' . uniqid()
             ]);
-            $this->testMergeCarId = $this->createTestCar(1, [
+            $this->testMergeCarId = $this->createTestCar($this->testUserId, [
                 'chassis' => 'MG' . uniqid()
             ]);
         } catch (RuntimeException $e) {
@@ -60,7 +64,7 @@ final class CarMergeTest extends IntegrationTestCase
     public function testMergeCarSuccessWithValidOldCar(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->merge($this->testMergeCarId, 'Test merge success', 1);
+        $result = $car->merge($this->testMergeCarId, 'Test merge success', $this->testUserId);
 
         $this->assertTrue($result);
     }
@@ -74,7 +78,7 @@ final class CarMergeTest extends IntegrationTestCase
         $this->expectException(CarNotFoundException::class);
 
         $car = new Car(99999);
-        $car->merge($this->testMergeCarId, 'Test merge', 1);
+        $car->merge($this->testMergeCarId, 'Test merge', $this->testUserId);
     }
 
     /**
@@ -86,7 +90,7 @@ final class CarMergeTest extends IntegrationTestCase
         $this->expectException(CarNotFoundException::class);
 
         $car = new Car($this->testCarId);
-        $car->merge(99999, 'Test merge', 1);
+        $car->merge(99999, 'Test merge', $this->testUserId);
     }
 
     /**
@@ -98,7 +102,7 @@ final class CarMergeTest extends IntegrationTestCase
         $this->expectException(CarValidationException::class);
 
         $car = new Car($this->testCarId);
-        $car->merge($this->testCarId, 'Test merge', 1);
+        $car->merge($this->testCarId, 'Test merge', $this->testUserId);
     }
 
     /**
@@ -108,7 +112,7 @@ final class CarMergeTest extends IntegrationTestCase
     public function testMergeTransfersHistoryRecords(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->merge($this->testMergeCarId, 'Test merge history transfer', 1);
+        $result = $car->merge($this->testMergeCarId, 'Test merge history transfer', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -129,7 +133,7 @@ final class CarMergeTest extends IntegrationTestCase
         $oldCarId = $this->testMergeCarId;
 
         $car = new Car($this->testCarId);
-        $result = $car->merge($oldCarId, 'Test merge deletes old car', 1);
+        $result = $car->merge($oldCarId, 'Test merge deletes old car', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -145,7 +149,7 @@ final class CarMergeTest extends IntegrationTestCase
     public function testMergeCreatesAuditTrail(): void
     {
         $car = new Car($this->testCarId);
-        $result = $car->merge($this->testMergeCarId, 'Test merge audit trail', 1);
+        $result = $car->merge($this->testMergeCarId, 'Test merge audit trail', $this->testUserId);
 
         $this->assertTrue($result);
 
@@ -169,7 +173,7 @@ final class CarMergeTest extends IntegrationTestCase
 
         try {
             // Attempt to merge non-existent car
-            $car->merge(99999, 'Test merge', 1);
+            $car->merge(99999, 'Test merge', $this->testUserId);
         } catch (CarNotFoundException $e) {
             // After failed merge, original car should still exist
             $carReloaded = new Car((int) $car->data()->id);
@@ -195,7 +199,7 @@ final class CarMergeTest extends IntegrationTestCase
         // The target car still exists; the source is gone — merge must throw
         $this->expectException(CarNotFoundException::class);
         $car = new Car($this->testCarId);
-        $car->merge($this->testMergeCarId, 'Test merge after source deletion', 1);
+        $car->merge($this->testMergeCarId, 'Test merge after source deletion', $this->testUserId);
     }
 
     /**
@@ -297,12 +301,15 @@ final class CarMergeTest extends IntegrationTestCase
     #[Group('fast')]
     public function testMergeHonorsExplicitActingUserIdWithoutGlobalUser(): void
     {
+        // Car::__construct() needs a global $user (via getSettings()), so construct before
+        // unsetting it — only merge() itself must not fall back to a global $user internally.
+        $car = new Car($this->testCarId);
+
         $savedUser = $GLOBALS['user'] ?? null;
         unset($GLOBALS['user']);
 
         try {
-            $car = new Car($this->testCarId);
-            $result = $car->merge($this->testMergeCarId, 'Explicit actingUserId test', 1);
+            $result = $car->merge($this->testMergeCarId, 'Explicit actingUserId test', $this->testUserId);
             $this->assertTrue($result);
         } finally {
             if ($savedUser !== null) {

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use ElanRegistry\Car\Car;
 use ElanRegistry\Owner;
 
 use PHPUnit\Framework\Attributes\Group;
@@ -27,10 +28,13 @@ final class CarTransferTest extends IntegrationTestCase
         parent::setUp();
         $this->requireDatabase();
 
+        $this->testUserId = $this->createTestUser();
+        $this->targetUserId = $this->createTestUser();
+
         // Set up authenticated user context for transfer operations
         global $user;
         $user = new User();
-        $user->find(1);  // Load user ID 1
+        $user->find($this->testUserId);
 
         // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
         // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
@@ -40,9 +44,17 @@ final class CarTransferTest extends IntegrationTestCase
 
         $GLOBALS['user'] = $user;
 
-        $this->testUserId = 1;
-        $this->targetUserId = 10;  // Use existing user ID (FredHansen)
         $this->db = DB::getInstance();
+
+        // city/state/country/lat/lon live on `profiles`, not `users` — createTestUser() only
+        // writes `users`. Give the transfer target real location data so
+        // testTransferUpdatesLocationData verifies an actual copy instead of comparing '' === ''.
+        $this->db->insert('profiles', [
+            'user_id' => $this->targetUserId,
+            'city'    => 'Hethel',
+            'state'   => 'Norfolk',
+            'country' => 'United Kingdom',
+        ]);
 
         // Create unique test car for this test
         try {
@@ -56,6 +68,9 @@ final class CarTransferTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
+        if ($this->databaseConnected && $this->targetUserId) {
+            $this->db->query("DELETE FROM profiles WHERE user_id = ?", [$this->targetUserId]);
+        }
         parent::tearDown();
     }
 
@@ -243,11 +258,14 @@ final class CarTransferTest extends IntegrationTestCase
     #[Group('fast')]
     public function testTransferHonorsExplicitActingUserIdWithoutGlobalUser(): void
     {
+        // Car::__construct() needs a global $user (via getSettings()), so construct before
+        // unsetting it — only transfer() itself must not fall back to a global $user internally.
+        $car = new Car($this->testCarId);
+
         $savedUser = $GLOBALS['user'] ?? null;
         unset($GLOBALS['user']);
 
         try {
-            $car = new Car($this->testCarId);
             $result = $car->transfer($this->targetUserId, 'Explicit actingUserId test', 'NEWOWNER', $this->testUserId);
             $this->assertTrue($result);
         } finally {

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -49,12 +49,15 @@ final class CarTransferTest extends IntegrationTestCase
         // city/state/country/lat/lon live on `profiles`, not `users` — createTestUser() only
         // writes `users`. Give the transfer target real location data so
         // testTransferUpdatesLocationData verifies an actual copy instead of comparing '' === ''.
-        $this->db->insert('profiles', [
+        // If this insert silently failed, the test would go right back to comparing '' === ''
+        // with no signal — so check it explicitly rather than let a failure hide.
+        $profileInserted = $this->db->insert('profiles', [
             'user_id' => $this->targetUserId,
             'city'    => 'Hethel',
             'state'   => 'Norfolk',
             'country' => 'United Kingdom',
         ]);
+        $this->assertTrue((bool) $profileInserted, 'Test fixture: profiles insert must succeed');
 
         // Create unique test car for this test
         try {

--- a/tests/integration/CarVerificationTest.php
+++ b/tests/integration/CarVerificationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use ElanRegistry\Car\Car;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -16,6 +17,7 @@ use PHPUnit\Framework\Attributes\Group;
 final class CarVerificationTest extends IntegrationTestCase
 {
     private $testCarId;
+    private $testUserId;
     protected $db;
 
     protected function setUp(): void
@@ -25,9 +27,11 @@ final class CarVerificationTest extends IntegrationTestCase
 
         $this->db = DB::getInstance();
 
+        $this->testUserId = $this->createTestUser();
+
         // Create unique test car for this test
         try {
-            $this->testCarId = $this->createTestCar(1, [
+            $this->testCarId = $this->createTestCar($this->testUserId, [
                 'chassis' => 'VF' . uniqid()
             ]);
         } catch (RuntimeException $e) {

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -84,7 +84,10 @@ abstract class IntegrationTestCase extends TestCase
                     $this->db->delete('cars', ['id', '=', $carId]);
                     $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
                 } catch (RuntimeException $e) {
-                    // Ignore cleanup errors
+                    // Don't fail the test over cleanup, but a silent swallow here means the
+                    // fixture row survives into the next test run with no trace of why —
+                    // log it so a polluted test schema is diagnosable.
+                    fwrite(STDERR, "NOTE: tearDown() cleanup failed for car ID {$carId}: {$e->getMessage()}\n");
                 }
             }
 
@@ -93,7 +96,7 @@ abstract class IntegrationTestCase extends TestCase
                 try {
                     $this->db->delete('users', ['id', '=', $userId]);
                 } catch (RuntimeException $e) {
-                    // Ignore cleanup errors
+                    fwrite(STDERR, "NOTE: tearDown() cleanup failed for user ID {$userId}: {$e->getMessage()}\n");
                 }
             }
         }
@@ -230,6 +233,7 @@ abstract class IntegrationTestCase extends TestCase
             $this->createdUserIds = array_values(array_diff($this->createdUserIds, [$userId]));
             return true;
         } catch (RuntimeException $e) {
+            fwrite(STDERR, "NOTE: deleteTestUser() failed for user ID {$userId}: {$e->getMessage()}\n");
             return false;
         }
     }
@@ -256,6 +260,7 @@ abstract class IntegrationTestCase extends TestCase
             $this->createdCarIds = array_values(array_diff($this->createdCarIds, [$carId]));
             return true;
         } catch (RuntimeException $e) {
+            fwrite(STDERR, "NOTE: deleteTestCar() failed for car ID {$carId}: {$e->getMessage()}\n");
             return false;
         }
     }

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -74,12 +74,15 @@ abstract class IntegrationTestCase extends TestCase
     protected function tearDown(): void
     {
         if ($this->databaseConnected) {
-            // Delete cars first (may depend on foreign key constraints)
+            // Delete cars first (may depend on foreign key constraints). cars_hist is deleted
+            // AFTER cars, not before — the cars_delete trigger inserts a DELETE-operation history
+            // row when the car row is removed, so deleting cars_hist first just leaves that
+            // trigger-inserted row orphaned forever.
             foreach ($this->createdCarIds as $carId) {
                 try {
                     $this->db->query("DELETE FROM car_transfer_requests WHERE existing_car_id = ?", [$carId]);
-                    $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
                     $this->db->delete('cars', ['id', '=', $carId]);
+                    $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
                 } catch (RuntimeException $e) {
                     // Ignore cleanup errors
                 }

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -247,8 +247,11 @@ abstract class IntegrationTestCase extends TestCase
         }
 
         try {
-            $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
+            // cars_hist is deleted AFTER cars, not before — the cars_delete trigger inserts a
+            // DELETE-operation history row when the car row is removed, so deleting cars_hist
+            // first just leaves that trigger-inserted row orphaned forever (same fix as tearDown()).
             $this->db->delete('cars', ['id', '=', $carId]);
+            $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
             // Remove from tracking so tearDown doesn't double-delete
             $this->createdCarIds = array_values(array_diff($this->createdCarIds, [$carId]));
             return true;

--- a/tests/integration/ManageConsolidatedDeletionTest.php
+++ b/tests/integration/ManageConsolidatedDeletionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/IntegrationTestCase.php';
 
+use ElanRegistry\Car\Car;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -35,10 +36,12 @@ final class ManageConsolidatedDeletionTest extends IntegrationTestCase
         parent::setUp();
         $this->requireDatabase();
 
+        $this->testUserId = $this->createTestUser();
+
         // Set up authenticated user context required by Car::delete()
         global $user;
         $user = new User();
-        $user->find(1);
+        $user->find($this->testUserId);
 
         // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
         // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
@@ -47,7 +50,6 @@ final class ManageConsolidatedDeletionTest extends IntegrationTestCase
         $isLoggedInProperty->setValue($user, true);
 
         $GLOBALS['user'] = $user;
-        $this->testUserId = 1;
 
         try {
             $this->testCarId = $this->createTestCar($this->testUserId, [

--- a/tests/integration/OwnerIntegrationTest.php
+++ b/tests/integration/OwnerIntegrationTest.php
@@ -24,10 +24,9 @@ class OwnerIntegrationTest extends IntegrationTestCase
      */
     public function testFindWithValidUser(): void
     {
-        // Use user ID 1 for testing
-        $userId = 1;
+        $userId = $this->createTestUser();
         $owner = new Owner();
-        $result = $owner->find((int)$userId);
+        $result = $owner->find($userId);
 
         $this->assertTrue($result);
         $this->assertNotNull($owner->data());
@@ -39,9 +38,9 @@ class OwnerIntegrationTest extends IntegrationTestCase
      */
     public function testGetCarsOwned(): void
     {
-        // Use user ID 1 for testing
-        $userId = 1;
-        $owner = new Owner((int)$userId);
+        $userId = $this->createTestUser();
+        $this->createTestCar($userId);
+        $owner = new Owner($userId);
 
         $ownedCars = $owner->getCarsOwned();
         $this->assertIsArray($ownedCars);

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -21,20 +21,20 @@ class StatisticsApiTest extends IntegrationTestCase
     private $testUserId;
 
     /**
-     * Set up test database connection and find test data
+     * Set up test database connection and create test fixture data
      */
     protected function setUp(): void
     {
         parent::setUp();
         $this->requireDatabase();
 
-        // Find test car data
-        $car = $this->db->query("SELECT id FROM cars LIMIT 1")->first();
-        $this->testCarId = $car ? $car->id : null;
-
-        // Find test user data
-        $user = $this->db->query("SELECT id FROM users WHERE active = 1 LIMIT 1")->first();
-        $this->testUserId = $user ? $user->id : null;
+        // Create the fixture the statistics assertions rely on, so registry-wide
+        // aggregate queries are true by construction rather than by ambient data.
+        $this->testUserId = $this->createTestUser();
+        $this->testCarId = $this->createTestCar($this->testUserId, [
+            'country' => 'United States',
+            'state'   => 'California',
+        ]);
     }
 
     // =========================================================================
@@ -64,13 +64,16 @@ class StatisticsApiTest extends IntegrationTestCase
     public function testGeographicTabCountryDistribution(): void
     {
 
-        // Verify country distribution data can be retrieved
+        // Verify country distribution data reflects the fixture car created in setUp()
         $results = $this->db->query(
             "SELECT country, COUNT(*) as count FROM cars
              WHERE country IS NOT NULL AND country != ''
              GROUP BY country ORDER BY count DESC"
         )->results();
         $this->assertNotEmpty($results, "Should have country distribution data");
+
+        $countries = array_map(static fn($row) => $row->country, $results);
+        $this->assertContains('United States', $countries, "Fixture car's country must appear in the distribution");
     }
 
     /**

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -82,14 +82,16 @@ class StatisticsApiTest extends IntegrationTestCase
     public function testGeographicTabUsStateDistribution(): void
     {
 
-        // Verify US state distribution data exists
+        // Verify US state distribution data reflects the fixture car created in setUp()
         $results = $this->db->query(
             "SELECT state, COUNT(*) as count FROM cars
              WHERE country = 'United States' AND state IS NOT NULL AND state != ''
              GROUP BY state ORDER BY count DESC"
         )->results();
-        // May be empty if no US cars, but query should work
-        $this->assertIsArray($results, "Should be able to query US states");
+        $this->assertNotEmpty($results, "Should have US state distribution data");
+
+        $states = array_map(static fn($row) => $row->state, $results);
+        $this->assertContains('California', $states, "Fixture car's state must appear in the distribution");
     }
 
     // =========================================================================

--- a/tests/integration/StatisticsApiTest.php
+++ b/tests/integration/StatisticsApiTest.php
@@ -280,9 +280,6 @@ class StatisticsApiTest extends IntegrationTestCase
         $this->assertIsArray($pins);
 
         if (empty($pins)) {
-            if ($this->testUserId === null) {
-                $this->markTestSkipped('No users in test DB — cannot create fixture car for getMapPins() test');
-            }
             $this->createTestCar($this->testUserId, ['lat' => '51.5074', 'lon' => '-0.1278']);
             $pins = $service->getMapPins();
         }

--- a/tests/integration/database/CarDatabaseOperationsTest.php
+++ b/tests/integration/database/CarDatabaseOperationsTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
  * triggers, and audit trails. These tests verify that the database layer
  * works correctly with the Car class.
  *
- * Uses real database fixtures (user ID 1, car IDs 1-2).
+ * Uses fixtures created via IntegrationTestCase::createTestUser()/createTestCar().
  */
 #[Group('integration')]
 final class CarDatabaseOperationsTest extends IntegrationTestCase
@@ -28,10 +28,12 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
         parent::setUp();
         $this->requireDatabase();
 
+        $this->testUserId = $this->createTestUser();
+
         // Set up authenticated user context for tests
         global $user;
         $user = new User();
-        $user->find(1);  // Load user ID 1
+        $user->find($this->testUserId);
 
         // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
         // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
@@ -40,8 +42,6 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
         $isLoggedInProperty->setValue($user, true);
 
         $GLOBALS['user'] = $user;
-
-        $this->testUserId = 1;
 
         // Create unique test car for this test
         try {
@@ -163,7 +163,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
     public function testCarTransferUpdatesRelationships(): void
     {
         $car = new Car($this->testCarId);
-        $targetUserId = 10;  // Use existing user ID (FredHansen)
+        $targetUserId = $this->createTestUser();
 
         // Verify original owner
         $origRelation = $this->db->query(
@@ -192,9 +192,9 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
     public function testCarTransferCreatesHistoryRecord(): void
     {
         $car = new Car($this->testCarId);
+        $targetUserId = $this->createTestUser();
 
-        // Transfer car to existing user ID 10 (FredHansen)
-        $result = $car->transfer(10, 'Integration test transfer history', 'NEWOWNER', $this->testUserId);
+        $result = $car->transfer($targetUserId, 'Integration test transfer history', 'NEWOWNER', $this->testUserId);
 
         $this->assertTrue($result);
 

--- a/tests/integration/database/CarsYearSmallintMigrationTest.php
+++ b/tests/integration/database/CarsYearSmallintMigrationTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('migration')]
 final class CarsYearSmallintMigrationTest extends IntegrationTestCase
 {
-    private int $testUserId = 1;
+    private int $testUserId;
 
     /** Car IDs created by individual tests that need early cleanup (e.g. DELETE tests). */
     private array $localCarIds = [];
@@ -51,6 +51,8 @@ final class CarsYearSmallintMigrationTest extends IntegrationTestCase
                 'Run: composer migrate'
             );
         }
+
+        $this->testUserId = $this->createTestUser();
 
         // Mirror the authenticated-user context required by Car::update() / Car::delete().
         global $user;

--- a/tests/integration/database/ChassisOverridePersistenceTest.php
+++ b/tests/integration/database/ChassisOverridePersistenceTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('chassis-override')]
 final class ChassisOverridePersistenceTest extends IntegrationTestCase
 {
-    private int $testUserId = 1;
+    private int $testUserId;
 
     protected function setUp(): void
     {
@@ -48,6 +48,8 @@ final class ChassisOverridePersistenceTest extends IntegrationTestCase
                 'chassis_override column not yet available — run fix script 07-Chassis-Override-Schema-Backfill.php'
             );
         }
+
+        $this->testUserId = $this->createTestUser();
 
         // Set up an authenticated user context (mirrors CarDatabaseOperationsTest pattern).
         // Bypass login() to set the private $_isLoggedIn flag directly via reflection.

--- a/tests/integration/database/DatabaseConnectionTest.php
+++ b/tests/integration/database/DatabaseConnectionTest.php
@@ -79,9 +79,10 @@ final class DatabaseConnectionTest extends IntegrationTestCase
     {
         $this->requireDatabase();
 
-        $result = $this->db->query("SELECT id, username, email FROM users LIMIT 1");
+        $userId = $this->createTestUser();
+        $result = $this->db->query("SELECT id, username, email FROM users WHERE id = ?", [$userId]);
 
-        $this->assertGreaterThan(0, $result->count(), "Should have users in database");
+        $this->assertSame(1, $result->count(), "Fixture user should be retrievable by ID");
 
         $user = $result->first();
         $this->assertNotNull($user->id, "User should have an ID");
@@ -97,9 +98,11 @@ final class DatabaseConnectionTest extends IntegrationTestCase
     {
         $this->requireDatabase();
 
-        $result = $this->db->query("SELECT id, year, model, chassis FROM cars LIMIT 1");
+        $userId = $this->createTestUser();
+        $carId = $this->createTestCar($userId);
+        $result = $this->db->query("SELECT id, year, model, chassis FROM cars WHERE id = ?", [$carId]);
 
-        $this->assertGreaterThan(0, $result->count(), "Should have cars in database");
+        $this->assertSame(1, $result->count(), "Fixture car should be retrievable by ID");
 
         $car = $result->first();
         $this->assertNotNull($car->id, "Car should have an ID");

--- a/tests/integration/transfer/CarTransferWorkflowTest.php
+++ b/tests/integration/transfer/CarTransferWorkflowTest.php
@@ -32,17 +32,9 @@ class CarTransferWorkflowTest extends IntegrationTestCase
         parent::setUp();
         $this->requireDatabase();
 
-        // Find a car and users for testing
-        $car = $this->db->query("SELECT id, user_id FROM cars LIMIT 1")->first();
-        $this->testCarId = $car ? $car->id : null;
-        $this->currentOwnerId = $car ? $car->user_id : null;
-
-        // Find a different user for transfer testing
-        $user = $this->db->query(
-            "SELECT id FROM users WHERE id != ? AND active = 1 LIMIT 1",
-            [$this->currentOwnerId]
-        )->first();
-        $this->testUserId = $user ? $user->id : null;
+        $this->currentOwnerId = $this->createTestUser();
+        $this->testCarId = $this->createTestCar($this->currentOwnerId);
+        $this->testUserId = $this->createTestUser(); // distinct transfer-target user
     }
 
     protected function tearDown(): void
@@ -234,8 +226,8 @@ class CarTransferWorkflowTest extends IntegrationTestCase
         }
 
         $requestId = $this->insertTransferRequest([
-            'existing_car_id'       => $this->testCarId ?? 1,
-            'requested_by_user_id'  => $this->testUserId ?? 1,
+            'existing_car_id'       => $this->testCarId,
+            'requested_by_user_id'  => $this->testUserId,
             'security_token'        => hash('sha256', 'test-' . time()),
             'expires_at'            => date('Y-m-d H:i:s', strtotime('+30 days')),
             'submitted_model'       => 'Test Model',
@@ -254,7 +246,7 @@ class CarTransferWorkflowTest extends IntegrationTestCase
             'submitted_state'       => 'Test State',
             'submitted_country'     => 'Test Country',
             'status'                => 'denied',
-            'created_by'            => 1,
+            'created_by'            => $this->testUserId,
         ]);
 
         $result = $this->db->query(

--- a/usersc/classes/LocationService.php
+++ b/usersc/classes/LocationService.php
@@ -418,12 +418,10 @@ class LocationService
             if ($response === false) {
                 logger(0, LogCategories::LOG_CATEGORY_LOCATION_SERVICE,
                     'LocationService: cURL error (' . curl_errno($ch) . '): ' . curl_error($ch));
-                curl_close($ch);
                 return false;
             }
 
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            curl_close($ch);
 
             if ($httpCode !== 200) {
                 logger(0, LogCategories::LOG_CATEGORY_LOCATION_SERVICE,


### PR DESCRIPTION
## Summary

Replaces hardcoded ambient-data assumptions (hardcoded user IDs, `LIMIT 1` "grab whatever exists" lookups) across the integration test suite with real fixtures created via `IntegrationTestCase::createTestUser()`/`createTestCar()`, so the suite passes honestly against #1436's isolated, empty test schema instead of silently depending on the shared dev database's ambient data (1590+ cars, 1763+ users).

- `tests/bootstrap-integration.php`: reference-data and settings auto-load failures now `exit(1)` via a new `abortBootstrap()` helper instead of silently continuing. Added a dynamic `settings`-table auto-seeder (introspects `information_schema`, fills NOT NULL columns type-safely, layers in real ElanRegistry + security-relevant values) since the isolated schema's empty `settings` table was silently breaking `Car::__construct()` everywhere.
- 14 integration test files: hardcoded user IDs / `LIMIT 1` ambient-data lookups replaced with real fixtures.
- `AdminAjaxEndpointsTest.php`: removed 14 dead placeholder tests that only asserted `true === true`.
- `IntegrationTestCase.php`: fixed a `cars_hist` cleanup-ordering bug (in both `tearDown()` and `deleteTestCar()`) that was orphaning a trigger-inserted history row per test car.
- `usersc/classes/LocationService.php`: removed two no-op `curl_close()` calls (deprecated as of PHP 8.5, unrelated cleanup found via the deprecation this branch's `composer test:integration` run surfaced).
- `tests/README.md`: documented the fixture convention and the schema-vs-per-test data lifecycle.

**Verification:** `composer test:integration` went from 58 errors / 18 failures on the original ambient-data baseline to 2 errors / 1 failure, both confirmed pre-existing and unrelated — not caused by, and not fixed by, this PR (filed as #1547, #1548).

## Bug Escape Analysis

**Root cause:** these tests were written against the shared dev DB, which always had ambient data, so hardcoded user IDs and `LIMIT 1` lookups silently worked for years. #1436's isolated, empty test schema is what first exercised the failure paths — this PR is a direct response to that, not a new bug introduced by it.

**Testing gap:** nothing verified the integration suite's own fixture hygiene — no check that the suite passes against a genuinely empty schema.

**Prevention:** this PR's own verification (`composer test:integration` re-run against the #1436 schema) is the direct regression check. Once built, #1439 (CI integration gate, not yet started) makes this permanent by running the suite against a fresh MySQL service container on every PR. `tests/README.md`'s new "Test Data Isolation" section documents the convention so future tests don't reintroduce the pattern.

## Found in passing (filed as separate issues, not fixed here)

- **#1547** — `car_transfer_requests` FK `ON DELETE CASCADE` declared in `database/1-schema.sql` but absent from both dev and test databases (schema/migration drift).
- **#1548** — `CarUpdateRepositoryFailureTest` mocks a `CarRepository::update()` method that no longer exists — a #934 regression guard has been silently broken.
- **#1549** — `tests/setup-test-database.php` is circular (requires the bootstrap it's meant to fix).
- **#1550** — `noowner` system account not seeded in the isolated test schema.
- **#1551** — two more instances of the `cars_hist` ordering bug this PR fixed, in files outside this PR's scope.

## Review

Went through two full review passes before this PR: an initial 4-agent `/review-pr` (code-reviewer, silent-failure-hunter, comment-analyzer, pr-test-analyzer) and a follow-up deep 6-agent pass (adding security-reviewer and senior-architect) against the full accumulated diff. All Blocking and Recommendation findings from both were fixed and re-verified.

## Test plan

- [x] `composer test:integration` — 369 tests, 1552 assertions, 2 errors / 1 failure (both pre-existing, tracked separately), 0 deprecations, 0 warnings.
- [x] `php -l` on all touched files.
- [x] `vendor/bin/phpstan analyse` on all touched files — no new errors introduced (baseline pre-existing errors unaffected; `tests/` itself is outside `phpstan.neon`'s configured scope).
- [x] Pre-commit hooks passed on every commit (coding standards, markdown lint, unit tests, PHPStan).

Closes #1503

Claude-Session: https://claude.ai/code/session_018RYKgRUy5Bzdky9F5dLu77