### PR TITLE
test: replace always-succeeds mock DB with per-test controllable doubles

### DIFF
--- a/docs/development/TESTING_STRATEGY.md
+++ b/docs/development/TESTING_STRATEGY.md
@@ -15,14 +15,32 @@ Three tiers, each with a distinct purpose and a hard boundary:
 
 - **Unit (`tests/unit/`)** — fast, no database. Test real application
   classes with real logic; never write a hand-rolled mock/reimplementation of
-  your own project code (a mock `DB`, mock `CarModel`, etc. tests the mock,
-  not the application). Mocking third-party/framework boundaries (like
-  UserSpice's `DB` class itself) is fine when the goal is isolating your own
-  code's logic from a real database — the anti-pattern is mocking *your own*
-  classes. This is the target convention, not yet the current state: legacy
-  mocks of `CarModel`/`DB` still exist in `tests/unit/` and are documented as
-  such in `tests/README.md`. Their removal is tracked separately in #1441.
-  Don't add new tests against those mocks; test the real class.
+  your own project code (a mock `CarModel`, mock `CarRepository`, etc. tests
+  the mock, not the application). Mocking third-party/framework boundaries
+  (like UserSpice's `DB` class itself) is fine when the goal is isolating
+  your own code's logic from a real database — the anti-pattern is mocking
+  *your own* classes (e.g. `CarRepository`). Construct the real class against
+  a mocked `DB` instead, so the class's own translation logic (DB response →
+  return value/exception) actually executes.
+
+  `tests/bootstrap-unit.php`'s global `DB` class is intentionally retained as
+  a thin, type-shaped stand-in — every class constructed in the unit tier
+  that type-hints `DB` (`CarRepository`, `CarTransferRepository`,
+  `RegistrationRecoveryNotifier`, and more) needs a class literally named
+  `DB` to resolve, and PHPUnit's `createMock(DB::class)`/`createStub(DB::class)`
+  needs one too to build a double against — a class can't be deleted just
+  because most of its default behavior was (#1441). The convention, per
+  `tests/unit/cars/services/CarRepositoryTest.php`'s `makeDbMock()`: build a
+  per-test `createMock(DB::class)`/`createStub(DB::class)` double configured
+  for exactly what that test needs, rather than relying on the shared
+  singleton's canned defaults for anything beyond "happy path, don't care
+  about the exact shape." A follow-up (extracting a narrow
+  `ElanRegistry\DatabaseInterface` for these classes to type-hint instead of
+  `DB`) would let the shell disappear for real — tracked in #1585.
+
+  A `CarModel` mock still exists in `tests/unit/` and is documented as such
+  in `tests/README.md`; its removal is tracked separately in #1446. Don't add
+  new tests against that mock; test the real class.
 - **Integration (`tests/integration/`)** — real database, real UserSpice
   framework. Every test creates the fixtures it depends on
   (`IntegrationTestCase::createTestUser()` / `createTestCar()`) and cleans

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -391,18 +391,6 @@ parameters:
 			path: tests/unit/admin/ProcessAdminSettingsTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/unit/cars/services/CarAdministrationServiceTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 2
-			path: tests/unit/cars/services/CarRepositoryTest.php
-
-		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with arguments ''ElanRegistry\\\\Exceptions\\\\ElanRegistryException'', ElanRegistry\\Exceptions\\CarValidationException and ''CarValidationExcept…'' will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 1
@@ -611,12 +599,6 @@ parameters:
 			identifier: property.onlyWritten
 			count: 1
 			path: tests/unit/uploads/ImageOrientationTest.php
-
-		-
-			message: '#^Property UserDeletionCleanupTest\:\:\$db is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: tests/unit/users/UserDeletionCleanupTest.php
 
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotEmpty\(\) with non\-falsy\-string will always evaluate to true\.$#'

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -166,6 +166,17 @@ if (!class_exists('DB')) {
             // Return a standard mock user row so tests that need a valid owner work.
             // The WHERE-clause guard prevents matching Owner::searchOwners() and other
             // queries that join users+profiles but use different WHERE conditions.
+            //
+            // This branch must stay even though #1441 moved most DB-behavior control to
+            // per-test createMock(DB::class) doubles: Owner DOES accept DB via
+            // constructor injection (?object $db = null), but
+            // CarAdministrationService::transfer():96 calls `new Owner($newUserId)`
+            // without passing one, so Owner falls back to this shared
+            // DB::getInstance() singleton — independent of whatever mock DB a test
+            // injects directly into CarRepository. Removing this branch would break
+            // CarAdministrationServiceTest's transfer tests; fixing it properly means
+            // giving transfer() a seam to pass its own DB through to Owner, a
+            // production-code change out of scope for a test-only issue.
             if (stripos($sql, 'profiles') !== false
                 && stripos($sql, 'users') !== false
                 && stripos($sql, 'WHERE u.id') !== false) {
@@ -251,8 +262,7 @@ if (!class_exists('DB')) {
         }
 
         /**
-         * Update a record. Return value can be overridden via
-         * $GLOBALS['mockDbUpdateResult'] to simulate write failures.
+         * Update a record.
          *
          * @param string $table Table name
          * @param int $id Record ID
@@ -260,12 +270,7 @@ if (!class_exists('DB')) {
          * @return bool
          */
         public function update(string $table, int $id, array $data): bool {
-            global $mockDbUpdateCalls, $mockDbUpdateResult;
-            if (!isset($mockDbUpdateCalls)) {
-                $mockDbUpdateCalls = [];
-            }
-            $mockDbUpdateCalls[] = [$table, $id, $data];
-            return $mockDbUpdateResult ?? true;
+            return true;
         }
 
         /**
@@ -302,6 +307,11 @@ if (!class_exists('DB')) {
         /** Returns the first row from the last query result, or null when empty. */
         public function first(): mixed {
             return null;
+        }
+
+        /** @return array<mixed> */
+        public function results(): array {
+            return [];
         }
 
         public function deleteById(string $table, int $id): bool {

--- a/tests/unit/auth/RegistrationRecoveryNotifierTest.php
+++ b/tests/unit/auth/RegistrationRecoveryNotifierTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use ElanRegistry\RegistrationRecoveryNotifier;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -49,28 +50,26 @@ if (!class_exists('User')) {
 #[Group('fast')]
 final class RegistrationRecoveryNotifierTest extends TestCase
 {
-    /** @var DB */
+    /** @var DB&MockObject */
     private $db;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        global $mockSentEmails, $mockDbUpdateCalls, $mockDbUpdateResult, $mockEmailSendResult, $mockEmailBodyResult, $mockLogEntries;
+        global $mockSentEmails, $mockEmailSendResult, $mockEmailBodyResult, $mockLogEntries;
         $mockSentEmails = [];
-        $mockDbUpdateCalls = [];
-        $mockDbUpdateResult = null;
         $mockEmailSendResult = null;
         $mockEmailBodyResult = null;
         $mockLogEntries = [];
 
-        $this->db = new DB();
+        $this->db = $this->createMock(DB::class);
     }
 
     protected function tearDown(): void
     {
-        global $mockSentEmails, $mockDbUpdateCalls, $mockDbUpdateResult, $mockEmailSendResult, $mockEmailBodyResult, $mockLogEntries;
-        unset($mockSentEmails, $mockDbUpdateCalls, $mockDbUpdateResult, $mockEmailSendResult, $mockEmailBodyResult, $mockLogEntries);
+        global $mockSentEmails, $mockEmailSendResult, $mockEmailBodyResult, $mockLogEntries;
+        unset($mockSentEmails, $mockEmailSendResult, $mockEmailBodyResult, $mockLogEntries);
 
         parent::tearDown();
     }
@@ -85,22 +84,24 @@ final class RegistrationRecoveryNotifierTest extends TestCase
         $fuser = new User(true, (object) ['id' => 42, 'fname' => 'Jane']);
         $email = 'jane@example.com';
 
+        $this->db->expects($this->once())
+            ->method('update')
+            ->with(
+                'users',
+                $this->identicalTo(42),
+                $this->callback(static fn(array $data): bool => isset($data['vericode'], $data['vericode_expiry']))
+            )
+            ->willReturn(true);
+
         $notifier = new RegistrationRecoveryNotifier($this->db);
         $result = $notifier->notifyIfAccountExists($fuser, $email, $this->settings());
 
         $this->assertTrue($result);
 
-        global $mockSentEmails, $mockDbUpdateCalls;
+        global $mockSentEmails;
 
         $this->assertCount(1, $mockSentEmails, 'Exactly one email should be sent');
         $this->assertSame($email, $mockSentEmails[0][0], 'Email must be sent to the submitted address');
-
-        $this->assertCount(1, $mockDbUpdateCalls, 'Exactly one DB update should be written');
-        [$table, $id, $data] = $mockDbUpdateCalls[0];
-        $this->assertSame('users', $table);
-        $this->assertSame(42, $id);
-        $this->assertArrayHasKey('vericode', $data);
-        $this->assertArrayHasKey('vericode_expiry', $data);
     }
 
     /**
@@ -119,15 +120,17 @@ final class RegistrationRecoveryNotifierTest extends TestCase
     {
         $fuser = new User(true, (object) ['id' => '42', 'fname' => 'Jane']);
 
+        // identicalTo() is a strict (===) match, so a string '42' reaching
+        // DB::update() fails the expectation rather than passing on ==.
+        $this->db->expects($this->once())
+            ->method('update')
+            ->with('users', $this->identicalTo(42), $this->anything())
+            ->willReturn(true);
+
         $notifier = new RegistrationRecoveryNotifier($this->db);
         $result = $notifier->notifyIfAccountExists($fuser, 'jane@example.com', $this->settings());
 
         $this->assertTrue($result, 'A string account ID must not cause a silent TypeError failure');
-
-        global $mockDbUpdateCalls;
-        $this->assertCount(1, $mockDbUpdateCalls);
-        [, $id] = $mockDbUpdateCalls[0];
-        $this->assertSame(42, $id, 'The ID passed to DB::update() must be cast to a native int');
     }
 
     /**
@@ -141,26 +144,36 @@ final class RegistrationRecoveryNotifierTest extends TestCase
     {
         $fuser = new User(false);
 
+        $this->db->expects($this->never())->method('update');
+
         $notifier = new RegistrationRecoveryNotifier($this->db);
         $result = $notifier->notifyIfAccountExists($fuser, 'nobody@example.com', $this->settings());
 
         $this->assertFalse($result);
 
-        global $mockSentEmails, $mockDbUpdateCalls;
+        global $mockSentEmails;
         $this->assertEmpty($mockSentEmails, 'No email should be sent when the account does not exist');
-        $this->assertEmpty($mockDbUpdateCalls, 'No DB write should occur when the account does not exist');
     }
 
     public function testVericodeIsHashedNotStoredAsPlaintext(): void
     {
         $fuser = new User(true, (object) ['id' => 42, 'fname' => 'Jane']);
 
+        // Capture the persisted value rather than asserting inside the callback:
+        // notifyIfAccountExists() catches \Throwable, so an assertion failure
+        // raised mid-call would be swallowed and reported as an unrelated failure.
+        $storedVericode = null;
+        $this->db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(
+                function (string $table, int $id, array $data) use (&$storedVericode): bool {
+                    $storedVericode = $data['vericode'] ?? null;
+                    return true;
+                }
+            );
+
         $notifier = new RegistrationRecoveryNotifier($this->db);
         $notifier->notifyIfAccountExists($fuser, 'jane@example.com', $this->settings());
-
-        global $mockDbUpdateCalls;
-        $this->assertCount(1, $mockDbUpdateCalls);
-        $storedVericode = $mockDbUpdateCalls[0][2]['vericode'];
 
         // bootstrap-unit.php mocks randomstring(15) to a fixed raw value of
         // str_repeat('x', 15); the stored value must not equal that raw output —
@@ -173,7 +186,7 @@ final class RegistrationRecoveryNotifierTest extends TestCase
     public function testDbUpdateFailureReturnsFalseWithoutSendingEmail(): void
     {
         $fuser = new User(true, (object) ['id' => 42, 'fname' => 'Jane']);
-        $GLOBALS['mockDbUpdateResult'] = false;
+        $this->db->expects($this->once())->method('update')->willReturn(false);
 
         $notifier = new RegistrationRecoveryNotifier($this->db);
         $result = $notifier->notifyIfAccountExists($fuser, 'jane@example.com', $this->settings());
@@ -190,6 +203,7 @@ final class RegistrationRecoveryNotifierTest extends TestCase
     public function testEmailSendFailureReturnsFalseWithoutThrowing(): void
     {
         $fuser = new User(true, (object) ['id' => 42, 'fname' => 'Jane']);
+        $this->db->expects($this->once())->method('update')->willReturn(true);
         $GLOBALS['mockEmailSendResult'] = false;
 
         $notifier = new RegistrationRecoveryNotifier($this->db);
@@ -201,6 +215,7 @@ final class RegistrationRecoveryNotifierTest extends TestCase
     public function testEmptyRenderedBodyReturnsFalseWithoutSendingEmail(): void
     {
         $fuser = new User(true, (object) ['id' => 42, 'fname' => 'Jane']);
+        $this->db->expects($this->once())->method('update')->willReturn(true);
         $GLOBALS['mockEmailBodyResult'] = '';
 
         $notifier = new RegistrationRecoveryNotifier($this->db);

--- a/tests/unit/cars/services/CarAdministrationServiceTest.php
+++ b/tests/unit/cars/services/CarAdministrationServiceTest.php
@@ -7,12 +7,20 @@ use ElanRegistry\Car\CarRepository;
 use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Exceptions\CarNotFoundException;
 use ElanRegistry\Exceptions\CarValidationException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Unit tests for CarAdministrationService service class
+ *
+ * These tests exercise the REAL CarRepository against a mocked DB. Mocking the
+ * framework boundary (DB) is the project convention; mocking our own
+ * CarRepository would hide real repository behaviour such as the
+ * CarNotFoundException thrown on 0-row deletes.
+ *
+ * @see docs/development/TESTING_STRATEGY.md
  */
 #[Group('fast')]
 final class CarAdministrationServiceTest extends TestCase
@@ -23,19 +31,48 @@ final class CarAdministrationServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->service = new CarAdministrationService();
-        $this->repo = new CarRepository(DB::getInstance());
+        $this->repo = new CarRepository($this->createStub(DB::class));
+    }
+
+    /**
+     * Configure $db's transaction-lifecycle expectations for one begin/end cycle.
+     *
+     * Models actual inTransaction() state via a closure-captured flag, rather than
+     * assuming a fixed call count/order (a prior willReturnOnConsecutiveCalls(false, true)
+     * version was one extra inTransaction() call away from a confusing null-return
+     * TypeError instead of a clear assertion failure). beginTransaction() flips the
+     * flag true; whichever of commit()/rollBack() actually runs flips it back false —
+     * matching CarRepository's real transactionOwner bookkeeping exactly, regardless
+     * of how many times inTransaction() happens to be called.
+     */
+    private function configureTransaction(MockObject $db, bool $expectCommit): void
+    {
+        $inTransaction = false;
+        $db->method('inTransaction')->willReturnCallback(function () use (&$inTransaction): bool {
+            return $inTransaction;
+        });
+        $db->expects($this->once())->method('beginTransaction')
+            ->willReturnCallback(function () use (&$inTransaction): void {
+                $inTransaction = true;
+            });
+        $db->expects($expectCommit ? $this->once() : $this->never())->method('commit')
+            ->willReturnCallback(function () use (&$inTransaction): void {
+                $inTransaction = false;
+            });
+        $db->expects($expectCommit ? $this->never() : $this->once())->method('rollBack')
+            ->willReturnCallback(function () use (&$inTransaction): void {
+                $inTransaction = false;
+            });
     }
 
     public function testDeleteSucceedsWithValidData(): void
     {
-        // delete() only reads ->id and ->chassis from carData; minimal fixture is sufficient.
-        // A mocked repo is required because the real deleteCar() throws CarNotFoundException
-        // on 0-row deletes, and car 999 does not exist in the test DB.
         $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('deleteCar')->willReturn(true);
-        $repo->expects($this->once())->method('commit');
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: true);
+        $db->method('error')->willReturn(false);
+        $db->method('count')->willReturn(1); // deleteCar(): count()>0 -> true, no CarNotFoundException
+        $repo = new CarRepository($db);
 
         $result = $this->service->delete($carData, 'Test deletion', 1, $repo);
         $this->assertTrue($result);
@@ -64,48 +101,45 @@ final class CarAdministrationServiceTest extends TestCase
 
     public function testTransferSucceeds(): void
     {
-        // userId=1 triggers (new Owner(1))->data() which requires user 1 in the test DB fixture.
+        // userId=1 triggers (new Owner(1))->data() internally inside CarAdministrationService::transfer().
+        // Owner DOES accept DB via constructor injection, but transfer() constructs it without passing
+        // one, so it falls back to the SHARED DB::getInstance() singleton — a separate object from $db
+        // below, unaffected by it. Do not try to make $db cover Owner.
         $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: true);
+        $db->method('update')->willReturn(true);  // CarRepository::updateCar() -> $this->db->update(...)
+        $db->method('insert')->willReturn(true);  // CarRepository::insertHistory() -> $this->db->insert(...)
+        $repo = new CarRepository($db);
 
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('updateCar')->willReturn(true);
-        $repo->expects($this->once())->method('insertHistory')->willReturn(true);
-        $repo->expects($this->once())->method('commit');
-        $repo->expects($this->never())->method('rollback');
-
-        $result = $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
-        $this->assertTrue($result);
+        // transfer()'s return type is literal `true` (throws on any failure), so no
+        // assertion is needed on the return value itself — the mock's beginTransaction/
+        // commit expectations above (verified in tearDown) are what this test proves.
+        $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
     }
 
     public function testTransferThrowsCarDatabaseExceptionWhenUpdateFails(): void
     {
-        $this->expectException(CarDatabaseException::class);
-
         $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: false);
+        $db->method('update')->willReturn(false); // updateCar() fails
+        $repo = new CarRepository($db);
 
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('updateCar')->willReturn(false);
-        $repo->expects($this->once())->method('rollback');
-        $repo->expects($this->never())->method('commit');
-
+        $this->expectException(CarDatabaseException::class);
         $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
     }
 
     public function testTransferThrowsCarDatabaseExceptionWhenInsertHistoryFails(): void
     {
-        $this->expectException(CarDatabaseException::class);
-
         $carData = (object) ['id' => 999, 'chassis' => 'TEST99999'];
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: false);
+        $db->method('update')->willReturn(true);  // updateCar() succeeds
+        $db->method('insert')->willReturn(false); // insertHistory() fails
+        $repo = new CarRepository($db);
 
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('updateCar')->willReturn(true);
-        $repo->expects($this->once())->method('insertHistory')->willReturn(false);
-        $repo->expects($this->once())->method('rollback');
-        $repo->expects($this->never())->method('commit');
-
+        $this->expectException(CarDatabaseException::class);
         $this->service->transfer($carData, 1, 'Test transfer reason', 'NEWOWNER', 1, $repo);
     }
 
@@ -120,13 +154,13 @@ final class CarAdministrationServiceTest extends TestCase
      */
     public function testDeletePropagatesCarNotFoundExceptionFromDeleteCar(): void
     {
+        // deleteCar(): error()=false, count()=0 -> throws CarNotFoundException (real CarRepository behavior)
         $carData = (object) ['id' => 999, 'chassis' => 'GHOST01'];
-
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('deleteCar')
-            ->willThrowException(new CarNotFoundException('Car 999 not found for deletion'));
-        $repo->expects($this->once())->method('rollback');
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: false);
+        $db->method('error')->willReturn(false);
+        $db->method('count')->willReturn(0);
+        $repo = new CarRepository($db);
 
         $this->expectException(CarNotFoundException::class);
         $this->service->delete($carData, 'Test deletion', 1, $repo);
@@ -139,12 +173,12 @@ final class CarAdministrationServiceTest extends TestCase
      */
     public function testDeleteThrowsCarDatabaseExceptionWhenDeleteCarReturnsFalse(): void
     {
+        // deleteCar(): error()=true -> returns false BEFORE checking count (real CarRepository behavior)
         $carData = (object) ['id' => 999, 'chassis' => 'GHOST02'];
-
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('deleteCar')->willReturn(false);
-        $repo->expects($this->once())->method('rollback');
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: false);
+        $db->method('error')->willReturn(true);
+        $repo = new CarRepository($db);
 
         $this->expectException(CarDatabaseException::class);
         $this->service->delete($carData, 'Test deletion', 1, $repo);
@@ -157,13 +191,13 @@ final class CarAdministrationServiceTest extends TestCase
      */
     public function testMergePropagatesCarNotFoundExceptionWhenSourceCarGone(): void
     {
+        // findByIdForUpdate(999): error()=false, count()=0 -> returns null -> merge() throws CarNotFoundException itself
         $targetCarData = (object) ['id' => 1, 'chassis' => 'TARGET01'];
-
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('findByIdForUpdate')->willReturn(null);
-        $repo->expects($this->once())->method('rollback');
-        $repo->expects($this->never())->method('commit');
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: false);
+        $db->method('error')->willReturn(false);
+        $db->method('count')->willReturn(0);
+        $repo = new CarRepository($db);
 
         $this->expectException(CarNotFoundException::class);
         $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);
@@ -175,15 +209,16 @@ final class CarAdministrationServiceTest extends TestCase
      */
     public function testMergeThrowsCarDatabaseExceptionWhenTransferHistoryFails(): void
     {
+        // error() called twice in sequence: 1st by findByIdForUpdate (must be false = success),
+        // 2nd by transferHistory (must be true = failure, since transferHistory returns !error()).
         $targetCarData = (object) ['id' => 1, 'chassis' => 'TARGET01'];
         $sourceData = (object) ['id' => 999, 'chassis' => 'SOURCE01'];
-
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('findByIdForUpdate')->willReturn($sourceData);
-        $repo->expects($this->once())->method('transferHistory')->willReturn(false);
-        $repo->expects($this->once())->method('rollback');
-        $repo->expects($this->never())->method('commit');
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: false);
+        $db->method('error')->willReturnOnConsecutiveCalls(false, true);
+        $db->method('count')->willReturn(1);
+        $db->method('first')->willReturn($sourceData);
+        $repo = new CarRepository($db);
 
         $this->expectException(CarDatabaseException::class);
         $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);
@@ -191,16 +226,16 @@ final class CarAdministrationServiceTest extends TestCase
 
     public function testMergeThrowsCarDatabaseExceptionWhenDeleteCarFails(): void
     {
+        // error() called 3x in sequence: findByIdForUpdate(false=ok), transferHistory(false=ok via !error()),
+        // deleteCar(true=fails, returns false before checking count). count() only used by findByIdForUpdate.
         $targetCarData = (object) ['id' => 1, 'chassis' => 'TARGET01'];
         $sourceData = (object) ['id' => 999, 'chassis' => 'SOURCE01'];
-
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('findByIdForUpdate')->willReturn($sourceData);
-        $repo->expects($this->once())->method('transferHistory')->willReturn(true);
-        $repo->expects($this->once())->method('deleteCar')->willReturn(false);
-        $repo->expects($this->once())->method('rollback');
-        $repo->expects($this->never())->method('commit');
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: false);
+        $db->method('error')->willReturnOnConsecutiveCalls(false, false, true);
+        $db->method('count')->willReturn(1);
+        $db->method('first')->willReturn($sourceData);
+        $repo = new CarRepository($db);
 
         $this->expectException(CarDatabaseException::class);
         $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);
@@ -208,17 +243,18 @@ final class CarAdministrationServiceTest extends TestCase
 
     public function testMergeThrowsCarDatabaseExceptionWhenInsertHistoryFails(): void
     {
+        // error() called 3x, all false (findByIdForUpdate ok, transferHistory ok, deleteCar ok).
+        // count() called 2x, both >0 (findByIdForUpdate finds the row, deleteCar affects a row).
+        // insert() (insertHistory) fails.
         $targetCarData = (object) ['id' => 1, 'chassis' => 'TARGET01'];
         $sourceData = (object) ['id' => 999, 'chassis' => 'SOURCE01'];
-
-        $repo = $this->createMock(CarRepository::class);
-        $repo->expects($this->once())->method('beginTransaction');
-        $repo->expects($this->once())->method('findByIdForUpdate')->willReturn($sourceData);
-        $repo->expects($this->once())->method('transferHistory')->willReturn(true);
-        $repo->expects($this->once())->method('deleteCar')->willReturn(true);
-        $repo->expects($this->once())->method('insertHistory')->willReturn(false);
-        $repo->expects($this->once())->method('rollback');
-        $repo->expects($this->never())->method('commit');
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: false);
+        $db->method('error')->willReturn(false);
+        $db->method('count')->willReturn(1);
+        $db->method('first')->willReturn($sourceData);
+        $db->method('insert')->willReturn(false);
+        $repo = new CarRepository($db);
 
         $this->expectException(CarDatabaseException::class);
         $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);

--- a/tests/unit/cars/services/CarDataTablesServiceTest.php
+++ b/tests/unit/cars/services/CarDataTablesServiceTest.php
@@ -174,17 +174,21 @@ final class CarDataTablesServiceTest extends TestCase
     #[DataProvider('validPaginationProvider')]
     public function testGetDataTablesDataAcceptsValidPagination(int $start, int $length): void
     {
-        $caught = null;
-        try {
-            $request = ['draw' => 1, 'start' => $start, 'length' => $length, 'search' => ['value' => ''], 'order' => [], 'columns' => []];
-            $this->service->getDataTablesData($request, 'cars', DB::getInstance());
-        } catch (CarValidationException $e) {
-            $caught = $e;
-        } catch (\Throwable) {
-            // DB not available in unit context — validation passed
-        }
+        $db = $this->createStub(DB::class);
+        // getDataTablesData() calls query() twice when search/columns are empty: COUNT(*), then the data SELECT.
+        $db->method('query')->willReturnOnConsecutiveCalls(
+            new QueryResult([(object) ['count' => 5]]),
+            new QueryResult([])
+        );
+        $db->method('error')->willReturn(false);
 
-        $this->assertNull($caught, 'Valid pagination parameters should not throw CarValidationException');
+        $request = ['draw' => 1, 'start' => $start, 'length' => $length, 'search' => ['value' => ''], 'order' => [], 'columns' => []];
+        $result = $this->service->getDataTablesData($request, 'cars', $db);
+
+        $this->assertSame(1, $result['draw']);
+        $this->assertSame(5, $result['recordsTotal']);
+        $this->assertSame(5, $result['recordsFiltered']);
+        $this->assertSame([], $result['data']);
     }
 
 }

--- a/tests/unit/cars/services/CarRepositoryTest.php
+++ b/tests/unit/cars/services/CarRepositoryTest.php
@@ -52,14 +52,14 @@ final class CarRepositoryTest extends TestCase
     {
         $this->repo->beginTransaction();
         $this->repo->commit();
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 
     public function testRollbackDoesNotThrow(): void
     {
         $this->repo->beginTransaction();
         $this->repo->rollback();
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 
     // =========================================================================
@@ -80,11 +80,18 @@ final class CarRepositoryTest extends TestCase
     {
         $db = $this->createMock(DB::class);
 
-        // No outer transaction — beginTransaction() should call through.
-        // beginTransaction() checks inTransaction() = false → starts tx.
-        // commit() checks inTransaction() = true → commits.
-        $db->method('inTransaction')->willReturnOnConsecutiveCalls(false, true);
-        $db->expects($this->once())->method('beginTransaction');
+        // No outer transaction — beginTransaction() should call through and flip the
+        // state; commit() then sees inTransaction()=true and commits. Modeling actual
+        // state via a callback (not willReturnOnConsecutiveCalls) means this doesn't
+        // depend on inTransaction() being called exactly twice in exactly this order.
+        $inTransaction = false;
+        $db->method('inTransaction')->willReturnCallback(function () use (&$inTransaction): bool {
+            return $inTransaction;
+        });
+        $db->expects($this->once())->method('beginTransaction')
+            ->willReturnCallback(function () use (&$inTransaction): void {
+                $inTransaction = true;
+            });
         $db->expects($this->once())->method('commit');
 
         $repo = new CarRepository($db);
@@ -126,10 +133,17 @@ final class CarRepositoryTest extends TestCase
     {
         $db = $this->createMock(DB::class);
 
-        // beginTransaction() checks inTransaction() = false → starts tx.
-        // rollback() checks inTransaction() = true → rolls back.
-        $db->method('inTransaction')->willReturnOnConsecutiveCalls(false, true);
-        $db->expects($this->once())->method('beginTransaction');
+        // beginTransaction() flips state to "in transaction"; rollback() then sees
+        // inTransaction()=true and rolls back. State-modeled, not call-count-modeled —
+        // see testStandaloneTransactionOwnsCommit's comment for why.
+        $inTransaction = false;
+        $db->method('inTransaction')->willReturnCallback(function () use (&$inTransaction): bool {
+            return $inTransaction;
+        });
+        $db->expects($this->once())->method('beginTransaction')
+            ->willReturnCallback(function () use (&$inTransaction): void {
+                $inTransaction = true;
+            });
         $db->expects($this->once())->method('rollBack');
         $db->expects($this->never())->method('commit');
 
@@ -269,7 +283,7 @@ final class CarRepositoryTest extends TestCase
     private function makeDbMock(): object
     {
         return $this->getMockBuilder(DB::class)
-            ->onlyMethods(['query', 'error', 'errorString', 'count', 'first'])
+            ->onlyMethods(['query', 'error', 'errorString', 'count', 'first', 'results'])
             ->getMock();
     }
 
@@ -468,5 +482,26 @@ final class CarRepositoryTest extends TestCase
 
         $this->expectException(CarDatabaseException::class);
         $repo->getAllForSitemap();
+    }
+
+    /**
+     * getAllForSitemap() returns the rows from DB::results() on the happy path.
+     *
+     * Regression guard for #1441: the shared mock DB previously had no results()
+     * method at all, so this call would have fatally errored ("Call to undefined
+     * method DB::results()") the first time a unit test actually exercised it.
+     */
+    public function testGetAllForSitemapReturnsRows(): void
+    {
+        $db = $this->makeDbMock();
+        $db->expects($this->once())->method('query');
+        $db->method('error')->willReturn(false);
+        $db->method('results')->willReturn([(object) ['id' => 1, 'mtime' => '2026-01-01 00:00:00']]);
+
+        $repo = new CarRepository($db);
+        $result = $repo->getAllForSitemap();
+
+        $this->assertCount(1, $result);
+        $this->assertSame(1, $result[0]->id);
     }
 }

--- a/tests/unit/transfer/CarTransferRepositoryTest.php
+++ b/tests/unit/transfer/CarTransferRepositoryTest.php
@@ -2,18 +2,22 @@
 
 declare(strict_types=1);
 
+use ElanRegistry\Exceptions\CarDatabaseException;
 use ElanRegistry\Transfer\CarTransferRepository;
 use ElanRegistry\Transfer\TransferStatus;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Smoke tests for CarTransferRepository using the mock DB from bootstrap-unit.php.
+ * Tests for CarTransferRepository.
  *
- * These tests run against a mock where query() always returns count=0, insert()
- * returns true, and lastId() returns 1 — SQL correctness (column names, WHERE
- * clauses, JOINs) is NOT verified here. Real-DB behavioral coverage lives in
- * tests/integration/transfer/CarTransferRepositoryIntegrationTest.php.
+ * Mixes two DB doubles: the happy-path/not-found tests run against the shared
+ * bootstrap-unit.php mock (query() always returns count=0, insert() returns
+ * true, lastId() returns 1) — SQL correctness (column names, WHERE clauses,
+ * JOINs) is NOT verified there. The "Database error paths" tests below inject
+ * a per-test createMock(DB::class) double whose error() returns true, proving
+ * each method fails closed with CarDatabaseException. Real-DB behavioral
+ * coverage lives in tests/integration/transfer/CarTransferRepositoryIntegrationTest.php.
  */
 #[Group('fast')]
 #[Group('transfer')]
@@ -97,5 +101,115 @@ final class CarTransferRepositoryTest extends TestCase
     {
         $result = $this->repo->getPendingWithCarAndUsers();
         $this->assertIsArray($result);
+    }
+
+    // =========================================================================
+    // Database error paths (issue #1441)
+    //
+    // The bootstrap mock DB always reports error() = false, so these guards were
+    // unreachable from the shared singleton. Each test injects a per-test DB
+    // double whose error() returns true, proving the repository fails closed with
+    // a CarDatabaseException rather than returning a healthy-looking empty result.
+    // =========================================================================
+
+    /** @return \PHPUnit\Framework\MockObject\MockObject&DB */
+    private function makeDbMock(): object
+    {
+        return $this->getMockBuilder(DB::class)
+            ->onlyMethods(['query', 'error', 'errorString', 'count', 'first', 'insert', 'lastId'])
+            ->getMock();
+    }
+
+    /**
+     * Assert that calling $action on a repository wired to an erroring DB throws
+     * CarDatabaseException. Shared by every "*ThrowsOnDatabaseError" test below —
+     * they differ only in which repository method $action invokes.
+     */
+    private function assertThrowsOnDatabaseError(callable $action): void
+    {
+        $db = $this->makeDbMock();
+        $db->expects($this->once())->method('query')->willReturn(new QueryResult([]));
+        $db->method('error')->willReturn(true);
+        $db->method('errorString')->willReturn('Connection lost');
+
+        $repo = new CarTransferRepository($db);
+
+        $this->expectException(CarDatabaseException::class);
+        $action($repo);
+    }
+
+    public function testFindByIdThrowsOnDatabaseError(): void
+    {
+        $this->assertThrowsOnDatabaseError(fn (CarTransferRepository $repo) => $repo->findById(1));
+    }
+
+    public function testFindPendingByIdThrowsOnDatabaseError(): void
+    {
+        $this->assertThrowsOnDatabaseError(fn (CarTransferRepository $repo) => $repo->findPendingById(1));
+    }
+
+    public function testFindPendingWithCarByIdThrowsOnDatabaseError(): void
+    {
+        $this->assertThrowsOnDatabaseError(fn (CarTransferRepository $repo) => $repo->findPendingWithCarById(1));
+    }
+
+    public function testHasPendingForCarThrowsOnDatabaseError(): void
+    {
+        $this->assertThrowsOnDatabaseError(fn (CarTransferRepository $repo) => $repo->hasPendingForCar(1, 2));
+    }
+
+    public function testGetPendingWithCarAndUsersThrowsOnDatabaseError(): void
+    {
+        $this->assertThrowsOnDatabaseError(fn (CarTransferRepository $repo) => $repo->getPendingWithCarAndUsers());
+    }
+
+    public function testGetTodayStatusCountsThrowsOnDatabaseError(): void
+    {
+        $this->assertThrowsOnDatabaseError(fn (CarTransferRepository $repo) => $repo->getTodayStatusCounts());
+    }
+
+    public function testCountPendingThrowsOnDatabaseError(): void
+    {
+        $this->assertThrowsOnDatabaseError(fn (CarTransferRepository $repo) => $repo->countPending());
+    }
+
+    public function testUpdateStatusThrowsOnDatabaseError(): void
+    {
+        $this->assertThrowsOnDatabaseError(
+            fn (CarTransferRepository $repo) => $repo->updateStatus(1, TransferStatus::Denied, 'Test denial')
+        );
+    }
+
+    // =========================================================================
+    // create() failure paths (issue #1441)
+    //
+    // create() doesn't fit assertThrowsOnDatabaseError() above — it calls
+    // insert()/lastId() directly, not query()/error(). Two distinct failure
+    // branches: the insert itself failing, and the insert "succeeding" but
+    // returning no usable ID.
+    // =========================================================================
+
+    public function testCreateThrowsOnInsertFailure(): void
+    {
+        $db = $this->makeDbMock();
+        $db->expects($this->once())->method('insert')->willReturn(false);
+        $db->method('errorString')->willReturn('Duplicate entry');
+
+        $repo = new CarTransferRepository($db);
+
+        $this->expectException(CarDatabaseException::class);
+        $repo->create(['existing_car_id' => 1]);
+    }
+
+    public function testCreateThrowsWhenNoIdReturned(): void
+    {
+        $db = $this->makeDbMock();
+        $db->expects($this->once())->method('insert')->willReturn(true);
+        $db->expects($this->once())->method('lastId')->willReturn(0);
+
+        $repo = new CarTransferRepository($db);
+
+        $this->expectException(CarDatabaseException::class);
+        $repo->create(['existing_car_id' => 1]);
     }
 }

--- a/tests/unit/users/UserDeletionCleanupTest.php
+++ b/tests/unit/users/UserDeletionCleanupTest.php
@@ -16,8 +16,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('fast')]
 final class UserDeletionCleanupTest extends TestCase
 {
-    private $db;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -26,7 +24,6 @@ final class UserDeletionCleanupTest extends TestCase
         $mockDeletedUsers = [];
         $mockLogEntries = [];
 
-        $this->db = DB::getInstance();
         $this->setupMockData();
     }
 


### PR DESCRIPTION
## Summary

Removes the structural false-confidence in `tests/bootstrap-unit.php`'s mock `DB` class (#1441, sibling to #1440's mock `Car`): it returned canned success for every call and identified queries by sniffing SQL text, so unit tests couldn't exercise DB-error paths and were coupled to production query wording. #1467 is the same root cause — `CarDataTablesServiceTest`'s pagination test swallowed a real PHP warning via a broad `catch (\Throwable)` because the mock's `QueryResult::first()` returned `false` instead of a real row.

## Key finding that shaped the approach

Issue #1441's literal acceptance criterion said "delete the shared mock DB entirely." Empirically verified this isn't achievable: every class instantiated in the unit tier that needs a `DB` collaborator (`CarRepository`, `CarTransferRepository`, `RegistrationRecoveryNotifier`, and more) type-hints the concrete class directly, and PHPUnit's own `createMock(DB::class)`/`createStub(DB::class)` — the *replacement* mechanism — also requires a class of that name to build a double against (confirmed via `ReflectionClass('DB')` throwing when no such class exists). So the shell stays as a thin type-shaped stand-in; a `DatabaseInterface` extraction that would let it actually disappear is filed separately as #1585.

## What changed

- **`tests/bootstrap-unit.php`** — added a missing `results()` method (a previously-undiscovered latent fatal-error trap: `CarRepository::getAllForSitemap()` calls it and it didn't exist), removed the `$GLOBALS['mockDbUpdateResult']` global-mutable-state hack, documented why one SQL-sniffing branch must stay (`CarAdministrationService::transfer()` constructs `Owner` without passing a DB override, so it always falls back to the shared singleton).
- **`CarAdministrationServiceTest.php`** — 10 tests converted from mocking our own `CarRepository` (anti-pattern per `docs/development/TESTING_STRATEGY.md`) to a real `CarRepository` backed by a mocked `DB`, so `CarRepository`'s own translation logic genuinely executes. Deduplicated via a `configureTransaction()` helper that models actual `inTransaction()` state rather than assuming a fixed call sequence (a `willReturnOnConsecutiveCalls` version produced a reproducible-but-rare spurious failure during review).
- **`CarDataTablesServiceTest.php`** — fixed #1467 with a real `DB` double and a real assertion of the response shape.
- **`CarTransferRepositoryTest.php`** — 10 new DB-error-path tests (was 0% coverage), including `create()`'s two failure branches.
- **`RegistrationRecoveryNotifierTest.php`** — migrated off the `$GLOBALS` hack onto `createMock(DB::class)`.
- **`CarRepositoryTest.php`** — added a happy-path test proving the `results()` fix works; applied the same state-modeled transaction-mock fix to two pre-existing tests using the old flaky pattern.
- **`docs/development/TESTING_STRATEGY.md`** — updated to describe the resolved convention.

## Verification

- `composer test:quick` — 1370 unit tests, **0 warnings/notices**.
- `composer test:full` — 400 integration tests, clean except the pre-existing, already-tracked #1547 (unrelated FK-cascade-drift issue).
- PHPStan clean on every touched file; baseline diff is pure removal (18 lines) — cleared 3 pre-existing entries on files this PR touched, per CLAUDE.md's fix-when-you-touch-it policy.
- The transaction-mock flakiness fix was stress-tested 15x with randomized test order.
- Reviewed across four parallel local-review agents (code, silent-failure, comments, tests) plus a security review and senior-architect review; all findings addressed.

## Follow-up filed (not fixed here)

- #1585 — extract a `DatabaseInterface` so the mock shell can eventually be deleted for real.

Closes #1441
Closes #1467