### PR TITLE
test: audit remaining unit test files for undetected mock/fake usage

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.29.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.1.md
@@ -87,3 +87,4 @@
 - [#1560](https://github.com/elan-registry/registry/issues/1560) — chore: fix pre-commit's known-broken/broken group naming mismatch; delete stale test:api/test:workflow composer scripts
 - [#1550](https://github.com/elan-registry/registry/issues/1550) — test: remove dead noowner skip and fix UserDeletionReassignmentTest not exercising the real reassignment path
 - [#1566](https://github.com/elan-registry/registry/issues/1566) — test: retire ad-hoc User double in RegistrationRecoveryNotifierTest.php that pollutes PHPStan analysis project-wide
+- [#1556](https://github.com/elan-registry/registry/issues/1556) — test: audit remaining unit test files for undetected mock/fake usage

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,6 +53,17 @@ tests/
 - `CarValidatorTest.php` - Input validation (model-combination existence is proven in the integration tier — see `CarValidatorModelTest.php`)
 - `FileUploadSecurityTest.php` - Upload security
 
+**Mock/fake audit log:** as of 2026-08-10 (#1556), all 66 files in `tests/unit/`
+have been individually confirmed to exercise real production code, not a
+bootstrap mock/fake standing in for the subject under test.
+Issues #1440, #1441, #1444, #1445, #1446, #1554, and #1566 fixed 14 files
+found by name-based grepping; #1556 read the remaining 52 and found 8 more reimplementation/
+tautology cases, now tracked as #1597–#1604 (targeted at v2.29.2). One
+file (`RobotsTxtPolicyTest.php`) has a different, already-tracked honesty gap
+(#1542 — verifies the repo's `robots.txt`, not the Cloudflare-injected
+as-served version). Before assuming a new `tests/unit/` file is clean by
+default, check whether it predates this audit.
+
 ### Integration Tests (`tests/integration/`)
 
 **Purpose**: Real database operations and workflows


### PR DESCRIPTION
## Summary

- Reads all 52 `tests/unit/` files not already covered by #1440–#1446/#1554/#1566 against the current `tests/bootstrap-unit.php` mock inventory (`Token`/`Input`/`DB`/`QueryResult` + guarded helper functions).
- 43 files confirmed clean (genuinely exercise real production code).
- 1 file already tracked by a different-but-related honesty issue: `RobotsTxtPolicyTest.php` → #1542.
- 8 new findings — production-logic reimplementations, tautological assertions, and one wholly fictional test file — filed as follow-ups targeting v2.29.2: #1597, #1598, #1599, #1600, #1601, #1602, #1603, #1604.
- Audit outcome recorded in `tests/README.md` so a future file can be checked against this baseline instead of re-auditing from scratch.

No production or test code changes — this issue is audit + issue-filing + documentation only, per its own scope ("File follow-up issues for anything found," not fix them here).

## Verification

- Every one of the 52 files independently spot-checked (direct read, not just agent report) before any issue was filed.
- `composer test:quick` — 1377 tests, 3927 assertions, all passing.
- Markdown lint clean.

Closes #1556

https://claude.ai/code/session_01KtyBe31Hortswi7zL7Kh7e