### PR TITLE
docs: write TESTING_STRATEGY.md and fix CLAUDE.md staleness

### DIFF
--- a/.claude.local.md.example
+++ b/.claude.local.md.example
@@ -1,0 +1,22 @@
+# Local overrides (not committed — see .gitignore)
+
+Copy this file to `.claude.local.md` and fill in your own values:
+
+```bash
+cp .claude.local.md.example .claude.local.md
+```
+
+This file is read manually by Claude Code when `CLAUDE.md` tells it to check
+here (e.g. for the GitHub Wiki clone path) — it is not Claude Code's
+built-in auto-loaded project memory. Nothing reads it unless a prompt or a
+CLAUDE.md instruction explicitly points at it.
+
+## Wiki clone
+
+The permanent local clone of the GitHub Wiki repo (elan-registry/registry.wiki)
+lives at:
+
+/path/to/your/local/wiki/clone
+
+Always use this exact path. Never clone to /tmp/, a worktree, or any other
+temporary location — there should be one permanent clone per machine.

--- a/.claude/commands/architecture-update.md
+++ b/.claude/commands/architecture-update.md
@@ -11,14 +11,18 @@ Before any other action, create one tracking task per major step below using
 TaskCreate (pull wiki repo, codebase audit, doc split decision, parallel agent
 launches, synthesis, diagram embedding, markdownlint, commit, summary).
 
-Update the ElanRegistry architecture documentation in the local wiki repo at
-`/Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki/`. Reads the
-current wiki pages from disk, audits them against the codebase, updates all
-content, evaluates whether to split into multiple documents, adds Mermaid
-diagrams throughout, ensures all files pass lint, and commits + pushes to the
-wiki remote. All file reads and writes target the wiki repo path directly.
+Update the ElanRegistry architecture documentation in the local wiki repo.
+Reads the current wiki pages from disk, audits them against the codebase,
+updates all content, evaluates whether to split into multiple documents,
+adds Mermaid diagrams throughout, ensures all files pass lint, and commits +
+pushes to the wiki remote. All file reads and writes target the wiki repo
+path directly.
 
-**Wiki repo path:** `/Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki/`
+**Wiki repo path:** developer-specific, not committed here — read it from
+`.claude.local.md` (gitignored; see `CLAUDE.md`'s GitHub Wiki section). If
+that file doesn't exist or doesn't list a wiki clone path, stop and ask the
+user for the local path to the wiki repo before proceeding. Every
+`<wiki repo path>` placeholder below refers to this resolved path.
 **Main repo path:** `/Users/jimboone/Documents/Developer/Web/ElanRegistry/Registry/` (read-only for codebase audit)
 
 ## Available Agents
@@ -35,20 +39,26 @@ when they don't depend on each other.
 
 ## Workflow
 
-### Step 0: Pull the wiki repo to ensure it is up to date
+### Step 0: Resolve the wiki repo path
+
+Read `.claude.local.md` in the main repo root for the wiki clone path. If it
+doesn't exist or doesn't list one, stop and ask the user. Substitute the
+resolved path for every `<wiki repo path>` placeholder in the steps below.
+
+### Step 0.5: Pull the wiki repo to ensure it is up to date
 
 ```bash
-git -C /Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki pull
+git -C <wiki repo path> pull
 ```
 
 List the existing wiki pages to understand what is already there:
 
 ```bash
-ls /Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki/*.md
+ls <wiki repo path>/*.md
 ```
 
 All file reads and writes in subsequent steps use absolute paths under
-`/Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki/`.
+`<wiki repo path>/`.
 
 ### Step 1: Read the current wiki documents
 
@@ -208,7 +218,7 @@ document:
 
 - This step is performed by the orchestrating agent only.
 - Write files to their absolute paths under
-  `/Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki/`.
+  `<wiki repo path>/`.
 - Place each diagram directly below the section heading it relates to.
 - Do not modify any existing prose — only insert diagram blocks.
 - If a section already has a diagram, add new ones alongside rather than
@@ -228,7 +238,7 @@ document:
   repo:
 
   ```bash
-  markdownlint /Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki/*.md
+  markdownlint <wiki repo path>/*.md
   ```
 
 - Fix any lint errors before proceeding — do not skip or suppress warnings.
@@ -242,7 +252,7 @@ document:
 - Stage all modified and newly created `.md` files:
 
   ```bash
-  git -C /Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki add *.md
+  git -C <wiki repo path> add *.md
   ```
 
 - Write a commit message in the format:
@@ -250,13 +260,13 @@ document:
 - Commit:
 
   ```bash
-  git -C /Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki commit -m "docs: update architecture documents with diagrams $(date +%Y-%m-%d)"
+  git -C <wiki repo path> commit -m "docs: update architecture documents with diagrams $(date +%Y-%m-%d)"
   ```
 
 - Push to the wiki remote:
 
   ```bash
-  git -C /Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki push
+  git -C <wiki repo path> push
   ```
 
 ### Step 12: Report what was done

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ElanRegistry.code-workspace
 !.claude/commands/
 !.claude/agents/
 !.claude/settings.json
+.claude.local.md
 
 ########################################
 # Operating System Files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,10 @@ See [DEPLOYMENT.md](docs/development/DEPLOYMENT.md) for complete procedures. **C
 
 The wiki is a **separate git repository**, cloned once at a permanent local
 path outside this repo. That path is developer-specific (not committed here
-— see `.claude.local.md`, gitignored).
+— see `.claude.local.md`, gitignored; copy `.claude.local.md.example` to set
+it up). Note this is a plain reference file Claude Code reads on demand when
+a prompt or instruction like this one points at it — it is not Claude Code's
+built-in auto-loaded project memory.
 
 **CRITICAL:** ALWAYS use that one permanent clone. NEVER clone to `/tmp/`, a
 worktree, or any other temporary location.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ working with code in this repository.
 - `docs/development/UI_STANDARDS.md` - **UI component standards** (color tokens, card hierarchy, component patterns) — read before any UI change
 - `docs/development/EMAIL_SYSTEM.md` - Brevo email plugin setup and configuration
 - `docs/development/CODING_STANDARDS.md` - Code quality requirements
+- `docs/development/TESTING_STRATEGY.md` - Testing tier architecture and UserSpice DB conventions
 - `docs/development/QUICK_REFERENCE.md` - Common tasks lookup
 - `docs/development/DEPLOYMENT.md` - Production deployment procedures
 - `docs/development/ENVIRONMENT.md` - Environment setup and configuration
@@ -308,6 +309,7 @@ and architecture agents.
 /architecture-update — Full wiki architecture documentation refresh
 /revise-claude-md    — Update CLAUDE.md with session learnings
 /clean_gone          — Delete local branches removed from remote
+/found               — Capture a pre-existing issue found mid-task; classify and file or fix
 ```
 
 ### Release Notes
@@ -343,21 +345,20 @@ See [DEPLOYMENT.md](docs/development/DEPLOYMENT.md) for complete procedures. **C
 
 ## GitHub Wiki
 
-The wiki is a **separate git repository** at the permanent path:
+The wiki is a **separate git repository**, cloned once at a permanent local
+path outside this repo. That path is developer-specific (not committed here
+— see `.claude.local.md`, gitignored).
 
-```text
-/Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki
-```
+**CRITICAL:** ALWAYS use that one permanent clone. NEVER clone to `/tmp/`, a
+worktree, or any other temporary location.
 
-**CRITICAL:** ALWAYS use this exact path. NEVER clone to `/tmp/`, a worktree,
-or any other temporary location — there is one permanent clone and it is the
-only place to use.
-
-To update the live wiki after editing files in `wiki/` on a branch:
+To update the live wiki, edit files directly in that clone (path in
+`.claude.local.md`):
 
 ```bash
-cp wiki/<file>.md /Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki/
-cd /Users/jimboone/Documents/Developer/Web/ElanRegistry/Wiki
+cd <your wiki clone path>
+git pull
+# edit <file>.md directly in this clone
 git add <file>.md
 git commit -m "docs: <description>"
 git push

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ project, structured for different audiences and use cases.
 - **[DATABASE.md](development/DATABASE.md)** - Complete database schema and table relationships
 - **[UserSpice Integration Guide][us-wiki]** - UserSpice integration and custom functions
 - **[CODING_STANDARDS.md](development/CODING_STANDARDS.md)** - Code quality requirements and project conventions
+- **[TESTING_STRATEGY.md](development/TESTING_STRATEGY.md)** - Testing tier architecture and UserSpice DB conventions
 - **[STRICT_TYPE_HANDLING.md](development/STRICT_TYPE_HANDLING.md)** - PHP strict type handling patterns
 
 #### 🔧 SPECIALIZED TOPICS

--- a/docs/development/ENVIRONMENT.md
+++ b/docs/development/ENVIRONMENT.md
@@ -167,6 +167,17 @@ internally, setting the `X-Forwarded-Proto: https` header so `$is_https` is
    composer test:integration
    ```
 
+5. **Set Up Claude Code Local Overrides (optional)**:
+
+   Personal/machine-specific paths that Claude Code needs (e.g. the local
+   GitHub Wiki clone path — see `CLAUDE.md`'s GitHub Wiki section) go in
+   `.claude.local.md`, gitignored and not shared with the team.
+
+   ```bash
+   cp .claude.local.md.example .claude.local.md
+   # Edit with your own local paths
+   ```
+
 ### Test Database Isolation
 
 Integration tests are **destructive** — they insert, update, delete, and merge real database

--- a/docs/development/TESTING_STRATEGY.md
+++ b/docs/development/TESTING_STRATEGY.md
@@ -19,7 +19,10 @@ Three tiers, each with a distinct purpose and a hard boundary:
   not the application). Mocking third-party/framework boundaries (like
   UserSpice's `DB` class itself) is fine when the goal is isolating your own
   code's logic from a real database — the anti-pattern is mocking *your own*
-  classes.
+  classes. This is the target convention, not yet the current state: legacy
+  mocks of `CarModel`/`Car`/`DB` still exist in `tests/unit/` and are
+  documented as such in `tests/README.md` — tracked for removal in #1440 and
+  #1441. Don't add new tests against those mocks; test the real class.
 - **Integration (`tests/integration/`)** — real database, real UserSpice
   framework. Every test creates the fixtures it depends on
   (`IntegrationTestCase::createTestUser()` / `createTestCar()`) and cleans
@@ -31,10 +34,19 @@ Three tiers, each with a distinct purpose and a hard boundary:
   coverage of business logic — browser tests are expensive and should stay
   narrow.
 
-`tests/regression/` is **not** a fourth tier — it's a `#[Group('regression')]`
-tag applied to tests that live in whichever tier fits them, run via
-`composer test:regression`. Treat "which tier" and "is it regression-tagged"
-as orthogonal questions.
+`tests/regression/` is **not** a fourth tier in the unit/integration/E2E
+sense — it's orthogonal in intent, tracking "was this specific bug fixed"
+rather than a class or flow. But mechanically it runs entirely under the
+unit bootstrap: `phpunit-unit.xml` scopes the `Regression` testsuite to the
+`tests/regression/` directory (directory-based, not a `#[Group]` tag), and
+that directory loads via `tests/bootstrap-unit.php` — mocks only, no
+database, same as `tests/unit/`. A regression test that needs a real
+database has to live in `tests/integration/` instead; it isn't a `composer
+test:regression` test. A new mock-compatible regression test belongs in
+`tests/regression/` (copy
+`RegressionTestTemplate.php`, see `tests/regression/README.md`) — a
+`#[Group('regression')]` attribute alone on a test living elsewhere will
+**not** be picked up by `composer test:regression`.
 
 ## UserSpice `DB` Class Conventions
 

--- a/docs/development/TESTING_STRATEGY.md
+++ b/docs/development/TESTING_STRATEGY.md
@@ -21,8 +21,9 @@ Three tiers, each with a distinct purpose and a hard boundary:
   code's logic from a real database — the anti-pattern is mocking *your own*
   classes. This is the target convention, not yet the current state: legacy
   mocks of `CarModel`/`Car`/`DB` still exist in `tests/unit/` and are
-  documented as such in `tests/README.md` — tracked for removal in #1440 and
-  #1441. Don't add new tests against those mocks; test the real class.
+  documented as such in `tests/README.md`. Their removal is tracked
+  separately in #1440 and #1441. Don't add new tests against those mocks;
+  test the real class.
 - **Integration (`tests/integration/`)** — real database, real UserSpice
   framework. Every test creates the fixtures it depends on
   (`IntegrationTestCase::createTestUser()` / `createTestCar()`) and cleans

--- a/docs/development/TESTING_STRATEGY.md
+++ b/docs/development/TESTING_STRATEGY.md
@@ -1,0 +1,87 @@
+# Testing Strategy
+
+This document covers **why** the test suite is organized the way it is and
+the UserSpice-specific behaviors that any new test needs to account for.
+For **how** to run or write tests — commands, directory layout, fixture
+helpers, troubleshooting — see [`tests/README.md`](../../tests/README.md)
+and [`docs/testing/TESTING.md`](../testing/TESTING.md) (Playwright specifics:
+[`docs/testing/PLAYWRIGHT_E2E.md`](../testing/PLAYWRIGHT_E2E.md)). This doc
+doesn't repeat that material — it's the single place that documents the
+*rules*, not the commands.
+
+## Tier Architecture
+
+Three tiers, each with a distinct purpose and a hard boundary:
+
+- **Unit (`tests/unit/`)** — fast, no database. Test real application
+  classes with real logic; never write a hand-rolled mock/reimplementation of
+  your own project code (a mock `DB`, mock `CarModel`, etc. tests the mock,
+  not the application). Mocking third-party/framework boundaries (like
+  UserSpice's `DB` class itself) is fine when the goal is isolating your own
+  code's logic from a real database — the anti-pattern is mocking *your own*
+  classes.
+- **Integration (`tests/integration/`)** — real database, real UserSpice
+  framework. Every test creates the fixtures it depends on
+  (`IntegrationTestCase::createTestUser()` / `createTestCar()`) and cleans
+  them up in `tearDown()`. Never assume ambient data exists — see
+  `tests/README.md`'s "Test Data Isolation" section for the do/don't
+  examples.
+- **Browser/E2E (`tests/playwright/`)** — golden paths and security-critical
+  flows only (CSRF, auth, XSS). Not a substitute for unit/integration
+  coverage of business logic — browser tests are expensive and should stay
+  narrow.
+
+`tests/regression/` is **not** a fourth tier — it's a `#[Group('regression')]`
+tag applied to tests that live in whichever tier fits them, run via
+`composer test:regression`. Treat "which tier" and "is it regression-tagged"
+as orthogonal questions.
+
+## UserSpice `DB` Class Conventions
+
+UserSpice ships no test suite and no testing conventions of its own — the
+following is derived directly from reading `users/classes/DB.php` (upstream,
+do not modify — see `CLAUDE.md`'s Template Customization Rules), not from
+UserSpice documentation. This is the source of truth for how to write
+assertions against it.
+
+- **Connection failures kill the request.** `DB::__construct()` catches
+  `PDOException` on connect and calls `die("Could not connect to database...")`
+  (uncatchable, no exception propagates). There is no framework-native way to
+  intercept or test the first-connection-fails path — don't write a test that
+  expects an exception here.
+- **`query()`/`action()` never throw for execute-time failures.** In
+  `DB::query()`, `$pdo->prepare()` runs *outside* the try/catch, so a
+  prepare-time failure (malformed SQL) throws an uncaught `PDOException`.
+  But `$query->execute()` runs *inside* the try/catch, and a failure there is
+  caught and converted into internal state (`$this->_error = true`) — it does
+  **not** throw. Always check `->error()` / `->errorString()` after a query
+  to assert failure; wrapping a call in `try/catch` only catches prepare-time
+  syntax errors, not execution failures like constraint violations.
+- **`first()` returns `[]`, never `null`.** `DB::first()` is
+  `$this->count() > 0 ? $this->results($assoc)[0] : []`. Asserting
+  `assertNotNull($result)` on a "no row found" case always passes — it's
+  testing the wrong thing. Use `assertIsObject()` / `assertNotEmpty()` (or
+  `assertSame([], $result)` for the not-found case) instead.
+- **`sql_mode` is deliberately `''` (strict mode off).** `DB::__construct()`
+  sets `PDO::MYSQL_ATTR_INIT_COMMAND => "SET SESSION sql_mode = ''"` unless
+  `Config::get('mysql/options')` overrides it. A raw diagnostic MySQL
+  connection (e.g. a manual `mysql` CLI session) defaults to strict mode and
+  will behave differently — don't validate fixture data against a connection
+  that isn't going through `DB`.
+
+## Provisioning
+
+Test, dev, CI, and prod all provision from the same mechanism: the baseline
+migration + `composer migrate` + `composer seed:run`
+(`scripts/provision-schema.sh` wraps the full sequence for a fresh schema).
+See `tests/README.md`'s "Provisioning a Test Schema" and "Database Fixtures"
+sections for the full walkthrough, seed class list, and what
+`tests/bootstrap-integration.php` verifies vs. seeds itself.
+
+## Related Work
+
+Framework-divergence documentation (which upstream UserSpice files this
+project has customized, and why) is tracked separately in #1460
+(`UPSTREAM_DIVERGENCES.md`) — not yet written as of this doc. Once it lands,
+cross-reference it here rather than duplicating UserSpice-quirk content in
+two places.

--- a/docs/releases/RELEASE_NOTES_v2.29.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.1.md
@@ -82,3 +82,4 @@
 - [#1503](https://github.com/elan-registry/registry/issues/1503) — test: make the integration test harness honest
 - [#1553](https://github.com/elan-registry/registry/issues/1553) — chore: derive ElanRegistry-only baseline migration (diff vs. stock UserSpice) and implement composer migrate + seed:run provisioning
 - [#1555](https://github.com/elan-registry/registry/issues/1555) — chore: add tests/ to phpstan.neon coverage
+- [#1558](https://github.com/elan-registry/registry/issues/1558) — docs: write TESTING_STRATEGY.md documenting testing tier architecture and UserSpice DB conventions


### PR DESCRIPTION
## Summary

- Adds `docs/development/TESTING_STRATEGY.md` — test-tier architecture (unit/integration/E2E boundaries, `tests/regression/` is a tag not a tier) and UserSpice `DB` class conventions verified directly against `users/classes/DB.php` (connection failures `die()`, `query()`/`action()` never throw for execute-time failures, `first()` returns `[]` not `null`, `sql_mode=''`). None of this was documented anywhere in the repo before. Linked from `CLAUDE.md` and `docs/README.md`.
- Added a cross-reference row in the GitHub Wiki's `Home.md` quick-lookup table (separate repo, already pushed).
- Found and fixed two `CLAUDE.md` issues during a `/claude-md-improver` pass:
  - The `## GitHub Wiki` section referenced editing files in a `wiki/` staging directory that doesn't exist and was never tracked — corrected to describe the actual workflow (edit directly in the permanent clone).
  - That section also hardcoded a personal absolute filesystem path in a public repo — moved to a new gitignored `.claude.local.md`.
  - `Other Commands` list was missing `/found`, an actively-used, already-referenced command.

Closes #1558

## Test plan

- [x] `npx markdownlint-cli2` clean on the new/changed docs (also ran via pre-commit)
- [x] Every technical claim in `TESTING_STRATEGY.md` checked against `users/classes/DB.php` source, not memory
- [x] Verified every doc/link referenced in `CLAUDE.md` exists in the repo
- [x] Docs-only change — no PHP/JS touched, no PHPStan/security impact