### PR TITLE
test: fix cars_hist DELETE-order leak in TransferRequestConstraintTest and CarsYearSmallintMigrationTest

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.29.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.1.md
@@ -88,3 +88,4 @@
 - [#1550](https://github.com/elan-registry/registry/issues/1550) — test: remove dead noowner skip and fix UserDeletionReassignmentTest not exercising the real reassignment path
 - [#1566](https://github.com/elan-registry/registry/issues/1566) — test: retire ad-hoc User double in RegistrationRecoveryNotifierTest.php that pollutes PHPStan analysis project-wide
 - [#1556](https://github.com/elan-registry/registry/issues/1556) — test: audit remaining unit test files for undetected mock/fake usage
+- [#1551](https://github.com/elan-registry/registry/issues/1551) — test: cars_hist DELETE-order leak in TransferRequestConstraintTest and CarsYearSmallintMigrationTest

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -74,15 +74,10 @@ abstract class IntegrationTestCase extends TestCase
     protected function tearDown(): void
     {
         if ($this->databaseConnected) {
-            // Delete cars first (may depend on foreign key constraints). cars_hist is deleted
-            // AFTER cars, not before — the cars_delete trigger inserts a DELETE-operation history
-            // row when the car row is removed, so deleting cars_hist first just leaves that
-            // trigger-inserted row orphaned forever.
             foreach ($this->createdCarIds as $carId) {
                 try {
                     $this->db->query("DELETE FROM car_transfer_requests WHERE existing_car_id = ?", [$carId]);
-                    $this->db->delete('cars', ['id', '=', $carId]);
-                    $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
+                    $this->deleteCarRows($carId);
                 } catch (RuntimeException $e) {
                     // Don't fail the test over cleanup, but a silent swallow here means the
                     // fixture row survives into the next test run with no trace of why —
@@ -251,18 +246,59 @@ abstract class IntegrationTestCase extends TestCase
         }
 
         try {
-            // cars_hist is deleted AFTER cars, not before — the cars_delete trigger inserts a
-            // DELETE-operation history row when the car row is removed, so deleting cars_hist
-            // first just leaves that trigger-inserted row orphaned forever (same fix as tearDown()).
-            $this->db->delete('cars', ['id', '=', $carId]);
-            $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
+            $this->deleteCarWithHistory($carId);
             // Remove from tracking so tearDown doesn't double-delete
             $this->createdCarIds = array_values(array_diff($this->createdCarIds, [$carId]));
             return true;
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            // PHPUnit\Framework\Exception extends RuntimeException, so the catch below would
+            // otherwise swallow deleteCarWithHistory()'s self-verification failures and log
+            // them away instead of failing the test — defeating the point of verifying at all.
+            throw $e;
         } catch (RuntimeException $e) {
             fwrite(STDERR, "NOTE: deleteTestCar() failed for car ID {$carId}: {$e->getMessage()}\n");
             return false;
         }
+    }
+
+    /**
+     * Delete a car's `cars` and `cars_hist` rows, in the order required to avoid
+     * orphaning the cars_delete trigger's own history row (#1503, #1551): cars
+     * must go first, then cars_hist.
+     *
+     * @param int $carId The car ID to delete
+     */
+    private function deleteCarRows(int $carId): void
+    {
+        $this->db->delete('cars', ['id', '=', $carId]);
+        $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
+    }
+
+    /**
+     * Delete a car's `cars` and `cars_hist` rows (see deleteCarRows()) and self-verify
+     * both are actually gone afterward. DB::query() never throws on an execute-time
+     * failure (see countMatchingLogs() below), so the verification queries check
+     * error() explicitly — otherwise a failed verification SELECT would return zero
+     * rows and the assertion would pass vacuously, "confirming" a deletion that may
+     * not have happened.
+     *
+     * @param int $carId The car ID to delete
+     */
+    protected function deleteCarWithHistory(int $carId): void
+    {
+        $this->deleteCarRows($carId);
+
+        $carsRemaining = $this->db->query("SELECT id FROM cars WHERE id = ?", [$carId]);
+        if ($carsRemaining->error()) {
+            throw new RuntimeException("Verification query failed for cars row {$carId}: {$carsRemaining->errorString()}");
+        }
+        $this->assertSame(0, $carsRemaining->count(), "cars row {$carId} must be deleted");
+
+        $histRemaining = $this->db->query("SELECT id FROM cars_hist WHERE car_id = ?", [$carId]);
+        if ($histRemaining->error()) {
+            throw new RuntimeException("Verification query failed for cars_hist rows (car {$carId}): {$histRemaining->errorString()}");
+        }
+        $this->assertSame(0, $histRemaining->count(), "cars_hist rows for car {$carId} must be deleted");
     }
 
     /**

--- a/tests/integration/database/CarsYearSmallintMigrationTest.php
+++ b/tests/integration/database/CarsYearSmallintMigrationTest.php
@@ -70,13 +70,21 @@ final class CarsYearSmallintMigrationTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Clean up any cars that were deleted mid-test (so IntegrationTestCase's tearDown
-        // doesn't try to DELETE them again, which would be a no-op but could hide bugs).
-        foreach ($this->localCarIds as $carId) {
-            $this->untrackCarId($carId);
+        try {
+            // Clean up cars_hist for any car deleted mid-test (localCarIds) — the
+            // cars_delete trigger's own DELETE-operation row still needs removing
+            // (#1551). Running this here, not at the end of the test body, means
+            // cleanup still happens even if the test's own assertions fail.
+            foreach ($this->localCarIds as $carId) {
+                $this->deleteCarWithHistory($carId);
+                $this->untrackCarId($carId);
+            }
+        } finally {
+            // Run even if deleteCarWithHistory() throws (a verification failure must
+            // still fail the test, but must not skip the base class's own user/car
+            // cleanup for the rest of this test's fixtures).
+            parent::tearDown();
         }
-
-        parent::tearDown();
     }
 
     // -------------------------------------------------------------------------

--- a/tests/integration/database/TransferRequestConstraintTest.php
+++ b/tests/integration/database/TransferRequestConstraintTest.php
@@ -150,12 +150,10 @@ final class TransferRequestConstraintTest extends IntegrationTestCase
         );
         $this->assertSame(1, $before->count(), 'Pre-condition: transfer request must exist');
 
-        // Delete the car via raw SQL so the CASCADE actually fires.
-        // deleteTestCar() pre-deletes related rows first, which would prevent
-        // the cascade from being exercised.
-        $this->db->query("DELETE FROM cars_hist WHERE car_id = ?", [$carId]);
-        $this->db->query("DELETE FROM cars WHERE id = ?", [$carId]);
-        $this->untrackCarId($carId); // car is gone; suppress tearDown's redundant DELETE
+        // deleteTestCar() deletes cars before cars_hist (#1503) and self-verifies
+        // both are gone, which the CASCADE assertion below depends on; it also
+        // untracks the car so tearDown() doesn't redundantly delete it again.
+        $this->deleteTestCar($carId);
 
         $after = $this->db->query(
             "SELECT id FROM car_transfer_requests WHERE id = ?",


### PR DESCRIPTION
## Summary

#1503 fixed a bug where `IntegrationTestCase::tearDown()` and `deleteTestCar()` deleted `cars_hist` **before** `cars`, orphaning the row the `cars_delete` AFTER-DELETE trigger inserts on car deletion. This PR fixes two more instances of the identical pattern in files #1503 never touched, surfaced by a code-review pass on that PR:

- `TransferRequestConstraintTest::test_deleteCar_cascadesTransferRequests` — deleted `cars_hist` then `cars` via raw SQL, with a comment incorrectly claiming `deleteTestCar()` would prevent the CASCADE from firing. Now calls `deleteTestCar()` directly.
- `CarsYearSmallintMigrationTest::test_deleteTrigger_createsHistRowWithOperation` — deliberately untracks its car from the base class's auto-cleanup (`localCarIds`) so it can assert the trigger's history row exists, but nothing ever cleaned that row up afterward.

While fixing these, local review surfaced that a naive inline fix would only run cleanup on the happy path (an assertion failure would skip it, reintroducing the same leak). Rather than patch around that per-file, extracted a shared `IntegrationTestCase::deleteCarWithHistory()` helper that:

- Deletes `cars` then `cars_hist` in the correct order (single source of truth for the ordering, used by `deleteTestCar()` and both fixed tests; the bulk `tearDown()` loop uses the underlying `deleteCarRows()` primitive without the assertions, to avoid aborting suite-wide cleanup on a verification failure)
- Self-verifies both are actually gone afterward, checking `error()` on the verification queries first (since `DB::query()` never throws on an execute-time failure)
- In `CarsYearSmallintMigrationTest`, cleanup moved into `tearDown()` wrapped in `try/finally`, so it runs even if the test's own assertions fail, without skipping the base class's own fixture cleanup

A subtlety caught during re-review and confirmed via `ReflectionClass`: `PHPUnit\Framework\Exception extends RuntimeException`, so `deleteTestCar()`'s existing `catch (RuntimeException $e)` would have silently swallowed the new self-verification failures. Fixed by rethrowing `AssertionFailedError` before that catch — verified by temporarily sabotaging a delete and confirming the test now fails loudly (`"cars row N must be deleted"`) instead of passing silently.

## Verification

- PHPStan clean on all touched files
- Full unit suite: 1377 tests, 3927 assertions, all passing
- Integration tests (`TransferRequestConstraintTest`, `CarsYearSmallintMigrationTest`, `CarMergeTest` — the only other `deleteTestCar()` caller) run against the local test DB: 22/23 pass; the one failure (`test_deleteCar_cascadesTransferRequests`'s CASCADE assertion) is pre-existing and already tracked as #1547 (no real FK constraint exists on `car_transfer_requests.existing_car_id`), confirmed via `git stash` to fail identically before this PR's changes
- `cars_hist` orphan row count (`car_id NOT IN (SELECT id FROM cars)`) stayed flat at 56 across repeated runs of the fixed tests, confirming the leak is closed
- Empirically verified the self-verification actually fires: temporarily broke the `cars` delete, confirmed the test failed with `"cars row N must be deleted"` instead of silently passing, then restored

No production code changes — test-harness-only, matching the issue's scope.

Closes #1551