### PR TITLE
test: retire tautological tests in VerificationSecurityTest

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.29.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.1.md
@@ -94,3 +94,4 @@ Do the following, in order, **separately for each environment** (test, then prod
 - [#1551](https://github.com/elan-registry/registry/issues/1551) — test: cars_hist DELETE-order leak in TransferRequestConstraintTest and CarsYearSmallintMigrationTest
 - [#1542](https://github.com/elan-registry/registry/issues/1542) — test: RobotsTxtPolicyTest verifies repo robots.txt, not the as-served file with Cloudflare's injection
 - [#1604](https://github.com/elan-registry/registry/issues/1604) — test: VerificationWorkflowTest tests a wholly fictional class — zero coupling to production code
+- [#1609](https://github.com/elan-registry/registry/issues/1609) — test: VerificationSecurityTest has tautological tests asserting local data against itself

--- a/tests/unit/users/VerificationSecurityTest.php
+++ b/tests/unit/users/VerificationSecurityTest.php
@@ -13,28 +13,6 @@ use PHPUnit\Framework\TestCase;
  */
 class VerificationSecurityTest extends TestCase
 {
-    /** @var array<string, mixed> */
-    private array $originalGet;
-
-    /** @var array<string, mixed> */
-    private array $originalServer;
-
-    protected function setUp(): void
-    {
-        $this->originalGet = $_GET;
-        $this->originalServer = $_SERVER;
-
-        // Mock server variables
-        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-        $_SERVER['REQUEST_URI'] = '/app/verify/verify_car.php';
-    }
-
-    protected function tearDown(): void
-    {
-        $_GET = $this->originalGet;
-        $_SERVER = $this->originalServer;
-    }
-
     /**
      * Test the unit-tier Token stub's accept/reject contract.
      *
@@ -75,158 +53,18 @@ class VerificationSecurityTest extends TestCase
     }
     
     /**
-     * Test action parameter validation
-     */
-    public function testActionParameterValidation(): void
-    {
-        $validActions = ['verify', 'edit', 'sold'];
-        
-        // Test valid actions
-        foreach ($validActions as $action) {
-            $this->assertContains($action, $validActions);
-        }
-        
-        // Test invalid actions
-        $invalidActions = ['delete', 'admin', 'hack', '<script>', '../../etc/passwd'];
-        foreach ($invalidActions as $action) {
-            $this->assertNotContains($action, $validActions);
-        }
-    }
-    
-    /**
-     * Test URL parameter encoding for verification links
-     */
-    public function testURLParameterEncoding(): void
-    {
-        $code = 'test+code&special=chars';
-        $action = 'verify';
-        $token = 'test_token_123';
-        
-        $encodedCode = urlencode($code);
-        $encodedToken = urlencode($token);
-        
-        $this->assertNotEquals($code, $encodedCode);
-        $this->assertStringContainsString('%2B', $encodedCode); // + encoded
-        $this->assertStringContainsString('%26', $encodedCode); // & encoded
-        $this->assertStringContainsString('%3D', $encodedCode); // = encoded
-    }
-    
-    /**
-     * Test verification code format validation
-     */
-    public function testVerificationCodeFormat(): void
-    {
-        // Test MD5 hash format (32 hex characters)
-        $validCode = md5(uniqid((string)rand(), true));
-        $this->assertEquals(32, strlen($validCode));
-        $this->assertTrue(ctype_xdigit($validCode));
-        
-        // Test invalid formats
-        $invalidCodes = [
-            '', // empty
-            'short', // too short
-            'not-hex-characters-here-123456789', // non-hex
-            str_repeat('a', 33), // too long
-            '../../../etc/passwd', // directory traversal
-            '<script>alert("xss")</script>' // XSS attempt
-        ];
-        
-        foreach ($invalidCodes as $code) {
-            $this->assertNotEquals(32, strlen($code));
-        }
-    }
-    
-    /**
-     * Test Input::get() usage for security
-     */
-    public function testInputGetUsage(): void
-    {
-        // Test that Input class functionality works as expected
-        // Since we're using mocks, test the concept rather than actual implementation
-        $_GET = [
-            'code' => 'test123',
-            'action' => 'verify',
-            'token' => 'csrf_token_123'
-        ];
-        
-        // Test that $_GET data exists
-        $this->assertEquals('test123', $_GET['code']);
-        $this->assertEquals('verify', $_GET['action']);
-        $this->assertEquals('csrf_token_123', $_GET['token']);
-        
-        // Test that Input class exists in our bootstrap
-        $this->assertTrue(class_exists('Input'));
-    }
-    
-    /**
-     * Test CSRF token generation uniqueness
+     * Test that the unit-tier Token stub's generate() produces unique
+     * values across repeated calls. Real CSRF crypto uniqueness is covered
+     * by tests/integration/TokenAndInputSecurityTest.php (see
+     * testCSRFTokenValidation's docblock for the stub-vs-real-crypto scope note).
      */
     public function testCSRFTokenUniqueness(): void
     {
-        // Test token uniqueness concept using uniqid
         $tokens = [];
-        
-        // Generate multiple tokens using uniqid (similar to Token::generate concept)
         for ($i = 0; $i < 10; $i++) {
-            $token = 'token_' . uniqid() . '_' . $i;
-            $this->assertNotContains($token, $tokens);
-            $tokens[] = $token;
+            $tokens[] = Token::generate();
         }
-        
-        // Ensure all tokens are unique
-        $this->assertEquals(10, count(array_unique($tokens)));
-        
-        // Test that Token class exists
-        $this->assertTrue(class_exists('Token'));
-    }
-    
-    /**
-     * Test security logging functionality
-     */
-    public function testSecurityLogging(): void
-    {
-        // Test log parameters that would be used
-        $userId = 123;
-        $category = 'Security';
-        $message = 'CSRF token validation failed';
-        
-        $this->assertIsInt($userId);
-        $this->assertIsString($category);
-        $this->assertIsString($message);
-        $this->assertStringContainsString('CSRF', $message);
-    }
-    
-    /**
-     * Test verification email URL structure
-     */
-    public function testVerificationEmailURLStructure(): void
-    {
-        $baseUrl = 'https://elanregistry.org';
-        $verifyUrl = $baseUrl . '/app/verify/verify_car.php';
-        $code = 'abc123def456';
-        $action = 'verify';
-        $token = 'csrf_token_123';
-        
-        $fullUrl = $verifyUrl . '?code=' . urlencode($code) . '&action=' . $action . '&token=' . urlencode($token);
-        
-        // Test URL components
-        $this->assertStringStartsWith('https://', $fullUrl);
-        $this->assertStringContainsString('/app/verify/verify_car.php', $fullUrl);
-        $this->assertStringContainsString('code=', $fullUrl);
-        $this->assertStringContainsString('action=verify', $fullUrl);
-        $this->assertStringContainsString('token=', $fullUrl);
-        
-        // Test URL parsing
-        $parsedUrl = parse_url($fullUrl);
-        $this->assertArrayHasKey('query', $parsedUrl);
-        
-        parse_str($parsedUrl['query'], $params);
-        $this->assertArrayHasKey('code', $params);
-        $this->assertArrayHasKey('action', $params);
-        $this->assertArrayHasKey('token', $params);
-        $this->assertEquals($code, $params['code']);
-        $this->assertEquals($action, $params['action']);
-        $this->assertEquals($token, $params['token']);
+        $this->assertCount(10, array_unique($tokens));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

`tests/unit/users/VerificationSecurityTest.php` mixed real tests (exercising production code) with several that only asserted locally-built data against itself — the false-confidence pattern the "Honest Tests" milestone (#1440, #1446, #1556, #1604) exists to eliminate.

- **Deleted** (no coupling to production code, per issue's own analysis):
  - `testActionParameterValidation` — hardcoded a copy of `verify_car.php`'s `$validActions` array and asserted it against itself
  - `testURLParameterEncoding` — tested PHP's own `urlencode()`
  - `testVerificationCodeFormat` — asserted a self-generated `md5(uniqid())` string's length; fully redundant with the file's own MD5-allowlist data-provider tests, which pin the real regex from `verify_car.php:26`
  - `testInputGetUsage` — wrote to `$_GET` then read it back, asserted only `class_exists('Input')`
  - `testSecurityLogging` — asserted `assertIsInt(123)` on local literals
  - `testVerificationEmailURLStructure` — built a URL string locally then parsed its own construction, never touched `send_email.php`'s real link-building code
- **Retargeted**: `testCSRFTokenUniqueness` now calls the real `Token::generate()` stub 10 times and asserts uniqueness, instead of hand-rolling `uniqid()` strings that never touched the `Token` class
- **Removed**: now-dead `setUp()`/`tearDown()` `$_GET`/`$_SERVER` mocking — no remaining test touches those superglobals
- **Unchanged**: `testCSRFTokenValidation`, `testVerificationCodeSanitization`, `testMd5AllowlistAcceptsValidCodes`, `testMd5AllowlistRejectsInvalidCodes` (already real coverage)

No production code changes.

## Test plan

- [x] `vendor/bin/phpstan analyse tests/unit/users/VerificationSecurityTest.php` — no errors
- [x] `composer test:quick` — 1374 tests, 3859 assertions, all passing
- [x] Local `/review-pr` pass (code-reviewer, pr-test-analyzer) — clean, no blocking findings; confirmed no dangling references to the deleted methods and no coverage regression (the two "likely delete" areas were never actually covered by the deleted tests)

Closes #1609