### PR TITLE
test: remove dead noowner skip and fix untested reassignment path in UserDeletionReassignmentTest

### DIFF
--- a/tests/integration/UserDeletionReassignmentTest.php
+++ b/tests/integration/UserDeletionReassignmentTest.php
@@ -47,9 +47,11 @@ final class UserDeletionReassignmentTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Restore rather than unset — bootstrap-integration.php only seeds a fallback
-        // $GLOBALS['user'] once per process, so unsetting it here would leave later
-        // test classes in the same run with no global $user at all.
+        // Restore rather than unset — bootstrap-integration.php seeds a fallback
+        // $GLOBALS['user'] once per process, so $savedGlobalUser should never actually
+        // be null here in practice. The unset() branch is defensive: it only matters if
+        // some earlier test explicitly unsets the global (none currently do), so that a
+        // later test class isn't left with no global $user at all if that ever changes.
         if ($this->savedGlobalUser !== null) {
             $GLOBALS['user'] = $this->savedGlobalUser;
         } else {

--- a/tests/integration/UserDeletionReassignmentTest.php
+++ b/tests/integration/UserDeletionReassignmentTest.php
@@ -20,10 +20,43 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('integration')]
 final class UserDeletionReassignmentTest extends IntegrationTestCase
 {
+    private $savedGlobalUser;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->requireDatabase();
+
+        // after_user_deletion.php requires an authenticated session (currentUserId()
+        // throws RuntimeException otherwise) — see the ASSUMPTION comment in
+        // after_user_deletion.php for which production callers provide one. The hook
+        // itself only checks for a session, not admin permission, so this fixture is
+        // an authenticated (non-admin) test user, not an actual admin. Without it, the
+        // hook aborts before reassigning cars and the final assertion below fails with
+        // a confusing "wrong ID" message instead of a clear "no session" error.
+        $this->savedGlobalUser = $GLOBALS['user'] ?? null;
+
+        $actingUserId = $this->createTestUser();
+        $actingUser = new User();
+        $actingUser->find($actingUserId);
+        $reflection = new ReflectionClass($actingUser);
+        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
+        $isLoggedInProperty->setValue($actingUser, true);
+        $GLOBALS['user'] = $actingUser;
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore rather than unset — bootstrap-integration.php only seeds a fallback
+        // $GLOBALS['user'] once per process, so unsetting it here would leave later
+        // test classes in the same run with no global $user at all.
+        if ($this->savedGlobalUser !== null) {
+            $GLOBALS['user'] = $this->savedGlobalUser;
+        } else {
+            unset($GLOBALS['user']);
+        }
+
+        parent::tearDown();
     }
 
     /**
@@ -36,9 +69,7 @@ final class UserDeletionReassignmentTest extends IntegrationTestCase
     public function test_afterUserDeletionHook_reassignsCarsToNoowner(): void
     {
         $noOwnerRow = $this->db->query("SELECT id FROM users WHERE username = ?", ['noowner'])->first();
-        if (!$noOwnerRow) {
-            $this->markTestSkipped('noowner system account not present in test DB');
-        }
+        $this->assertNotEmpty($noOwnerRow, 'noowner system account missing — run composer seed:run (NoownerSeed)');
         $noOwnerId = (int) $noOwnerRow->id;
 
         $userId = $this->createTestUser();


### PR DESCRIPTION
## Summary

- Removes the dead `markTestSkipped()` guard in `UserDeletionReassignmentTest.php` — the `noowner` account is now always seeded (#1553), so the skip branch could never fire.
- While verifying the removal, found the test's actual reassignment assertion had never been genuinely exercised: `after_user_deletion.php`'s `currentUserId()` call throws without an authenticated session, so the hook silently aborted before reassigning any cars. The test never set up `$GLOBALS['user']`, so this always happened — the test was not testing what its own docblock claims ("Full hook path... cars go to noowner").
- Fixed by authenticating a test user in `setUp()`, reusing the established pattern from `CarDeletionTest.php` (`new User()` + `find()` + reflection-set `_isLoggedIn`), with save/restore of `$GLOBALS['user']` in `tearDown()` to avoid leaking state into later test classes in the same run.
- Replaced the removed skip with a loud `assertNotEmpty()` guard on the `noowner` lookup, so a genuinely missing seed fails with a diagnostic message instead of silently producing `null`.

## Escape analysis

This wasn't caught by CI because the integration suite isn't run there (`.github/workflows/tests.yml` only runs `test:quick:ci` + `test:regression:ci`) — it only surfaces on local runs against a provisioned DB. Confirmed via `git stash` that the failure (and the underlying missing-session bug) predates this PR and is unrelated to the dead-skip removal itself.

## Follow-up (not in this PR)

- No test currently covers the abort-when-no-session path itself, or the `noowner`-missing fallback branch in `after_user_deletion.php`.
- `IntegrationTestCase` never resets `$GLOBALS['user']` between test classes, making several integration tests (this one included, previously) order-dependent on leaked global auth state. Worth its own issue given the milestone's "honest tests" theme.

## Test plan

- `vendor/bin/phpunit -c phpunit-integration.xml --filter UserDeletionReassignmentTest` — passes, genuinely exercises the reassignment path now.
- Full integration suite (373 tests) — matches pre-change baseline exactly (2 unrelated pre-existing failures, confirmed present before this change).
- `vendor/bin/phpstan analyse tests/integration/UserDeletionReassignmentTest.php` — clean.

Closes #1550