### PR TITLE
docs: move plans/ working-doc convention to a permanent local directory

### DIFF
--- a/.claude.local.md.example
+++ b/.claude.local.md.example
@@ -20,3 +20,12 @@ lives at:
 
 Always use this exact path. Never clone to /tmp/, a worktree, or any other
 temporary location — there should be one permanent clone per machine.
+
+## Plans directory
+
+Working documents (sprint plans, triage reports, FRDs) live outside the repo at:
+
+/path/to/your/local/plans/directory
+
+Large plans (multi-file: an FRD plus mockups, exported PDFs, images) get their
+own subdirectory. Smaller single-file plans live directly under this directory.

--- a/.claude/commands/start-issue-examples.md
+++ b/.claude/commands/start-issue-examples.md
@@ -113,7 +113,8 @@ All changes implemented, tested, documented, and reviewed.
 
 Implementation complete for issue #423. Next steps:
 
-0. Update test plan  — Add test scenarios to plans/test-plan-<milestone>.md
+0. Update test plan  — Add test scenarios to test-plan-<milestone>.md in the
+                       local Plans directory (path in .claude.local.md)
 1. /simplify         — Review and clean up the code (optional)
 2. /review-pr        — Multi-agent local review (recommended before push)
 3. /commit           — Commit your changes
@@ -205,7 +206,8 @@ Here's my plan with escape analysis and preventive tests...
 
 Implementation complete for issue #512. Next steps:
 
-0. Update test plan  — Add test scenarios to plans/test-plan-<milestone>.md
+0. Update test plan  — Add test scenarios to test-plan-<milestone>.md in the
+                       local Plans directory (path in .claude.local.md)
 1. /simplify         — Review and clean up the code (optional)
 2. /review-pr        — Multi-agent local review (recommended before push)
 3. /commit           — Commit your changes

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -440,7 +440,8 @@ Once the user has explicitly approved the plan, execute using agents strategical
    ```text
    Implementation complete for issue #ISSUE_NUMBER. Next steps:
 
-   0. Update test plan  — Add test scenarios to plans/test-plan-<milestone>.md
+   0. Update test plan  — Add test scenarios to test-plan-<milestone>.md in the
+                          local Plans directory (path in .claude.local.md)
    1. /simplify         — Review and clean up the code (optional)
    2. /review-pr        — Run the multi-agent local review (RECOMMENDED before
                           push; uses your Max/Pro subscription so CI can stay

--- a/.gitignore
+++ b/.gitignore
@@ -201,7 +201,6 @@ screenshots/
 # Temporary/Development
 ########################################
 TODO
-plans
 
 ########################################
 # Monitoring & Log Analysis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,8 +294,11 @@ and architecture agents.
 
 ### Planning Work
 
-- `plans/` directory is for temporary working documents (sprint plans, triage
-  reports) — delete after decisions are applied to GitHub milestones/issues
+- Working documents (sprint plans, triage reports, FRDs) live in a permanent
+  local directory outside this repo — path in `.claude.local.md` (gitignored;
+  copy `.claude.local.md.example` to set it up), same pattern as the wiki
+  clone. Delete a plan's contents after its decisions are applied to GitHub
+  milestones/issues.
 - For milestone planning, use the `senior-product-manager`, `senior-architect`,
   and `security-reviewer` agents in parallel for comprehensive analysis
 


### PR DESCRIPTION
## Summary

- Working documents (sprint plans, triage reports, FRDs) now live outside this repo, same pattern as the wiki clone — path configured in `.claude.local.md` (gitignored).
- Updates `CLAUDE.md`, the `.claude.local.md.example` template, and the `start-issue` command/examples that referenced the old in-repo `plans/` path.
- Drops `plans` from `.gitignore` since the directory no longer exists in this repo.

Split out of #1588 into its own PR — it was committed alongside issue #1444's work but is unrelated to it.

## Test plan

Documentation-only change; no code paths affected.