### PR TITLE
test: retire mock CarModel reference data, validate against real data

### DIFF
--- a/docs/development/TESTING_STRATEGY.md
+++ b/docs/development/TESTING_STRATEGY.md
@@ -38,9 +38,10 @@ Three tiers, each with a distinct purpose and a hard boundary:
   `ElanRegistry\DatabaseInterface` for these classes to type-hint instead of
   `DB`) would let the shell disappear for real — tracked in #1585.
 
-  A `CarModel` mock still exists in `tests/unit/` and is documented as such
-  in `tests/README.md`; its removal is tracked separately in #1446. Don't add
-  new tests against that mock; test the real class.
+  Model-combination existence can't be proven in the unit tier — the shared
+  `DB` mock has no `car_models` branch, so `CarModel::exists()` always returns
+  `false` there (#1446). Assert it in
+  `tests/integration/cars/services/CarValidatorModelTest.php` instead.
 
   UserSpice's own bare (non-namespaced) classes under `users/classes/` are a
   different case, and the rule there is absolute: they can **never** be loaded

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -140,7 +140,8 @@ Tests that require `car_models` data:
 - `tests/integration/Reference/CarModelTest.php` - Complete CarModel class testing
 - `tests/integration/cars/services/CarValidatorModelTest.php` - Model validation with real database
 
-Unit tests use mock CarModel class (no database required).
+Unit tests never validate model-combination existence — that check needs a
+real `car_models` row and is proven only in the integration tier above.
 
 ## Configuration
 
@@ -151,7 +152,7 @@ Unit tests use mock CarModel class (no database required).
 
 ### PHPUnit Config Files
 
-- `phpunit-unit.xml` - Unit test configuration (uses mock CarModel)
+- `phpunit-unit.xml` - Unit test configuration (mocks only, no database)
 - `phpunit-integration.xml` - Integration test configuration (uses real database)
 
 ## Troubleshooting

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -373,12 +373,6 @@ parameters:
 			path: tests/unit/admin/ProcessAdminSettingsTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with arguments ''ElanRegistry\\\\Exceptions\\\\ElanRegistryException'', ElanRegistry\\Exceptions\\CarValidationException and ''CarValidationExcept…'' will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/unit/cars/services/CarValidatorTest.php
-
-		-
 			message: '#^Parameter \#1 \$card of static method ElanRegistry\\Documentation\\DocumentPortalTemplate\:\:renderDocumentCard\(\) expects array\{title\: string, icon\: string, url\: string, buttonText\: string, headerClass\?\: string, buttonClass\?\: string, cardClass\?\: string, description\?\: string, \.\.\.\}, array\{icon\: ''fa\-car'', url\: ''/test'', buttonText\: ''View''\} given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,7 +43,6 @@ tests/
 
 **Characteristics:**
 
-- Mock CarModel class for model validation
 - Mock DB class for database operations
 - No UserSpice framework loaded
 - Ideal for TDD and rapid feedback
@@ -51,7 +50,7 @@ tests/
 **Example test suites:**
 
 - `CarRepositoryTest.php` - Car database repository methods (real class, mocked DB boundary)
-- `CarValidatorTest.php` - Input validation (with mock CarModel)
+- `CarValidatorTest.php` - Input validation (model-combination existence is proven in the integration tier — see `CarValidatorModelTest.php`)
 - `FileUploadSecurityTest.php` - Upload security
 
 ### Integration Tests (`tests/integration/`)
@@ -287,12 +286,15 @@ final class MyValidatorTest extends TestCase
 
     public function testValidatesInput(): void
     {
-        // Uses mock CarModel automatically
+        // Model-combination validation needs a real car_models row — that
+        // check is only meaningful in the integration tier (see the
+        // CarValidatorModelTest example below). Unit tests exercise
+        // everything else validateAndSanitizeFields() does.
         $result = $this->validator->validateAndSanitizeFields([
-            'model' => 'S4|FHC|36', // Valid in mock
+            'chassis' => 'ABC123',
         ], false);
 
-        $this->assertArrayHasKey('model', $result);
+        $this->assertArrayHasKey('chassis', $result);
     }
 }
 ```
@@ -349,15 +351,6 @@ here.
 **Problem**: Unit test is marked `@group integration` but in `tests/unit/`
 
 **Solution**: Move to `tests/integration/` or remove database dependency and use mocks.
-
-### Mock CarModel Doesn't Match Real Data
-
-**Problem**: Unit test fails because mock doesn't have all valid model combinations.
-
-**Solution**: Either:
-
-1. Add the model to mock in `bootstrap-unit.php`
-2. Move test to integration suite if real data is required
 
 ## See Also
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -287,9 +287,9 @@ final class MyValidatorTest extends TestCase
     public function testValidatesInput(): void
     {
         // Model-combination validation needs a real car_models row — that
-        // check is only meaningful in the integration tier (see the
-        // CarValidatorModelTest example below). Unit tests exercise
-        // everything else validateAndSanitizeFields() does.
+        // check is only meaningful in the integration tier (see
+        // CarValidatorModelTest.php). Unit tests exercise everything else
+        // validateAndSanitizeFields() does.
         $result = $this->validator->validateAndSanitizeFields([
             'chassis' => 'ABC123',
         ], false);

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -46,16 +46,18 @@ if (!isset($_SESSION)) {
     $_SESSION = [];
 }
 
-// These mocks are plain global classes (Token, Input, DB, QueryResult) plus the
-// namespaced CarModel below. Composer autoloads only namespaced ElanRegistry\*
-// classes, so it can never resolve these bare names — defining them here simply
-// provides the only declaration the unit suite ever sees. Order relative to the
-// vendor/autoload.php require below is immaterial.
+// These mocks are plain global classes (Token, Input, DB, QueryResult). Composer
+// autoloads only namespaced ElanRegistry\* classes, so it can never resolve these
+// bare names — defining them here simply provides the only declaration the unit
+// suite ever sees. Order relative to the vendor/autoload.php require below is
+// immaterial.
 //
-// CarModel is different: it IS namespaced and Composer-resolvable
-// (ElanRegistry\Reference\CarModel, PSR-4 mapped to usersc/classes/Reference/), so its
-// eval'd shadow below must be declared before anything first touches the class — see
-// the note at the eval.
+// ElanRegistry\Reference\CarModel is NOT mocked here (removed #1446) — it's
+// PSR-4 mapped, so it autoloads for real and its DB::getInstance() call
+// resolves against the shared DB mock below, which has no car_models branch —
+// so CarModel::exists() always returns false in this tier. Don't add a unit
+// test asserting a model combination validates; that needs a real car_models
+// row and belongs in CarValidatorModelTest.php (integration tier, #1446).
 //
 // Why Token and Input are mocked rather than loaded for real: NOTHING under
 // users/classes/ can ever be require_once'd from this bootstrap, because the whole
@@ -65,9 +67,8 @@ if (!isset($_SESSION)) {
 // This constraint is about file availability, not runtime dependencies: Token and
 // Input touch nothing but superglobals and would otherwise be perfectly loadable.
 //
-// DB and CarModel are mocked for the separate, additional reason that their real
-// implementations require a live database connection, which unit tests deliberately
-// do not have.
+// DB is mocked for the separate, additional reason that its real implementation
+// requires a live database connection, which unit tests deliberately do not have.
 //
 // Consequence: these mocks are stubs, not production behavior. Real CSRF crypto
 // (hash_equals over the session token) and real htmlspecialchars() input sanitization
@@ -442,71 +443,6 @@ if (!function_exists('currentUserId')) {
         return (int) $user->data()->id;
     }
 }
-
-// ============================================================
-// Mock CarModel Reference Data Class
-// ============================================================
-// CRITICAL: Must be defined BEFORE autoloader to prevent loading real CarModel.
-// Unlike the bare classes above, ElanRegistry\Reference\CarModel is PSR-4 mapped in
-// composer.json (usersc/classes/Reference/CarModel.php), so Composer WOULD resolve it —
-// this declaration only wins if it lands first.
-// Provides test data for valid model combinations without requiring database
-
-// Use eval to create the class in the correct namespace
-// This is a special case for unit testing - allows us to mock a namespaced class
-eval('
-namespace ElanRegistry\Reference;
-
-/**
- * Mock CarModel class for unit tests
- * Returns valid test data for known model combinations
- */
-class CarModel {
-    /**
-     * Valid model combinations for testing
-     * @var array<string, bool>
-     */
-    private static array $validModels = [
-        "S4|FHC|36" => true,
-        "S4|DHC|45" => true,
-        "Sprint|FHC|36" => true,
-        "Sprint|DHC|45" => true,
-        "S3|FHC|36" => true,
-        "S3|DHC|45" => true,
-        "+2|FHC|50" => true,
-        "+2S|FHC|50" => true,
-        "+2S/130|FHC|50" => true,
-    ];
-
-    /**
-     * Check if a model combination exists
-     */
-    public function exists(string $series, string $variant, string $typeCode): bool {
-        $series = trim($series);
-        $variant = trim($variant);
-        $typeCode = trim($typeCode);
-
-        $modelValue = "{$series}|{$variant}|{$typeCode}";
-        return isset(self::$validModels[$modelValue]);
-    }
-
-    /**
-     * Get model by composite value
-     */
-    public function byValue(string $value): ?object {
-        if (isset(self::$validModels[$value])) {
-            $parts = explode("|", $value);
-            return (object)[
-                "model_value" => $value,
-                "series_normalized" => $parts[0],
-                "variant" => $parts[1],
-                "type_code" => $parts[2],
-            ];
-        }
-        return null;
-    }
-}
-');
 
 // Load Composer autoloader for all custom classes and exceptions
 require_once $projectRoot . '/vendor/autoload.php';

--- a/tests/integration/cars/services/CarValidatorModelTest.php
+++ b/tests/integration/cars/services/CarValidatorModelTest.php
@@ -7,7 +7,9 @@ namespace Tests\Integration\Cars\Services;
 use PHPUnit\Framework\TestCase;
 use ElanRegistry\Car\CarValidator;
 use ElanRegistry\Exceptions\CarValidationException;
+use RuntimeException;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -30,98 +32,87 @@ final class CarValidatorModelTest extends TestCase
 
     /**
      * @test
-     * Model validation accepts valid model combinations
+     * Every model combination in the reference-data CSV validates. The
+     * provider reads the same file CarModelsSeed seeds car_models from, so
+     * it can't drift from the database (#1446).
      */
-    public function testValidateModelAcceptsValidCombination(): void
-    {
+    #[DataProvider('allReferenceModelCombinationsProvider')]
+    public function testValidateModelAcceptsEveryReferenceCombination(
+        string $series,
+        string $variant,
+        string $typeCode
+    ): void {
         $data = [
-            'model' => 'S4|FHC|36',
+            'model' => "{$series}|{$variant}|{$typeCode}",
         ];
 
         $result = $this->validator->validateAndSanitizeFields($data, false);
 
         $this->assertArrayHasKey('model', $result);
-        $this->assertEquals('S4|FHC|36', $result['model']);
+        $this->assertEquals("{$series}|{$variant}|{$typeCode}", $result['model']);
     }
 
     /**
-     * @test
-     * Model validation accepts Sprint FHC
+     * @return array<string, array{0: string, 1: string, 2: string}> Keyed by
+     *   model_value; each value is [series, variant, type_code].
      */
-    public function testValidateModelAcceptsSprintFHC(): void
+    public static function allReferenceModelCombinationsProvider(): array
     {
-        $data = [
-            'model' => 'Sprint|FHC|36',
-        ];
+        $csvPath = dirname(__DIR__, 4) . '/database/seeds/data/car_models.csv';
+        $handle = fopen($csvPath, 'r');
+        if ($handle === false) {
+            throw new RuntimeException("Could not read reference-data CSV at {$csvPath}");
+        }
 
-        $result = $this->validator->validateAndSanitizeFields($data, false);
+        $header = fgetcsv($handle, 0, ',', '"', '\\');
+        $cases = [];
+        while (($row = fgetcsv($handle, 0, ',', '"', '\\')) !== false) {
+            $record = array_combine($header, $row);
+            $cases[$record['model_value']] = [
+                $record['series'],
+                $record['variant'],
+                $record['type_code'],
+            ];
+        }
+        fclose($handle);
 
-        $this->assertArrayHasKey('model', $result);
-        $this->assertEquals('Sprint|FHC|36', $result['model']);
+        // A truncated/corrupted CSV read must fail loudly, not just silently
+        // run fewer test cases — mirrors CarModelsSeed::EXPECTED_ROWS.
+        if (count($cases) !== 23) {
+            throw new RuntimeException(
+                'Expected 23 model combinations from ' . $csvPath . ', got ' . count($cases)
+            );
+        }
+
+        return $cases;
     }
 
     /**
      * @test
-     * Model validation accepts Sprint DHC
+     * Model validation rejects invalid combinations — each case isolates a
+     * single mismatched field against two otherwise-real ones, so a
+     * regression that stops checking just one column (series, variant, or
+     * type_code) would still fail here.
      */
-    public function testValidateModelAcceptsSprintDHC(): void
-    {
-        $data = [
-            'model' => 'Sprint|DHC|45',
-        ];
-
-        $result = $this->validator->validateAndSanitizeFields($data, false);
-
-        $this->assertArrayHasKey('model', $result);
-        $this->assertEquals('Sprint|DHC|45', $result['model']);
-    }
-
-    /**
-     * @test
-     * Model validation accepts S4 DHC (Drophead)
-     */
-    public function testValidateModelAcceptsS4DHC(): void
-    {
-        $data = [
-            'model' => 'S4|DHC|45',
-        ];
-
-        $result = $this->validator->validateAndSanitizeFields($data, false);
-
-        $this->assertArrayHasKey('model', $result);
-        $this->assertEquals('S4|DHC|45', $result['model']);
-    }
-
-    /**
-     * @test
-     * Model validation accepts Plus 2 models
-     */
-    public function testValidateModelAcceptsPlus2(): void
-    {
-        $data = [
-            'model' => '+2|FHC|50',
-        ];
-
-        $result = $this->validator->validateAndSanitizeFields($data, false);
-
-        $this->assertArrayHasKey('model', $result);
-        $this->assertEquals('+2|FHC|50', $result['model']);
-    }
-
-    /**
-     * @test
-     * Model validation rejects invalid combinations
-     */
-    public function testValidateModelRejectsInvalidCombination(): void
+    #[DataProvider('invalidCombinationProvider')]
+    public function testValidateModelRejectsInvalidCombination(string $model): void
     {
         $this->expectException(CarValidationException::class);
         $this->expectExceptionMessage('is not a valid Lotus Elan model');
 
-        $data = [
-            'model' => 'S4|Roadster|99', // Invalid: S4 Roadster with type 99
-        ];
+        $this->validator->validateAndSanitizeFields(['model' => $model], false);
+    }
 
-        $this->validator->validateAndSanitizeFields($data, false);
+    /** @return array<string, array{0: string}> */
+    public static function invalidCombinationProvider(): array
+    {
+        return [
+            'all three fields wrong' => ['S4|Roadster|99'],
+            // Real pairing is S4|FHC|36 — 45 belongs to S4|DHC, not S4|FHC.
+            'type_code wrong for series+variant' => ['S4|FHC|45'],
+            // FHC|36 is a real pairing (S3/S4), but S1 never had an FHC variant.
+            'series wrong for variant+type_code' => ['S1|FHC|36'],
+        ];
     }
 
     /**

--- a/tests/integration/cars/services/CarValidatorModelTest.php
+++ b/tests/integration/cars/services/CarValidatorModelTest.php
@@ -18,6 +18,9 @@ use PHPUnit\Framework\Attributes\Group;
  * Tests model validation that requires car_models reference data.
  * These tests verify that CarValidator correctly integrates with the
  * CarModel class to validate model combinations against the database.
+ *
+ * Not run by CI (tests.yml runs Unit + Regression only) — proven via
+ * `composer test:integration`/`test:full` before merge instead.
  */
 #[Group('integration')]
 #[Group('reference-data')]
@@ -77,10 +80,12 @@ final class CarValidatorModelTest extends TestCase
         fclose($handle);
 
         // A truncated/corrupted CSV read must fail loudly, not just silently
-        // run fewer test cases — mirrors CarModelsSeed::EXPECTED_ROWS.
+        // run fewer test cases. This 23 must stay in sync with
+        // CarModelsSeed::EXPECTED_ROWS if the reference data set ever changes.
         if (count($cases) !== 23) {
             throw new RuntimeException(
                 'Expected 23 model combinations from ' . $csvPath . ', got ' . count($cases)
+                . ' — if the dataset changed, update this count and CarModelsSeed::EXPECTED_ROWS'
             );
         }
 

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -512,14 +512,13 @@ final class CarValidatorTest extends TestCase
     // ============================================================
 
     /**
-     * Full positive case with mock model validation
-     * Uses mock CarModel class that accepts known valid combinations
+     * Full positive case for every field except `model` — see
+     * CarValidatorModelTest.php for the model-inclusive version (#1446).
      */
     public function testValidateAndSanitizeFieldsReturnsFullSanitizedArray(): void
     {
         $fields = [
             'chassis' => '1234A', // 1970 legacy 5-char format: 4 numeric digits + Elan suffix 'A' (valid letter code)
-            'model' => 'S4|FHC|36', // Valid in mock CarModel
             'year' => '1970',
             'email' => 'owner@example.com',
             'website' => 'https://example.com',
@@ -535,7 +534,6 @@ final class CarValidatorTest extends TestCase
         $result = $this->validator->validateAndSanitizeFields($fields, true);
 
         $this->assertEquals('1234A', $result['chassis']);
-        $this->assertEquals('S4|FHC|36', $result['model']);
         $this->assertSame(1970, $result['year']);
         $this->assertEquals('owner@example.com', $result['email']);
         $this->assertEquals('https://example.com', $result['website']);
@@ -632,43 +630,12 @@ final class CarValidatorTest extends TestCase
     }
 
     // ============================================================
-    // Model validation tests with Mock CarModel
-    // Unit tests using mock CarModel class (see bootstrap-unit.php)
-    // Integration tests that require real database are in
-    // tests/integration/cars/services/CarValidatorModelTest.php
+    // Model validation tests
+    //
+    // Format/required/empty checks run before CarModel is touched, so they
+    // stay here. Combination-existence validation needs a real car_models
+    // row — moved to CarValidatorModelTest (integration tier) in #1446.
     // ============================================================
-
-    /**
-     * @test
-     * Model validation accepts valid model combinations (mock)
-     */
-    public function testValidateModelAcceptsValidCombination(): void
-    {
-        $data = [
-            'model' => 'S4|FHC|36', // Valid in mock CarModel
-        ];
-
-        $result = $this->validator->validateAndSanitizeFields($data, false);
-
-        $this->assertArrayHasKey('model', $result);
-        $this->assertEquals('S4|FHC|36', $result['model']);
-    }
-
-    /**
-     * @test
-     * Model validation rejects invalid combinations (mock)
-     */
-    public function testValidateModelRejectsInvalidCombination(): void
-    {
-        $this->expectException(CarValidationException::class);
-        $this->expectExceptionMessage('is not a valid Lotus Elan model');
-
-        $data = [
-            'model' => 'S4|Roadster|99', // Invalid: not in mock CarModel
-        ];
-
-        $this->validator->validateAndSanitizeFields($data, false);
-    }
 
     /**
      * @test

--- a/tests/unit/cars/services/CarValidatorTest.php
+++ b/tests/unit/cars/services/CarValidatorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use ElanRegistry\Car\CarValidator;
 use ElanRegistry\Exceptions\CarValidationException;
-use ElanRegistry\Exceptions\ElanRegistryException;
 use PHPUnit\Framework\TestCase;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -551,8 +550,11 @@ final class CarValidatorTest extends TestCase
     // ============================================================
 
     /**
-     * Verify every validation error path throws CarValidationException
-     * (extends ElanRegistryException), never generic Exception.
+     * Verify every validation error path throws CarValidationException,
+     * never generic Exception. That CarValidationException itself extends
+     * ElanRegistryException is a static fact PHP's own class declaration
+     * already guarantees — not something a runtime assertion adds coverage
+     * for, so it isn't re-checked here.
      *
      * @param array<string, mixed> $fields
      */
@@ -567,11 +569,6 @@ final class CarValidatorTest extends TestCase
                 CarValidationException::class,
                 $e,
                 'Validation error must throw CarValidationException, got ' . get_class($e)
-            );
-            $this->assertInstanceOf(
-                ElanRegistryException::class,
-                $e,
-                'CarValidationException must extend ElanRegistryException'
             );
         }
     }

--- a/tests/unit/system/AutoloaderTest.php
+++ b/tests/unit/system/AutoloaderTest.php
@@ -126,9 +126,9 @@ class AutoloaderTest extends TestCase
     /**
      * Test that ElanRegistry\Reference\CarModel is available to the application.
      *
-     * Note: bootstrap-unit.php pre-loads CarModel via an eval mock before the
-     * autoloader registers, so class_exists() here confirms availability, not
-     * PSR-4 path resolution.
+     * Unlike Token/Input/DB, CarModel is not mocked in bootstrap-unit.php
+     * (removed #1446) — it's PSR-4 mapped and loads for real via Composer, so
+     * this genuinely confirms autoloader path resolution.
      */
     public function testReferenceClassIsAvailable(): void
     {


### PR DESCRIPTION
## Summary

- Retires the hand-maintained `eval`'d mock `ElanRegistry\Reference\CarModel` in `tests/bootstrap-unit.php`, which permanently shadowed the real PSR-4-mapped class for the unit tier with 9 hardcoded "valid" model combinations that could silently drift from real reference data.
- The real `ElanRegistry\Reference\CarModel` now autoloads normally in unit tests. Its `DB::getInstance()` call resolves against the existing shared `DB` mock, which has no `car_models` branch — so `CarModel::exists()` always returns `false` in the unit tier now (no unit test relies on it returning `true`).
- Model-combination-*existence* validation moved entirely to the integration tier: `CarValidatorModelTest.php` gained a `#[DataProvider]` that reads `database/seeds/data/car_models.csv` directly (all 23 real combinations, replacing 5 hand-picked ones) with a defensive assertion the CSV read exactly 23 rows, plus a 3-case negative-combination provider (each case isolates a single mismatched field — series-only, type_code-only, all-three) replacing 1 hardcoded case, added after mutation testing showed the original single case couldn't catch a regression that stops checking just one column.
- Fixed 6 stale references to the removed mock across `tests/README.md`, `docs/testing/TESTING.md`, and `docs/development/TESTING_STRATEGY.md` — including a copy-paste example in `tests/README.md` that would otherwise now silently produce a failing test.

## Changes

- `tests/bootstrap-unit.php` — removed the eval'd mock CarModel block; updated surrounding comments to explain the real class now autoloads and to state the unit-tier consequence (`exists()` always `false`).
- `tests/unit/cars/services/CarValidatorTest.php` — removed 2 tests whose assertions depended on the retired mock's canned combo list; kept format/required/empty-guard tests (none reach `CarModel`).
- `tests/integration/cars/services/CarValidatorModelTest.php` — CSV-driven `#[DataProvider]` for all 23 real combinations (with row-count guard), 3-case negative-combination provider, class docblock note that this tier isn't run by CI.
- `tests/unit/system/AutoloaderTest.php` — updated docblock now that `class_exists()` genuinely confirms PSR-4 resolution rather than confirming a bootstrap-declared mock.
- `tests/README.md`, `docs/testing/TESTING.md`, `docs/development/TESTING_STRATEGY.md` — removed/updated all references to the deleted mock.

## Verification

- `composer test:quick` — 1377 tests, 3939 assertions, all pass.
- `vendor/bin/phpunit --configuration phpunit-integration.xml --filter CarValidatorModelTest` — 30 tests, 69 assertions, all pass (23 CSV-driven positive cases + 3 negative + 4 others), against a real seeded `car_models` table.
- `vendor/bin/phpstan analyse` (full project) — no errors; `composer phpstan:baseline` — zero diff.
- Local review: 2 full rounds (`code-reviewer` + `comment-analyzer` + `pr-test-analyzer`, run against the complete branch diff each time) plus a confirmation pass and 3 `/simplify` passes. All findings independently re-verified and fixed, including a duplicate release-notes line, an incorrectly-flipped test parameter that would have silently dropped coverage, and a dangling doc cross-reference.

Note: the new integration-tier coverage is not run by CI (`tests.yml` runs Unit + Regression only) — matches the project's existing convention for developer-local-only integration proof (see `TESTING_STRATEGY.md`'s Token/Input section).

Closes #1446