### PR TITLE
test: extend LogCategoriesUsageTest to admin files, tighten CarTransferTest exceptions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,12 +271,6 @@ parameters:
 			path: tests/integration/CarDataTablesTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 7
-			path: tests/integration/CarTransferTest.php
-
-		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<Server\>\|Server, string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/IntegrationTestCase.php';
 
 use ElanRegistry\Car\Car;
 use ElanRegistry\Owner;
+use ElanRegistry\Exceptions\CarNotFoundException;
+use ElanRegistry\Exceptions\CarValidationException;
 
 use PHPUnit\Framework\Attributes\Group;
 
@@ -85,9 +87,7 @@ final class CarTransferTest extends IntegrationTestCase
     {
         $car = new Car($this->testCarId);
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER', $this->testUserId);
-
-        $this->assertTrue($result);
+        $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER', $this->testUserId);
 
         // Reload car data from database to verify transfer
         $transferredCar = new Car($this->testCarId);
@@ -100,7 +100,7 @@ final class CarTransferTest extends IntegrationTestCase
     #[Group('fast')]
     public function testTransferCarFailsWithInvalidUser(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CarValidationException::class);
 
         $car = new Car($this->testCarId);
         $car->transfer(99999, 'Test transfer', 'NEWOWNER', $this->testUserId);
@@ -112,7 +112,7 @@ final class CarTransferTest extends IntegrationTestCase
     #[Group('fast')]
     public function testTransferCarFailsWhenCarNotExists(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CarNotFoundException::class);
 
         $car = new Car(99999);
         $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER', $this->testUserId);
@@ -134,9 +134,7 @@ final class CarTransferTest extends IntegrationTestCase
         )->first();
         $this->assertSame($this->testUserId, (int) $before->user_id);
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER', $this->testUserId);
-
-        $this->assertTrue($result);
+        $car->transfer($this->targetUserId, 'Test transfer', 'NEWOWNER', $this->testUserId);
 
         // Verify owner was updated
         $after = $this->db->query(
@@ -155,9 +153,7 @@ final class CarTransferTest extends IntegrationTestCase
         $car = new Car($this->testCarId);
         $carId = $car->data()->id;
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer history', 'NEWOWNER', $this->testUserId);
-
-        $this->assertTrue($result);
+        $car->transfer($this->targetUserId, 'Test transfer history', 'NEWOWNER', $this->testUserId);
 
         // Check that history record was created with NEWOWNER operation
         $historyQuery = $this->db->query(
@@ -179,9 +175,7 @@ final class CarTransferTest extends IntegrationTestCase
         $targetUser = (new Owner($this->targetUserId))->data();
         $this->assertNotNull($targetUser);
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer profile', 'NEWOWNER', $this->testUserId);
-
-        $this->assertTrue($result);
+        $car->transfer($this->targetUserId, 'Test transfer profile', 'NEWOWNER', $this->testUserId);
 
         // Verify that car now has target user's profile data
         $updatedCar = new Car((int) $car->data()->id);
@@ -197,7 +191,7 @@ final class CarTransferTest extends IntegrationTestCase
     public function testTransferTransactionRollbackOnFailure(): void
     {
         // Test that invalid user causes transfer to fail completely
-        $this->expectException(Exception::class);
+        $this->expectException(CarValidationException::class);
 
         $car = new Car($this->testCarId);
         $originalUserId = $car->data()->user_id;
@@ -221,9 +215,7 @@ final class CarTransferTest extends IntegrationTestCase
         $car = new Car($this->testCarId);
         $carId = $car->data()->id;
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer', 'TRANSFER', $this->testUserId);
-
-        $this->assertTrue($result);
+        $car->transfer($this->targetUserId, 'Test transfer', 'TRANSFER', $this->testUserId);
 
         // Check that history record was created with TRANSFER operation
         $historyQuery = $this->db->query(
@@ -241,9 +233,7 @@ final class CarTransferTest extends IntegrationTestCase
     {
         $car = new Car($this->testCarId);
 
-        $result = $car->transfer($this->targetUserId, 'Test transfer location', 'NEWOWNER', $this->testUserId);
-
-        $this->assertTrue($result);
+        $car->transfer($this->targetUserId, 'Test transfer location', 'NEWOWNER', $this->testUserId);
 
         // Verify that car now has target user's location data
         $targetUser = (new Owner($this->targetUserId))->data();
@@ -269,12 +259,20 @@ final class CarTransferTest extends IntegrationTestCase
         unset($GLOBALS['user']);
 
         try {
-            $result = $car->transfer($this->targetUserId, 'Explicit actingUserId test', 'NEWOWNER', $this->testUserId);
-            $this->assertTrue($result);
+            $car->transfer($this->targetUserId, 'Explicit actingUserId test', 'NEWOWNER', $this->testUserId);
         } finally {
             if ($savedUser !== null) {
                 $GLOBALS['user'] = $savedUser;
             }
         }
+
+        // Reload with global $user restored (Car::__construct() needs it via getSettings())
+        // to verify transfer() itself did not depend on it.
+        $transferredCar = new Car($this->testCarId);
+        $this->assertEquals(
+            $this->targetUserId,
+            $transferredCar->data()->user_id,
+            'transfer() must not depend on global $user'
+        );
     }
 }

--- a/tests/unit/system/LogCategoriesUsageTest.php
+++ b/tests/unit/system/LogCategoriesUsageTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Test that car-related PHP endpoints use LogCategories constants
+ * Test that car, contact, and admin PHP endpoints use LogCategories constants
  * instead of hardcoded string literals in withLogging() and logger() calls.
  */
 #[Group('system')]
@@ -38,6 +38,17 @@ class LogCategoriesUsageTest extends TestCase
     private const CONTACT_ENDPOINT_FILES = [
         'app/api/contact/send-feedback.php',
         'app/api/contact/send-owner-email.php',
+    ];
+
+    /**
+     * Owner/user-administration PHP files that should use LogCategories constants
+     * for all logging category parameters. (Some other app/admin/includes/ files
+     * are grouped under CAR_ENDPOINT_FILES instead, by domain rather than path.)
+     */
+    private const ADMIN_ENDPOINT_FILES = [
+        'app/admin/includes/process-owner-search.php',
+        'app/admin/includes/process-owner-update.php',
+        'app/admin/includes/process-user-details.php',
     ];
 
     private string $rootDir;
@@ -506,6 +517,75 @@ class LogCategoriesUsageTest extends TestCase
     {
         $data = [];
         foreach (self::CONTACT_ENDPOINT_FILES as $file) {
+            $data[$file] = [$file];
+        }
+        return $data;
+    }
+
+    #[DataProvider('adminEndpointFilesProvider')]
+    public function testNoHardcodedWithLoggingStringsInAdminFiles(string $relativePath): void
+    {
+        $filePath = $this->rootDir . '/' . $relativePath;
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped("File not found: $relativePath");
+        }
+
+        $content = file_get_contents($filePath);
+
+        // Match withLogging calls that use string literals for the category parameter
+        // Pattern: ->withLogging(anything, 'SomeString', anything)
+        // The category is the second argument after the user ID
+        $pattern = '/->withLogging\s*\([^,]+,\s*[\'"][A-Za-z]+[\'"]/';
+
+        $matches = [];
+        preg_match_all($pattern, $content, $matches);
+
+        $this->assertEmpty(
+            $matches[0],
+            sprintf(
+                "File %s contains hardcoded string literals in withLogging() calls. " .
+                "Use LogCategories constants instead.\nFound: %s",
+                $relativePath,
+                implode(', ', $matches[0])
+            )
+        );
+    }
+
+    #[DataProvider('adminEndpointFilesProvider')]
+    public function testNoHardcodedLoggerStringsInAdminFiles(string $relativePath): void
+    {
+        $filePath = $this->rootDir . '/' . $relativePath;
+        if (!file_exists($filePath)) {
+            $this->markTestSkipped("File not found: $relativePath");
+        }
+
+        $content = file_get_contents($filePath);
+
+        // Match logger() calls that use string literals for the category parameter
+        // Pattern: logger(anything, 'SomeString', anything)
+        $pattern = '/\blogger\s*\([^,]+,\s*[\'"][A-Za-z]+[\'"]/';
+
+        $matches = [];
+        preg_match_all($pattern, $content, $matches);
+
+        $this->assertEmpty(
+            $matches[0],
+            sprintf(
+                "File %s contains hardcoded string literals in logger() calls. " .
+                "Use LogCategories constants instead.\nFound: %s",
+                $relativePath,
+                implode(', ', $matches[0])
+            )
+        );
+    }
+
+    /**
+     * Data provider for admin endpoint files
+     */
+    public static function adminEndpointFilesProvider(): array
+    {
+        $data = [];
+        foreach (self::ADMIN_ENDPOINT_FILES as $file) {
             $data[$file] = [$file];
         }
         return $data;


### PR DESCRIPTION
## Summary

- Added `ADMIN_ENDPOINT_FILES` to `LogCategoriesUsageTest` covering the three admin files (`process-owner-search.php`, `process-owner-update.php`, `process-user-details.php`) migrated to `LogCategories` constants in v2.28.0, wired to the same hardcoded-string regression checks used for car/contact endpoints.
- Tightened three `CarTransferTest` assertions from base `Exception::class` to the specific typed exceptions actually thrown (`CarValidationException`, `CarNotFoundException`), verified against the real throw sites in `Car::transfer()` and `CarAdministrationService::transfer()`.
- Cleared 7 baselined PHPStan errors in `CarTransferTest.php` for tautological `assertTrue($result)` calls (`Car::transfer()` is typed `: true`) per fix-when-you-touch-it baseline hygiene — replaced the one that was a test's sole assertion with a real DB-state check.

## Test plan

- [x] `vendor/bin/phpstan analyse` on both changed test files — 0 errors
- [x] `composer check:php` — 0 errors, 42 pre-existing unrelated warnings
- [x] `vendor/bin/phpunit --filter LogCategoriesUsageTest` — 43/43 pass (51 assertions)
- [x] `composer test:quick` (full unit suite) — 1363/1363 pass
- [x] `php -l` on `CarTransferTest.php` — no syntax errors
- [ ] `CarTransferTest` integration tests could not run locally (no DB configured in this environment — confirmed pre-existing/environment-wide, all other integration tests skip identically); exception-type changes verified via source tracing instead
- [x] Local multi-agent review (`/review-pr`): code-reviewer, pr-test-analyzer, comment-analyzer — one blocking finding (PHPStan baseline debt), fixed and re-verified; two minor docblock accuracy recommendations, also fixed

Closes #1423

https://claude.ai/code/session_01KtyBe31Hortswi7zL7Kh7e