### PR TITLE
chore: fix pre-commit known-broken group naming mismatch, remove stale test:api/test:workflow scripts

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -164,7 +164,7 @@ if [ -n "$CRITICAL_FILES" ]; then
     if [ ! -f "composer.json" ] || [ ! -d "vendor" ]; then
         echo "⚠️  Skipping: composer dependencies not installed"
     else
-        if vendor/bin/phpunit --testsuite=Unit --exclude-group broken 2>&1; then
+        if vendor/bin/phpunit --testsuite=Unit --exclude-group known-broken 2>&1; then
             echo "✅ Passed"
         else
             echo ""

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,6 @@
         "test:unit:all": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml",
         "test:integration": "@php vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml --testsuite=Integration",
         "test:database": "@php vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml tests/integration/database",
-        "test:api": "@php vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml tests/integration/api",
-        "test:workflow": "@php vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml tests/integration/workflow",
         "test:full": ["@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml", "@php vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml"],
         "test:coverage": "@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml --coverage-html=coverage",
         "test:medium": ["@php vendor/phpunit/phpunit/phpunit -c phpunit-unit.xml", "@php vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml tests/integration/database"],


### PR DESCRIPTION
## Summary

- `.githooks/pre-commit` excluded PHPUnit group `broken`; CI (`test:quick:ci`, `test:regression:ci`) and `tests/README.md` document the convention as `known-broken`. Fixed pre-commit to match.
- Removed `test:api` and `test:workflow` from `composer.json` — both pointed at `tests/integration/api` and `tests/integration/workflow`, neither of which exists anymore. No other references found in the repo.

Closes #1560

## Test plan

- [x] `composer validate` — clean (pre-existing license warning only)
- [x] No PHP files touched, so no PHPStan/phpcs impact
- [x] Pre-commit hook itself ran clean on this commit (verified `--exclude-group known-broken` executes)