### PR TITLE
test: close CarTransferRepository/CarAdministrationService/TransferEmailService unit test gaps

### DIFF
--- a/tests/unit/cars/services/CarAdministrationServiceTest.php
+++ b/tests/unit/cars/services/CarAdministrationServiceTest.php
@@ -259,4 +259,30 @@ final class CarAdministrationServiceTest extends TestCase
         $this->expectException(CarDatabaseException::class);
         $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);
     }
+
+    /**
+     * merge() succeeds end-to-end: source car found, history transferred, source
+     * car deleted, audit trail inserted, transaction commits. Success-path
+     * counterpart to the four failure-path tests above.
+     */
+    public function testMergeSucceeds(): void
+    {
+        $targetCarData = (object) ['id' => 1, 'chassis' => 'TARGET01'];
+        $sourceData = (object) ['id' => 999, 'chassis' => 'SOURCE01'];
+        $db = $this->createMock(DB::class);
+        $this->configureTransaction($db, expectCommit: true);
+        $db->method('error')->willReturn(false);
+        $db->method('count')->willReturn(1);
+        $db->method('first')->willReturn($sourceData);
+        // Must actually assert the audit-trail insert happens — a loose ->method('insert')
+        // stub would leave this test green even if merge() stopped calling insertHistory().
+        $db->expects($this->once())->method('insert')->with('cars_hist', $this->anything())->willReturn(true);
+        $repo = new CarRepository($db);
+
+        // merge()'s return type is literal `true` (throws on any failure), so no
+        // assertion is needed on the return value itself — the mock's beginTransaction/
+        // commit expectations above (verified via PHPUnit's mock-expectation checks after
+        // the test method completes) are what this test proves.
+        $this->service->merge($targetCarData, 999, 'Test merge', 1, $repo);
+    }
 }

--- a/tests/unit/transfer/CarTransferRepositoryTest.php
+++ b/tests/unit/transfer/CarTransferRepositoryTest.php
@@ -36,6 +36,12 @@ final class CarTransferRepositoryTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testFindPendingWithCarByIdReturnsNullForMissingId(): void
+    {
+        $result = $this->repo->findPendingWithCarById(PHP_INT_MAX);
+        $this->assertNull($result);
+    }
+
     public function testHasPendingForCarReturnsFalseForMissingCar(): void
     {
         $result = $this->repo->hasPendingForCar(PHP_INT_MAX, PHP_INT_MAX);

--- a/tests/unit/transfer/TransferEmailServiceTest.php
+++ b/tests/unit/transfer/TransferEmailServiceTest.php
@@ -78,6 +78,18 @@ final class TransferEmailServiceTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Constructor validation
+    // -------------------------------------------------------------------------
+
+    public function testConstructorThrowsWhenMailerIsNotCallable(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('TransferEmailService: $mailer must be callable');
+
+        new TransferEmailService($this->createMockDb(0), 123);
+    }
+
+    // -------------------------------------------------------------------------
     // Early-exit (not-found) tests — existing coverage
     // -------------------------------------------------------------------------
 
@@ -170,6 +182,24 @@ final class TransferEmailServiceTest extends TestCase
 
         $this->assertTrue($result);
         $this->assertSame(2, $attempt, 'Mailer must be called once per admin address');
+    }
+
+    public function testSendAdminAlertReturnsFalseWhenAllMailerAttemptsFail(): void
+    {
+        $GLOBALS['mockAdminEmails'] = 'fail1@example.com,fail2@example.com';
+
+        $db      = $this->createFoundMockDb($this->makeTransferRow(), $this->makeCarRow());
+        $attempt = 0;
+        $mailer  = function () use (&$attempt): bool {
+            $attempt++;
+            return false;
+        };
+
+        $service = new TransferEmailService($db, $mailer);
+        $result  = $service->sendAdminAlert(1);
+
+        $this->assertFalse($result);
+        $this->assertSame(2, $attempt, 'Mailer must be attempted once per admin address even though all fail');
     }
 
     /**
@@ -294,6 +324,107 @@ final class TransferEmailServiceTest extends TestCase
 
         $this->assertTrue($result);
         $this->assertSame(2, $attempt, 'Mailer must be called for requester and previous owner');
+    }
+
+    // -------------------------------------------------------------------------
+    // Owner-not-found guards — new coverage
+    // -------------------------------------------------------------------------
+
+    /**
+     * Asserts $mockLogEntries contains an entry whose message contains $needle.
+     *
+     * A guard's "not found" message (e.g. "Current owner ID 0 not found") is
+     * distinct from the catch-all Throwable handler's message (e.g. "... error
+     * for request #1 [TypeError] in ..."), which fires with the same false-return/
+     * mailer-not-called observable outcome if the guard is deleted and the null
+     * owner hits a typed parameter downstream. Asserting the guard's specific
+     * message — not just the return value — is what makes these tests actually
+     * detect a deleted guard instead of passing either way.
+     *
+     * @param array<int, array{user_id: int, category: string, message: string}> $logEntries
+     */
+    private function assertLogContains(array $logEntries, string $needle): void
+    {
+        $matches = array_filter($logEntries, fn($e) => str_contains($e['message'], $needle));
+        $this->assertNotEmpty($matches, "Expected a log entry containing \"$needle\", got: " . json_encode($logEntries));
+    }
+
+    public function testSendRequestReturnsFalseWhenCurrentOwnerNotFound(): void
+    {
+        global $mockLogEntries;
+        $mockLogEntries = [];
+
+        $db     = $this->createFoundMockDb($this->makeTransferRow(), $this->makeCarRow(['user_id' => 0]));
+        $called = false;
+        $mailer = function () use (&$called): bool {
+            $called = true;
+            return true;
+        };
+
+        $service = new TransferEmailService($db, $mailer);
+
+        $this->assertFalse($service->sendRequest(1));
+        $this->assertFalse($called, 'Mailer must not be called when the current owner cannot be found');
+        $this->assertLogContains($mockLogEntries, 'Current owner ID 0 not found');
+    }
+
+    public function testSendRequestReturnsFalseWhenRequesterNotFound(): void
+    {
+        global $mockLogEntries;
+        $mockLogEntries = [];
+
+        $db     = $this->createFoundMockDb($this->makeTransferRow(['requested_by_user_id' => 0]), $this->makeCarRow());
+        $called = false;
+        $mailer = function () use (&$called): bool {
+            $called = true;
+            return true;
+        };
+
+        $service = new TransferEmailService($db, $mailer);
+
+        $this->assertFalse($service->sendRequest(1));
+        $this->assertFalse($called, 'Mailer must not be called when the requester cannot be found');
+        $this->assertLogContains($mockLogEntries, 'Requester ID 0 not found');
+    }
+
+    public function testSendAdminAlertReturnsFalseWhenCurrentOwnerNotFound(): void
+    {
+        global $mockLogEntries;
+        $mockLogEntries = [];
+        $GLOBALS['mockAdminEmails'] = 'admin@example.com';
+
+        $db     = $this->createFoundMockDb($this->makeTransferRow(), $this->makeCarRow(['user_id' => 0]));
+        $called = false;
+        $mailer = function () use (&$called): bool {
+            $called = true;
+            return true;
+        };
+
+        $service = new TransferEmailService($db, $mailer);
+
+        $this->assertFalse($service->sendAdminAlert(1));
+        $this->assertFalse($called, 'Mailer must not be called when the current owner cannot be found');
+        $this->assertLogContains($mockLogEntries, 'Current owner ID 0 not found');
+    }
+
+    public function testSendAdminAlertReturnsFalseWhenRequesterNotFound(): void
+    {
+        global $mockLogEntries;
+        $mockLogEntries = [];
+        $GLOBALS['mockAdminEmails'] = 'admin@example.com';
+
+        $db     = $this->createFoundMockDb($this->makeTransferRow(['requested_by_user_id' => 0]), $this->makeCarRow());
+        $called = false;
+        $mailer = function () use (&$called): bool {
+            $called = true;
+            return true;
+        };
+
+        $service = new TransferEmailService($db, $mailer);
+
+        $this->assertFalse($service->sendAdminAlert(1));
+        $this->assertFalse($called, 'Mailer must not be called when the requester cannot be found');
+        $this->assertLogContains($mockLogEntries, 'Requester ID 0 not found');
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `CarTransferRepository::findPendingWithCarById()` had no smoke test at any level (only a DB-error-path test). Added, mirroring the existing sibling smoke tests.
- **Note:** the issue's primary gap — DB-error-path tests for all 8 `CarTransferRepository` methods — was already closed by #1441/#1586 before this work started. Verified all 8 `*ThrowsOnDatabaseError` tests already exist; no duplicate work added.
- `CarAdministrationService::merge()` had 4 failure-path tests but no success-path test. Added.
- `TransferEmailService` gaps closed: non-callable `$mailer` constructor guard, `sendAdminAlert()` all-fail path (`$successCount === 0`), and the `sendRequest()`/`sendAdminAlert()` owner-not-found guards (`$currentOwner === null`, `$requester === null`).

Test-only change — no production code modified.

## Review notes

A local `/review-pr` pass (code-reviewer, comment-analyzer, pr-test-analyzer) found two recommendations, both fixed and verified by temporarily mutating the production code and confirming the tests fail as expected (then restored — `usersc/classes/` has zero diff):

- The 4 owner-not-found tests originally asserted only the `false` return value, which is indistinguishable from the guard being deleted entirely and a `TypeError` being swallowed by the method's catch-all `Throwable` handler. Now they assert the guard's specific log message.
- `testMergeSucceeds()` originally used a loose `insert()` stub; tightened to an actual call expectation so deleting `insertHistory()` from `merge()` would fail the test.

## Test plan

- [x] `composer test:quick` — 1385 tests, 3947 assertions, all passing
- [x] PHPStan clean on all three touched files
- [x] Mutation-verified the two hardened assertions (guard/insertHistory removed → tests fail; restored → tests pass)
- [x] Security review skipped — test-only diff, no forms/SQL/auth/production code changed

Closes #1422

Claude-Session: https://claude.ai/code/session_01KtyBe31Hortswi7zL7Kh7e