### PR TITLE
test: retire ad-hoc User double in RegistrationRecoveryNotifierTest.php

### DIFF
--- a/docs/development/TESTING_STRATEGY.md
+++ b/docs/development/TESTING_STRATEGY.md
@@ -73,6 +73,19 @@ Three tiers, each with a distinct purpose and a hard boundary:
   `is_uploaded_file()` branch, be aware a file merely on disk
   (`file_exists()`) will pass that check too — it isn't isolated to
   `FileUploadSecurityTest.php`.
+
+  When a test needs a bare global-namespace double for a real UserSpice class
+  (not a namespaced project class) to satisfy a type hint the production code
+  can't be changed to relax, declare it in its own `_`-prefixed file and add
+  that file to `phpstan.neon`'s `excludePaths`, rather than inline in the
+  test class — e.g. `tests/unit/auth/_User_test_double.php` standing in for
+  `\User`. PHP has no per-file scoping for global classes: once `tests/`
+  entered PHPStan's scan path
+  (#1555), an inline double becomes *the* definition PHPStan uses for that
+  class everywhere in the codebase, not just within the test that declares it
+  (#1566). Excluding the file keeps the class genuinely unanalyzable to
+  PHPStan instead, which the project's existing `ignoreErrors` patterns for
+  UserSpice runtime classes already account for.
 - **Integration (`tests/integration/`)** — real database, real UserSpice
   framework. Every test creates the fixtures it depends on
   (`IntegrationTestCase::createTestUser()` / `createTestCar()`) and cleans

--- a/docs/releases/RELEASE_NOTES_v2.29.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.1.md
@@ -86,3 +86,4 @@
 - [#1558](https://github.com/elan-registry/registry/issues/1558) — docs: write TESTING_STRATEGY.md documenting testing tier architecture and UserSpice DB conventions
 - [#1560](https://github.com/elan-registry/registry/issues/1560) — chore: fix pre-commit's known-broken/broken group naming mismatch; delete stale test:api/test:workflow composer scripts
 - [#1550](https://github.com/elan-registry/registry/issues/1550) — test: remove dead noowner skip and fix UserDeletionReassignmentTest not exercising the real reassignment path
+- [#1566](https://github.com/elan-registry/registry/issues/1566) — test: retire ad-hoc User double in RegistrationRecoveryNotifierTest.php that pollutes PHPStan analysis project-wide

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -61,6 +61,10 @@ parameters:
         # Not valid PHP — placeholder template syntax for copy-pasting new regression
         # tests, same treatment as the fix-script template above.
         - tests/regression/RegressionTestTemplate.php
+        # Test double for \User (#1566). Excluded so PHPStan never adopts its narrow
+        # 2-method surface as the definition of \User project-wide — see the file's
+        # own docblock for the full leak mechanism this prevents.
+        - tests/unit/auth/_User_test_double.php
 
     treatPhpDocTypesAsCertain: false
     checkMissingTypehints: true
@@ -87,8 +91,9 @@ parameters:
         # QueryResult (the return type of DB::query(), also unanalyzable — real class
         # lives in users/, has no project-owned counterpart to check a signature
         # against). Since tests/ entered the scan path (#1555), PHPStan resolves calls
-        # on these classes against whichever test double happens to declare a
-        # same-named global class/method — narrower or differently-typed than the
+        # on DB/Token/Input (still bare global test doubles inside the scanned
+        # tests/bootstrap-unit.php) against whichever test double happens to declare
+        # a same-named global class/method — narrower or differently-typed than the
         # real runtime class — and misreports call sites throughout the whole
         # project, not just the test file that defines the double. This is the same
         # "unanalyzable at runtime" root cause as the block above, just two different
@@ -96,14 +101,17 @@ parameters:
         # mismatches (undefined method, wrong arg count, wrong arg type); the fourth
         # is PHPStan's redundant-comparison check firing on a `===`/`!==` expression,
         # because it thinks QueryResult's real vs. stubbed type can never overlap.
+        # User is deliberately absent from these four patterns: its one test double
+        # lives in a file excluded from PHPStan's scan (#1566), so \User resolves to
+        # "unknown class" instead — already covered by the block above, not this one.
         -
-            message: '#Call to an undefined method (DB|Token|Input|User|Redirect|Session|Cookie|Server|Validate|TOTPHandler|Config|Menu|QueryResult)::\w+\(\)#'
+            message: '#Call to an undefined method (DB|Token|Input|Redirect|Session|Cookie|Server|Validate|TOTPHandler|Config|Menu|QueryResult)::\w+\(\)#'
             reportUnmatched: false
         -
-            message: '#(Static m|M)ethod (DB|Token|Input|User|Redirect|Session|Cookie|Server|Validate|TOTPHandler|Config|Menu|QueryResult)::\w+\(\) invoked with#'
+            message: '#(Static m|M)ethod (DB|Token|Input|Redirect|Session|Cookie|Server|Validate|TOTPHandler|Config|Menu|QueryResult)::\w+\(\) invoked with#'
             reportUnmatched: false
         -
-            message: '#of (method|class) (DB|Token|Input|User|Redirect|Session|Cookie|Server|Validate|TOTPHandler|Config|Menu|QueryResult)(::|\s)#'
+            message: '#of (method|class) (DB|Token|Input|Redirect|Session|Cookie|Server|Validate|TOTPHandler|Config|Menu|QueryResult)(::|\s)#'
             reportUnmatched: false
         -
             message: '#(comparison using === between|comparison using !== between) QueryResult#'

--- a/tests/unit/auth/RegistrationRecoveryNotifierTest.php
+++ b/tests/unit/auth/RegistrationRecoveryNotifierTest.php
@@ -7,37 +7,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
 
-/**
- * Test double for \User.
- *
- * The real users/classes/User.php is not loaded in the unit-test environment
- * (its constructor calls the live DB::getInstance() singleton and is not
- * mockable via constructor injection), and it is not part of this project's
- * PSR-4 autoload map, so \User does not exist here unless something defines
- * it. That makes a plain stand-in class named `User` — implementing only the
- * two methods RegistrationRecoveryNotifier::notifyIfAccountExists() calls,
- * exists() and data() — the simplest and most robust option: it satisfies the
- * \User type hint directly with no reflection or subclassing tricks needed.
- */
-if (!class_exists('User')) {
-    class User {
-        private bool $_exists;
-        private object $_data;
-
-        public function __construct(bool $exists = false, ?object $data = null) {
-            $this->_exists = $exists;
-            $this->_data = $data ?? new \stdClass();
-        }
-
-        public function exists(): bool {
-            return $this->_exists;
-        }
-
-        public function data(): object {
-            return $this->_data;
-        }
-    }
-}
+// Test double for \User — kept in its own file, excluded from PHPStan's scan
+// path (see phpstan.neon and the file's own docblock), so it doesn't leak
+// its narrow 2-method surface into PHPStan's understanding of \User
+// project-wide (#1566).
+require_once __DIR__ . '/_User_test_double.php';
 
 /**
  * Unit tests for RegistrationRecoveryNotifier (issue #1406).

--- a/tests/unit/auth/_User_test_double.php
+++ b/tests/unit/auth/_User_test_double.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Test double for \User, used only by RegistrationRecoveryNotifierTest.
+ *
+ * The real users/classes/User.php is not loaded in the unit-test environment
+ * (its constructor calls the live DB::getInstance() singleton and is not
+ * mockable via constructor injection), and it is not part of this project's
+ * PSR-4 autoload map, so \User does not exist here unless something defines
+ * it. That makes a plain stand-in class named `User` the simplest and most
+ * robust option — it satisfies the \User type hint directly with no
+ * reflection or subclassing tricks needed. It implements only the two
+ * methods RegistrationRecoveryNotifier::notifyIfAccountExists() calls:
+ * exists() and data().
+ *
+ * IMPORTANT: Kept in a separate file (#1566), not inline in the test class.
+ * PHP has no per-file scoping for global classes. `tests/` entered PHPStan's
+ * scan path in #1555, and PHPStan has no other way to learn what \User looks
+ * like (users/ is excluded from phpstan.neon's `paths`) — so when this
+ * declaration lived inside RegistrationRecoveryNotifierTest.php, PHPStan
+ * adopted this double's narrow 2-method surface as *the* definition of
+ * \User project-wide, misreporting real usages elsewhere (usersc/join.php,
+ * usersc/login.php, tests/integration/*.php calling the real User::find(),
+ * etc.) against a shape that was never meant to represent the whole class.
+ * This file is listed in phpstan.neon's `excludePaths`, so PHPStan never
+ * sees this declaration at all and \User goes back to being genuinely
+ * unanalyzable everywhere — covered by the same `ignoreErrors` patterns
+ * already relied on for DB/Token/Input, instead of resolving to a
+ * misleadingly narrow double. This is the same class-shape-adoption problem
+ * phpstan.neon's `ignoreErrors` comment block describes for DB/Token/Input's
+ * call-site mismatches — here it manifests as PHPStan defining \User's
+ * shape outright, rather than misreporting individual method calls.
+ */
+if (!class_exists('User')) {
+    class User {
+        private bool $_exists;
+        private object $_data;
+
+        public function __construct(bool $exists = false, ?object $data = null) {
+            $this->_exists = $exists;
+            $this->_data = $data ?? new \stdClass();
+        }
+
+        public function exists(): bool {
+            return $this->_exists;
+        }
+
+        public function data(): object {
+            return $this->_data;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`tests/unit/auth/RegistrationRecoveryNotifierTest.php` declared a bare global `class User` test double inline, guarded by `class_exists('User')`. PHP has no per-file scoping for global classes: once `tests/` entered PHPStan's scan path (#1555), this double became *the* definition PHPStan used for `\User` project-wide — not just within this test — misreporting real usages in `usersc/join.php`, `usersc/login.php`, and `tests/integration/*.php` (which call the real `User::find()`) against its narrow 2-method surface. #1555 patched the resulting false errors with broad `ignoreErrors` regex patterns naming `User` alongside `DB`/`Token`/`Input`.

This PR moves the double into its own file (`tests/unit/auth/_User_test_double.php`) and adds that file to `phpstan.neon`'s `excludePaths` — the same technique already used for `RegressionTestTemplate.php` and `_TEMPLATE_Fix-Script.php`. PHPStan now never sees the double's declaration, so `\User` goes back to being genuinely unanalyzable everywhere (still covered by the existing "unknown class" `ignoreErrors` pattern) instead of resolving to a misleading narrow shape.

This issue was originally scoped to be folded into #1441 or #1554 ("whichever lands first"). Both are now closed and neither introduced a different design — `DB`/`Token`/`Input` remain bare global doubles in `tests/bootstrap-unit.php`, suppressed the same way. Treated as its own standalone fix here.

## Changes

- **New file** `tests/unit/auth/_User_test_double.php` — the double, isolated, with a docblock explaining the PHPStan leak mechanism it prevents.
- **`tests/unit/auth/RegistrationRecoveryNotifierTest.php`** — now `require_once`s the double; all 7 existing tests unchanged.
- **`phpstan.neon`** — added the double's file to `excludePaths`; removed the now-dead `User` token from 3 of the 5 UserSpice-class `ignoreErrors` patterns (empirically verified: those 3 patterns matched nothing once the double left the scan path — removing `User` from the other 2 patterns reintroduces real errors, so it stays there).
- **`docs/development/TESTING_STRATEGY.md`** — documents the new convention for isolating global-class test doubles.

## Verification

- Full `vendor/bin/phpstan analyse --memory-limit=512M` — 0 errors, baseline regenerated with zero diff (281 errors, unchanged).
- `composer test:quick` — 1379 tests / 3944 assertions (later re-verified at 1553/4427 after this branch's later fixes were included), all passing, including the 7 `RegistrationRecoveryNotifierTest` methods against the extracted double.
- `php scripts/check-coding-standards.php .` — 0 errors.
- Two rounds of local multi-agent review (`code-reviewer` + `comment-analyzer`, twice) plus two `/simplify` passes — one blocking finding (dead `ignoreErrors` tokens) found and fixed; final pass clean.

Closes #1566