### PR TITLE
test: extract shared authenticated-session helper for integration tests

### DIFF
--- a/docs/development/TESTING_STRATEGY.md
+++ b/docs/development/TESTING_STRATEGY.md
@@ -117,6 +117,56 @@ test:regression` test. A new mock-compatible regression test belongs in
 `#[Group('regression')]` attribute alone on a test living elsewhere will
 **not** be picked up by `composer test:regression`.
 
+### Authenticated Sessions in Integration Tests
+
+Code under test that calls `currentUserId()`, reads `global $user`, or checks
+permissions needs an authenticated session. `IntegrationTestCase` provides the
+only supported way to create one:
+
+- `loginAsTestUser(int $userId): User` — marks a real `users` row (usually one
+  from `createTestUser()`) as the ambient logged-in session, setting both
+  `$GLOBALS['user']` and the `global $user` alias, and returns the `User`
+  instance.
+- `restoreGlobalUser(): void` — restores whatever session was ambient before
+  the first `loginAsTestUser()` call of the current test. Idempotent.
+
+Two usage patterns:
+
+- **Whole class needs a session** — call `$this->loginAsTestUser($userId);` in
+  `setUp()` and do nothing else. `IntegrationTestCase::tearDown()` calls
+  `restoreGlobalUser()` automatically, so the fake session can't leak into the
+  next test class.
+- **Only specific test methods need a session** — leave `setUp()`
+  unauthenticated, call `$this->loginAsTestUser($userId)` inline in the methods
+  that need it, and call `$this->restoreGlobalUser();` in a `finally` block so
+  the session ends with that method rather than at `tearDown()`.
+
+**If your test class overrides `tearDown()`, it must call `parent::tearDown()`
+unconditionally** — wrap its own cleanup in
+`try { ...own cleanup... } finally { parent::tearDown(); }`. The automatic
+restore is the *first* statement of `IntegrationTestCase::tearDown()` precisely
+so a later failure can't skip it, but that guarantee silently evaporates if a
+subclass's own cleanup throws before reaching `parent::tearDown()`. Nothing
+fails loudly when this happens; the fake session just leaks into the next test
+class. See `tests/integration/database/CarsYearSmallintMigrationTest.php` for
+the pattern.
+
+Do **not** hand-roll the reflection-based login bypass (`new User()` → `find()`
+→ set `_isLoggedIn` → assign `$GLOBALS['user']`) in a test again. Duplicating it
+is what left authenticated sessions leaking between test classes (#1572); the
+helper is the single place that idiom is allowed to live.
+
+**Out of scope — the inverse idiom.** Temporarily *removing* `$GLOBALS['user']`
+mid-test to verify "no ambient session" behaviour (rather than authenticating) is
+deliberately **not** covered by these helpers, and remains hand-rolled in
+`CarDeletionTest.php`, `CarMergeTest.php`, and `CarTransferTest.php` (one test
+method each). That is a known, intentional boundary, not an oversight —
+`loginAsTestUser()`/`restoreGlobalUser()` are session *creation* helpers, and
+folding an "unauthenticate" mode into them would complicate the snapshot
+bookkeeping for three call sites. If a fourth appears, extract a separate
+helper for that narrower need rather than re-duplicating the idiom or
+overloading these two.
+
 ## UserSpice `DB` Class Conventions
 
 UserSpice ships no test suite and no testing conventions of its own — the

--- a/docs/development/TESTING_STRATEGY.md
+++ b/docs/development/TESTING_STRATEGY.md
@@ -137,9 +137,12 @@ Two usage patterns:
   `restoreGlobalUser()` automatically, so the fake session can't leak into the
   next test class.
 - **Only specific test methods need a session** — leave `setUp()`
-  unauthenticated, call `$this->loginAsTestUser($userId)` inline in the methods
-  that need it, and call `$this->restoreGlobalUser();` in a `finally` block so
-  the session ends with that method rather than at `tearDown()`.
+  unauthenticated. In the methods that need it, start a `try` block and call
+  `$this->loginAsTestUser($userId)` as its first statement, then call
+  `$this->restoreGlobalUser();` in a `finally` block so the session ends with
+  that method rather than at `tearDown()`. Login must be the first statement
+  inside `try` — not before it — so a throw during login can't skip the
+  `finally` and leak the fake session.
 
 **If your test class overrides `tearDown()`, it must call `parent::tearDown()`
 unconditionally** — wrap its own cleanup in

--- a/docs/releases/RELEASE_NOTES_v2.29.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.1.md
@@ -96,3 +96,4 @@ Do the following, in order, **separately for each environment** (test, then prod
 - [#1604](https://github.com/elan-registry/registry/issues/1604) — test: VerificationWorkflowTest tests a wholly fictional class — zero coupling to production code
 - [#1609](https://github.com/elan-registry/registry/issues/1609) — test: VerificationSecurityTest has tautological tests asserting local data against itself
 - [#1603](https://github.com/elan-registry/registry/issues/1603) — test: LocationServiceResponseTest only exercises ApiResponse literals, never the location-search/reverse endpoints
+- [#1572](https://github.com/elan-registry/registry/issues/1572) — test: extract shared authenticated-session helper for integration tests, migrating 10 files off the duplicated login idiom

--- a/tests/integration/CarDeletionTest.php
+++ b/tests/integration/CarDeletionTest.php
@@ -30,17 +30,7 @@ final class CarDeletionTest extends IntegrationTestCase
         $this->testUserId = $this->createTestUser();
 
         // Set up authenticated user context for deletion operations
-        global $user;
-        $user = new User();
-        $user->find($this->testUserId);
-
-        // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
-        // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
-        $reflection = new ReflectionClass($user);
-        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
-        $isLoggedInProperty->setValue($user, true);
-
-        $GLOBALS['user'] = $user;
+        $this->loginAsTestUser($this->testUserId);
 
         // Create unique test car for this test
         try {

--- a/tests/integration/CarMergeTest.php
+++ b/tests/integration/CarMergeTest.php
@@ -32,17 +32,7 @@ final class CarMergeTest extends IntegrationTestCase
         $this->testUserId = $this->createTestUser();
 
         // Set up authenticated user context for merge operations
-        global $user;
-        $user = new User();
-        $user->find($this->testUserId);
-
-        // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
-        // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
-        $reflection = new ReflectionClass($user);
-        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
-        $isLoggedInProperty->setValue($user, true);
-
-        $GLOBALS['user'] = $user;
+        $this->loginAsTestUser($this->testUserId);
 
         // Create unique test cars for this test
         try {

--- a/tests/integration/CarOwnershipSecurityTest.php
+++ b/tests/integration/CarOwnershipSecurityTest.php
@@ -68,8 +68,6 @@ final class CarOwnershipSecurityTest extends IntegrationTestCase
         $nonOwnerUserId = $this->createTestUser();
         $carId = $this->createTestCar($ownerUserId);
 
-        $this->loginAsTestUser($nonOwnerUserId);
-
         // hasPerm() reads the $master_account global, which may be null when
         // users/init.php aborts early in the integration test bootstrap.
         global $master_account;
@@ -77,6 +75,10 @@ final class CarOwnershipSecurityTest extends IntegrationTestCase
         $master_account = $master_account ?? [];
 
         try {
+            // Login happens inside try so a throw during login can never
+            // skip the finally's restoreGlobalUser() and leak the fake session.
+            $this->loginAsTestUser($nonOwnerUserId);
+
             $car = new Car($carId);
 
             // Read the global session, exactly as the production guard does.
@@ -98,9 +100,11 @@ final class CarOwnershipSecurityTest extends IntegrationTestCase
         $ownerUserId = $this->createTestUser();
         $carId = $this->createTestCar($ownerUserId);
 
-        $this->loginAsTestUser($ownerUserId);
-
         try {
+            // Login happens inside try so a throw during login can never
+            // skip the finally's restoreGlobalUser() and leak the fake session.
+            $this->loginAsTestUser($ownerUserId);
+
             $car = new Car($carId);
 
             // Read the global session, exactly as the production guard does.

--- a/tests/integration/CarOwnershipSecurityTest.php
+++ b/tests/integration/CarOwnershipSecurityTest.php
@@ -68,18 +68,7 @@ final class CarOwnershipSecurityTest extends IntegrationTestCase
         $nonOwnerUserId = $this->createTestUser();
         $carId = $this->createTestCar($ownerUserId);
 
-        global $user;
-        $originalUser = $user;
-
-        $nonOwner = new User();
-        $nonOwner->find($nonOwnerUserId);
-
-        $reflection = new ReflectionClass($nonOwner);
-        $prop = $reflection->getProperty('_isLoggedIn');
-        $prop->setValue($nonOwner, true);
-
-        $user = $nonOwner;
-        $GLOBALS['user'] = $nonOwner;
+        $this->loginAsTestUser($nonOwnerUserId);
 
         // hasPerm() reads the $master_account global, which may be null when
         // users/init.php aborts early in the integration test bootstrap.
@@ -90,14 +79,14 @@ final class CarOwnershipSecurityTest extends IntegrationTestCase
         try {
             $car = new Car($carId);
 
-            $isNotOwner = ((int) $user->data()->id !== (int) $car->data()->user_id);
+            // Read the global session, exactly as the production guard does.
+            $isNotOwner = ((int) $GLOBALS['user']->data()->id !== (int) $car->data()->user_id);
             $isNotAdmin = !hasPerm([2, 3]);
 
             $this->assertTrue($isNotOwner && $isNotAdmin, 'Guard must block non-owner');
         } finally {
             $master_account = $masterAccountBackup;
-            $user = $originalUser;
-            $GLOBALS['user'] = $originalUser;
+            $this->restoreGlobalUser();
         }
     }
 
@@ -109,28 +98,17 @@ final class CarOwnershipSecurityTest extends IntegrationTestCase
         $ownerUserId = $this->createTestUser();
         $carId = $this->createTestCar($ownerUserId);
 
-        global $user;
-        $originalUser = $user;
-
-        $owner = new User();
-        $owner->find($ownerUserId);
-
-        $reflection = new ReflectionClass($owner);
-        $prop = $reflection->getProperty('_isLoggedIn');
-        $prop->setValue($owner, true);
-
-        $user = $owner;
-        $GLOBALS['user'] = $owner;
+        $this->loginAsTestUser($ownerUserId);
 
         try {
             $car = new Car($carId);
 
-            $isNotOwner = ((int) $user->data()->id !== (int) $car->data()->user_id);
+            // Read the global session, exactly as the production guard does.
+            $isNotOwner = ((int) $GLOBALS['user']->data()->id !== (int) $car->data()->user_id);
 
             $this->assertFalse($isNotOwner, 'Guard must allow the owner through');
         } finally {
-            $user = $originalUser;
-            $GLOBALS['user'] = $originalUser;
+            $this->restoreGlobalUser();
         }
     }
 }

--- a/tests/integration/CarTransferTest.php
+++ b/tests/integration/CarTransferTest.php
@@ -34,17 +34,7 @@ final class CarTransferTest extends IntegrationTestCase
         $this->targetUserId = $this->createTestUser();
 
         // Set up authenticated user context for transfer operations
-        global $user;
-        $user = new User();
-        $user->find($this->testUserId);
-
-        // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
-        // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
-        $reflection = new ReflectionClass($user);
-        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
-        $isLoggedInProperty->setValue($user, true);
-
-        $GLOBALS['user'] = $user;
+        $this->loginAsTestUser($this->testUserId);
 
         $this->db = DB::getInstance();
 
@@ -73,10 +63,15 @@ final class CarTransferTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        if ($this->databaseConnected && $this->targetUserId) {
-            $this->db->query("DELETE FROM profiles WHERE user_id = ?", [$this->targetUserId]);
+        try {
+            if ($this->databaseConnected && $this->targetUserId) {
+                $this->db->query("DELETE FROM profiles WHERE user_id = ?", [$this->targetUserId]);
+            }
+        } finally {
+            // Run even if the profile cleanup above throws, so the base class's own
+            // fixture cleanup — and its restoreGlobalUser() call — is never skipped.
+            parent::tearDown();
         }
-        parent::tearDown();
     }
 
     /**

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -183,9 +183,10 @@ abstract class IntegrationTestCase extends TestCase
         } else {
             // Defensive, not dead: tests/bootstrap-integration.php seeds a non-null
             // $GLOBALS['user'] once per process, so in practice the snapshot is never
-            // null — unless an earlier test unset the global itself.
+            // null — unless an earlier test unset the global itself. No unset($user)
+            // here: unsetting a global-bound local never unsets the actual superglobal,
+            // so it would just be a no-op.
             unset($GLOBALS['user']);
-            unset($user);
         }
 
         $this->savedGlobalUser = null;

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -42,6 +42,12 @@ abstract class IntegrationTestCase extends TestCase
     /** @var int[] User IDs created during this test, cleaned up in tearDown */
     private array $createdUserIds = [];
 
+    /** @var User|null Snapshot of $GLOBALS['user'] from the first loginAsTestUser() call of a test. */
+    private ?User $savedGlobalUser = null;
+
+    /** Whether $savedGlobalUser is awaiting restoration (disambiguates "nothing saved" from "saved null"). */
+    private bool $globalUserRestorePending = false;
+
     /**
      * Set up test environment
      * Initializes database connection
@@ -73,6 +79,8 @@ abstract class IntegrationTestCase extends TestCase
      */
     protected function tearDown(): void
     {
+        $this->restoreGlobalUser();
+
         if ($this->databaseConnected) {
             foreach ($this->createdCarIds as $carId) {
                 try {
@@ -110,6 +118,78 @@ abstract class IntegrationTestCase extends TestCase
         if (!$this->databaseConnected) {
             $this->markTestSkipped('Database connection not available for integration testing');
         }
+    }
+
+    /**
+     * Authenticate a test user as the ambient session for the current test.
+     *
+     * UserSpice's User class has no public API to mark an instance logged-in without a
+     * real HTTP request/session round-trip, so this bypasses login() by setting the
+     * private $_isLoggedIn flag directly via reflection. setAccessible() is intentionally
+     * omitted on the ReflectionProperty call below — it has been a no-op since PHP 8.1.
+     *
+     * Sets $GLOBALS['user'] (the `global $user` alias inside this method binds the same
+     * storage slot, so both reads observe the authenticated session). The previous
+     * $GLOBALS['user'] is snapshotted on first use only, so calling this more than once
+     * in a test still restores the value ambient before *this test's* first call.
+     *
+     * IntegrationTestCase::tearDown() restores automatically; call restoreGlobalUser()
+     * directly if a test must not leak the fake session past a single test method.
+     *
+     * @param int $userId A user ID already persisted to `users` (e.g. via createTestUser()).
+     * @return User The authenticated instance, already the ambient session.
+     */
+    protected function loginAsTestUser(int $userId): User
+    {
+        $loggedInUser = new User();
+        if (!$loggedInUser->find($userId)) {
+            throw new RuntimeException("loginAsTestUser(): no users row with id {$userId}");
+        }
+
+        $reflection = new ReflectionClass($loggedInUser);
+        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
+        $isLoggedInProperty->setValue($loggedInUser, true);
+
+        if (!$this->globalUserRestorePending) {
+            $this->savedGlobalUser = $GLOBALS['user'] ?? null;
+            $this->globalUserRestorePending = true;
+        }
+
+        global $user;
+        $user = $loggedInUser;
+        $GLOBALS['user'] = $loggedInUser;
+
+        return $loggedInUser;
+    }
+
+    /**
+     * Restore $GLOBALS['user'] (and the `global $user` alias) to whatever was ambient
+     * before the first loginAsTestUser() call of this test, or unset both if nothing was
+     * ambient. Idempotent — safe to call when no loginAsTestUser() call is pending, so
+     * setUp()-only callers (auto-restored by tearDown()) and inline mid-test-method
+     * callers (explicit finally-block call, whose later tearDown() invocation becomes a
+     * harmless no-op) both work correctly.
+     */
+    protected function restoreGlobalUser(): void
+    {
+        if (!$this->globalUserRestorePending) {
+            return;
+        }
+
+        global $user;
+        if ($this->savedGlobalUser !== null) {
+            $user = $this->savedGlobalUser;
+            $GLOBALS['user'] = $this->savedGlobalUser;
+        } else {
+            // Defensive, not dead: tests/bootstrap-integration.php seeds a non-null
+            // $GLOBALS['user'] once per process, so in practice the snapshot is never
+            // null — unless an earlier test unset the global itself.
+            unset($GLOBALS['user']);
+            unset($user);
+        }
+
+        $this->savedGlobalUser = null;
+        $this->globalUserRestorePending = false;
     }
 
     /**

--- a/tests/integration/IntegrationTestCaseAuthHelperTest.php
+++ b/tests/integration/IntegrationTestCaseAuthHelperTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/IntegrationTestCase.php';
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for IntegrationTestCase's own loginAsTestUser()/restoreGlobalUser() helpers.
+ *
+ * The snapshot/restore bookkeeping (snapshot-on-first-call-only, idempotent restore,
+ * unset-vs-restore branching) is the only non-trivial logic in the helper, and none of
+ * the call sites that use it exercise those branches — each logs in exactly once and
+ * lets tearDown() restore. This file covers them directly, since a regression there
+ * reintroduces exactly the cross-test session leak #1572 fixed.
+ *
+ * Every test here deliberately manipulates $GLOBALS['user'] itself to set up the
+ * precondition it needs, so setUp()/tearDown() snapshot and restore the process-wide
+ * ambient value around each test — otherwise this file would leak the very state it
+ * exists to protect.
+ */
+#[Group('integration')]
+final class IntegrationTestCaseAuthHelperTest extends IntegrationTestCase
+{
+    /** Car ID no fixture ever creates — only ever handed to the cleanup probe below. */
+    private const UNUSED_CAR_ID = PHP_INT_MAX;
+
+    /** Value of $GLOBALS['user'] before this test ran (meaningless if $ambientUserWasSet is false). */
+    private mixed $ambientUser = null;
+
+    /** Whether $GLOBALS['user'] existed at all before this test ran. */
+    private bool $ambientUserWasSet = false;
+
+    /**
+     * Set by test_tearDownRestoresGlobalBeforeRunningCleanup() only: whether the ambient
+     * session was already back in $GLOBALS['user'] when tearDown()'s cleanup phase ran.
+     * Null means the probe was never armed, so tearDown() has nothing to assert.
+     */
+    private ?bool $globalWasRestoredDuringCleanup = null;
+
+    /** Real DB handle, stashed while the cleanup probe stands in for it. */
+    private mixed $realDb = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Snapshot BEFORE requireDatabase(): markTestSkipped() returns from setUp() early,
+        // but tearDown() still runs — with no snapshot taken it would fall into the
+        // unset($GLOBALS['user']) branch and wipe the ambient session for the rest of
+        // the process, which is the exact leak this file exists to guard against.
+        $this->ambientUserWasSet = array_key_exists('user', $GLOBALS);
+        $this->ambientUser = $GLOBALS['user'] ?? null;
+
+        $this->requireDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            parent::tearDown();
+        } finally {
+            if ($this->realDb !== null) {
+                $this->db = $this->realDb;
+                $this->realDb = null;
+            }
+
+            // Restore after parent::tearDown(), since the helper's own restore runs there
+            // and would otherwise put this test's sentinel back into the global.
+            if ($this->ambientUserWasSet) {
+                $GLOBALS['user'] = $this->ambientUser;
+            } else {
+                unset($GLOBALS['user']);
+            }
+        }
+
+        if ($this->globalWasRestoredDuringCleanup !== null) {
+            $this->assertTrue(
+                $this->globalWasRestoredDuringCleanup,
+                'tearDown() must restore $GLOBALS[\'user\'] before it starts deleting fixtures'
+            );
+        }
+    }
+
+    /**
+     * A second loginAsTestUser() call must not re-snapshot: restore returns the session
+     * that was ambient before the *first* login, not the intermediate one.
+     */
+    public function test_secondLoginDoesNotResnapshot_restoreReturnsPreFirstLoginSession(): void
+    {
+        $ambientSentinel = new User();
+        $GLOBALS['user'] = $ambientSentinel;
+
+        $firstUserId  = $this->createTestUser();
+        $secondUserId = $this->createTestUser();
+
+        $firstSession = $this->loginAsTestUser($firstUserId);
+        $this->assertSame($firstSession, $GLOBALS['user'], 'First login must publish to the global');
+
+        $secondSession = $this->loginAsTestUser($secondUserId);
+        $this->assertNotSame($firstSession, $secondSession, 'Each login must build a fresh User instance');
+        $this->assertSame($secondSession, $GLOBALS['user'], 'Second login must publish to the global');
+
+        $this->restoreGlobalUser();
+
+        $this->assertSame(
+            $ambientSentinel,
+            $GLOBALS['user'],
+            'Restore must return the session ambient before the FIRST login, not the intermediate one'
+        );
+    }
+
+    /**
+     * restoreGlobalUser() is idempotent: once it has restored, a second call must leave
+     * $GLOBALS['user'] alone rather than re-applying a stale snapshot.
+     */
+    public function test_secondRestoreIsNoOp(): void
+    {
+        $ambientSentinel = new User();
+        $GLOBALS['user'] = $ambientSentinel;
+
+        $this->loginAsTestUser($this->createTestUser());
+        $this->restoreGlobalUser();
+        $this->assertSame($ambientSentinel, $GLOBALS['user'], 'First restore must put the ambient session back');
+
+        // Simulate whatever runs next (another test, or tearDown) owning the global now.
+        $laterSentinel = new User();
+        $GLOBALS['user'] = $laterSentinel;
+
+        $this->restoreGlobalUser();
+
+        $this->assertSame(
+            $laterSentinel,
+            $GLOBALS['user'],
+            'A second restore must be a no-op, not clobber the current session with a stale snapshot'
+        );
+    }
+
+    /**
+     * When nothing was ambient before the login, restore must remove the key entirely —
+     * leaving it set to null would make `isset($GLOBALS['user'])` behave the same but
+     * `array_key_exists()` checks see a different state than they did before the test.
+     */
+    public function test_restoreUnsetsGlobalWhenNothingWasAmbient(): void
+    {
+        // Create the fixture first: the "no ambient session" window must be as narrow
+        // as possible, since DB fixture helpers may consult the global.
+        $userId = $this->createTestUser();
+
+        // tests/bootstrap-integration.php seeds a non-null $GLOBALS['user'] once per
+        // process, so the no-ambient-value case has to be forced here. setUp() captured
+        // the real ambient value and tearDown() puts it back.
+        unset($GLOBALS['user']);
+
+        $this->loginAsTestUser($userId);
+        $this->assertArrayHasKey('user', $GLOBALS, 'Login must publish to the global');
+
+        $this->restoreGlobalUser();
+
+        $this->assertFalse(
+            array_key_exists('user', $GLOBALS),
+            'Restore must unset $GLOBALS[\'user\'] entirely when nothing was ambient, not set it to null'
+        );
+    }
+
+    /**
+     * A user ID with no `users` row must fail loudly. Silently returning a User that
+     * find() left unpopulated would publish a hollow session to $GLOBALS['user'] and
+     * surface later as a confusing null-property error in whatever the test asserts.
+     */
+    public function test_loginAsTestUserThrowsWhenUserIdDoesNotExist(): void
+    {
+        $missingUserId = $this->firstUnusedUserId();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("loginAsTestUser(): no users row with id {$missingUserId}");
+
+        $this->loginAsTestUser($missingUserId);
+    }
+
+    /**
+     * tearDown() must restore the global session *before* it deletes fixtures, so a
+     * cleanup failure cannot strand the fake session in $GLOBALS['user'] for every test
+     * that follows. The cleanup loops swallow their own RuntimeExceptions, so the failure
+     * is invisible from outside: the DB handle is swapped for a probe that records what
+     * $GLOBALS['user'] holds the moment cleanup starts and then fails the delete.
+     * tearDown() above asserts on the recording.
+     */
+    public function test_tearDownRestoresGlobalBeforeRunningCleanup(): void
+    {
+        $ambientSentinel = new User();
+        $GLOBALS['user'] = $ambientSentinel;
+
+        $userId  = $this->createTestUser();
+        $session = $this->loginAsTestUser($userId);
+        $this->assertSame($session, $GLOBALS['user'], 'Login must publish to the global');
+
+        // Delete the fixture through the real handle now — the probe below intercepts
+        // every query tearDown() would otherwise use to clean it up.
+        $this->deleteTestUser($userId);
+
+        // Give the car cleanup loop one iteration to run. The ID is deliberately one no
+        // fixture created; the probe never reaches the database with it anyway.
+        $this->trackCarId(self::UNUSED_CAR_ID);
+
+        $recordGlobal = function () use ($ambientSentinel): void {
+            $this->globalWasRestoredDuringCleanup = (($GLOBALS['user'] ?? null) === $ambientSentinel);
+        };
+
+        $this->realDb = $this->db;
+        $this->db     = new class ($recordGlobal) {
+            public function __construct(private Closure $recordGlobal)
+            {
+            }
+
+            public function query(string $sql, array $params = []): never
+            {
+                $this->recordAndFail();
+            }
+
+            public function delete(string $table, array $where): never
+            {
+                $this->recordAndFail();
+            }
+
+            private function recordAndFail(): never
+            {
+                ($this->recordGlobal)();
+                throw new RuntimeException('intentional cleanup failure (tearDown ordering probe)');
+            }
+        };
+    }
+
+    /**
+     * Lowest `users.id` guaranteed not to exist, with enough headroom that a concurrent
+     * fixture insert cannot claim it mid-test.
+     */
+    private function firstUnusedUserId(): int
+    {
+        $result = $this->db->query('SELECT COALESCE(MAX(id), 0) + 1000000 AS unused_id FROM users');
+        if ($result->error()) {
+            throw new RuntimeException("Could not determine an unused user ID: {$result->errorString()}");
+        }
+
+        return (int) $result->first()->unused_id;
+    }
+}

--- a/tests/integration/ManageConsolidatedDeletionTest.php
+++ b/tests/integration/ManageConsolidatedDeletionTest.php
@@ -39,17 +39,7 @@ final class ManageConsolidatedDeletionTest extends IntegrationTestCase
         $this->testUserId = $this->createTestUser();
 
         // Set up authenticated user context required by Car::delete()
-        global $user;
-        $user = new User();
-        $user->find($this->testUserId);
-
-        // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
-        // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
-        $reflection = new ReflectionClass($user);
-        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
-        $isLoggedInProperty->setValue($user, true);
-
-        $GLOBALS['user'] = $user;
+        $this->loginAsTestUser($this->testUserId);
 
         try {
             $this->testCarId = $this->createTestCar($this->testUserId, [

--- a/tests/integration/OwnerEmailSecurityTest.php
+++ b/tests/integration/OwnerEmailSecurityTest.php
@@ -32,7 +32,7 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
      * H2 regression anchor: forged from_user_id in POST is ignored.
      *
      * The endpoint derives $fromUserId = (int) $user->data()->id
-     * (send-owner-email.php:63), never from POST input. This test confirms
+     * (send-owner-email.php:67), never from POST input. This test confirms
      * that even when an attacker injects from_user_id into POST, the
      * derivation still returns the real session user.
      */
@@ -41,32 +41,21 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
         $realSenderId = $this->createTestUser();
         $forgedTargetId = $this->createTestUser();
 
-        global $user;
-        $originalUser = $user;
-
-        $realSender = new User();
-        $realSender->find($realSenderId);
-
-        $reflection = new ReflectionClass($realSender);
-        $prop = $reflection->getProperty('_isLoggedIn');
-        $prop->setValue($realSender, true);
-
-        $user = $realSender;
-        $GLOBALS['user'] = $realSender;
+        $this->loginAsTestUser($realSenderId);
 
         try {
             // Inject the forged value inside try{} so finally always cleans it up
             $_POST['from_user_id'] = (string) $forgedTargetId;
 
-            // Replicate the endpoint's sender derivation (send-owner-email.php:63)
-            $fromUserId = (int) $user->data()->id;
+            // Replicate the endpoint's sender derivation (send-owner-email.php:67) — read
+            // the global session, exactly as production does, not a local helper return value.
+            $fromUserId = (int) $GLOBALS['user']->data()->id;
 
             $this->assertEquals($realSenderId, $fromUserId);
             $this->assertNotEquals((int) $_POST['from_user_id'], $fromUserId);
         } finally {
             unset($_POST['from_user_id']);
-            $user = $originalUser;
-            $GLOBALS['user'] = $originalUser;
+            $this->restoreGlobalUser();
         }
     }
 
@@ -77,27 +66,16 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
     {
         $userId = $this->createTestUser();
 
-        global $user;
-        $originalUser = $user;
-
-        $sessionUser = new User();
-        $sessionUser->find($userId);
-
-        $reflection = new ReflectionClass($sessionUser);
-        $prop = $reflection->getProperty('_isLoggedIn');
-        $prop->setValue($sessionUser, true);
-
-        $user = $sessionUser;
-        $GLOBALS['user'] = $sessionUser;
+        $this->loginAsTestUser($userId);
 
         try {
-            // Replicate the endpoint's sender derivation (send-owner-email.php:63)
-            $fromUserId = (int) $user->data()->id;
+            // Replicate the endpoint's sender derivation (send-owner-email.php:67) — read
+            // the global session, exactly as production does, not a local helper return value.
+            $fromUserId = (int) $GLOBALS['user']->data()->id;
 
             $this->assertEquals($userId, $fromUserId);
         } finally {
-            $user = $originalUser;
-            $GLOBALS['user'] = $originalUser;
+            $this->restoreGlobalUser();
         }
     }
 

--- a/tests/integration/OwnerEmailSecurityTest.php
+++ b/tests/integration/OwnerEmailSecurityTest.php
@@ -41,9 +41,11 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
         $realSenderId = $this->createTestUser();
         $forgedTargetId = $this->createTestUser();
 
-        $this->loginAsTestUser($realSenderId);
-
         try {
+            // Login happens inside try so a throw during login can never skip the
+            // finally's restoreGlobalUser() and leak the fake session.
+            $this->loginAsTestUser($realSenderId);
+
             // Inject the forged value inside try{} so finally always cleans it up
             $_POST['from_user_id'] = (string) $forgedTargetId;
 
@@ -66,9 +68,11 @@ final class OwnerEmailSecurityTest extends IntegrationTestCase
     {
         $userId = $this->createTestUser();
 
-        $this->loginAsTestUser($userId);
-
         try {
+            // Login happens inside try so a throw during login can never skip the
+            // finally's restoreGlobalUser() and leak the fake session.
+            $this->loginAsTestUser($userId);
+
             // Replicate the endpoint's sender derivation (send-owner-email.php:67) — read
             // the global session, exactly as production does, not a local helper return value.
             $fromUserId = (int) $GLOBALS['user']->data()->id;

--- a/tests/integration/UserDeletionReassignmentTest.php
+++ b/tests/integration/UserDeletionReassignmentTest.php
@@ -23,8 +23,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('integration')]
 final class UserDeletionReassignmentTest extends IntegrationTestCase
 {
-    private $savedGlobalUser;
-
     /**
      * @var int[] user_ids of profile rows this test inserted directly (bypassing
      *     IntegrationTestCase's fixtures, which don't track profiles). The hook is
@@ -48,38 +46,24 @@ final class UserDeletionReassignmentTest extends IntegrationTestCase
         // an authenticated (non-admin) test user, not an actual admin. Without it, the
         // hook aborts before reassigning cars and the final assertion below fails with
         // a confusing "wrong ID" message instead of a clear "no session" error.
-        $this->savedGlobalUser = $GLOBALS['user'] ?? null;
-
         $actingUserId = $this->createTestUser();
-        $actingUser = new User();
-        $actingUser->find($actingUserId);
-        $reflection = new ReflectionClass($actingUser);
-        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
-        $isLoggedInProperty->setValue($actingUser, true);
-        $GLOBALS['user'] = $actingUser;
+        $this->loginAsTestUser($actingUserId);
     }
 
     protected function tearDown(): void
     {
-        // Restore rather than unset — bootstrap-integration.php seeds a fallback
-        // $GLOBALS['user'] once per process, so $savedGlobalUser should never actually
-        // be null here in practice. The unset() branch is defensive: it only matters if
-        // some earlier test explicitly unsets the global (none currently do), so that a
-        // later test class isn't left with no global $user at all if that ever changes.
-        if ($this->savedGlobalUser !== null) {
-            $GLOBALS['user'] = $this->savedGlobalUser;
-        } else {
-            unset($GLOBALS['user']);
+        try {
+            // Belt-and-suspenders: the hook is expected to have already deleted these
+            // (that's what the test asserts), so this is normally a 0-row no-op. It only
+            // matters if an assertion failed partway through and left a row behind.
+            foreach ($this->createdProfileUserIds as $userId) {
+                $this->db->query('DELETE FROM profiles WHERE user_id = ?', [$userId]);
+            }
+        } finally {
+            // Run even if the profile cleanup above throws, so the base class's own
+            // fixture cleanup — and its restoreGlobalUser() call — is never skipped.
+            parent::tearDown();
         }
-
-        // Belt-and-suspenders: the hook is expected to have already deleted these
-        // (that's what the test asserts), so this is normally a 0-row no-op. It only
-        // matters if an assertion failed partway through and left a row behind.
-        foreach ($this->createdProfileUserIds as $userId) {
-            $this->db->query('DELETE FROM profiles WHERE user_id = ?', [$userId]);
-        }
-
-        parent::tearDown();
     }
 
     /**

--- a/tests/integration/database/CarDatabaseOperationsTest.php
+++ b/tests/integration/database/CarDatabaseOperationsTest.php
@@ -36,17 +36,7 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
         $this->testUserId = $this->createTestUser();
 
         // Set up authenticated user context for tests
-        global $user;
-        $user = new User();
-        $user->find($this->testUserId);
-
-        // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
-        // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
-        $reflection = new ReflectionClass($user);
-        $isLoggedInProperty = $reflection->getProperty('_isLoggedIn');
-        $isLoggedInProperty->setValue($user, true);
-
-        $GLOBALS['user'] = $user;
+        $this->loginAsTestUser($this->testUserId);
 
         // Create unique test car for this test
         try {
@@ -56,11 +46,6 @@ final class CarDatabaseOperationsTest extends IntegrationTestCase
         } catch (RuntimeException $e) {
             $this->markTestSkipped('Could not create test car: ' . $e->getMessage());
         }
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
     }
 
     /**

--- a/tests/integration/database/CarsYearSmallintMigrationTest.php
+++ b/tests/integration/database/CarsYearSmallintMigrationTest.php
@@ -55,15 +55,7 @@ final class CarsYearSmallintMigrationTest extends IntegrationTestCase
         $this->testUserId = $this->createTestUser();
 
         // Mirror the authenticated-user context required by Car::update() / Car::delete().
-        global $user;
-        $user = new User();
-        $user->find($this->testUserId);
-
-        $reflection     = new ReflectionClass($user);
-        $isLoggedInProp = $reflection->getProperty('_isLoggedIn');
-        $isLoggedInProp->setValue($user, true);
-
-        $GLOBALS['user'] = $user;
+        $this->loginAsTestUser($this->testUserId);
 
         $this->localCarIds = [];
     }

--- a/tests/integration/database/ChassisOverridePersistenceTest.php
+++ b/tests/integration/database/ChassisOverridePersistenceTest.php
@@ -52,17 +52,7 @@ final class ChassisOverridePersistenceTest extends IntegrationTestCase
         $this->testUserId = $this->createTestUser();
 
         // Set up an authenticated user context (mirrors CarDatabaseOperationsTest pattern).
-        // Bypass login() to set the private $_isLoggedIn flag directly via reflection.
-        // setAccessible() is intentionally omitted — it is a no-op since PHP 8.1.
-        global $user;
-        $user = new User();
-        $user->find($this->testUserId);
-
-        $reflection        = new ReflectionClass($user);
-        $isLoggedInProp    = $reflection->getProperty('_isLoggedIn');
-        $isLoggedInProp->setValue($user, true);
-
-        $GLOBALS['user'] = $user;
+        $this->loginAsTestUser($this->testUserId);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds `loginAsTestUser(int $userId): User` / `restoreGlobalUser(): void` to `IntegrationTestCase`, replacing a duplicated inline "fake login via reflection" idiom across 10 integration test files (the original 9 from the issue, plus `UserDeletionReassignmentTest.php`, folded in to avoid leaving a second bespoke "canonical" implementation).
- Closes a latent test-pollution leak: 9 of those 10 files never restored `$GLOBALS['user']` afterward, so a fake-authenticated session could leak into whichever test class PHPUnit happened to run next in the same process. `IntegrationTestCase::tearDown()` now restores it as its first statement, and two subclasses (`CarTransferTest`, `UserDeletionReassignmentTest`) were updated to wrap their own cleanup in `try/finally` so that guarantee holds even if their cleanup throws.
- Adds `IntegrationTestCaseAuthHelperTest.php`, covering the helper's own snapshot/restore edge cases (double-login-doesn't-resnapshot, idempotent restore, unset-vs-null, the new `RuntimeException` on a bad user ID, and a probe test proving `tearDown()` restores before running cleanup).
- Documents the pattern in `docs/development/TESTING_STRATEGY.md` so the idiom isn't hand-rolled again.

## Review
Went through a full plan-review cycle, a security review, an architect review, a code-simplifier pass, and a full-branch `/review-pr` (code-reviewer + silent-failure-hunter + comment-analyzer + pr-test-analyzer in parallel, followed by a re-verification pass after fixes). All rounds came back clean — no blocking issues at any stage.

## Test plan
- [x] Full integration suite passes, verified across default/reverse/random orderings (no new order-dependent failures — the issue's explicit acceptance criterion)
- [x] `vendor/bin/phpstan analyse` clean on all touched files
- [x] Coding standards check clean
- [x] New tests mutation-verified (each fails when its target branch is broken)
- [ ] One pre-existing, unrelated failure (`TransferRequestConstraintTest::test_deleteCar_cascadesTransferRequests`) reproduces identically on the unmodified milestone base — not introduced by this PR, left alone per scope

Closes #1572

https://claude.ai/code/session_01XZAMc3DfZpPHyMbsH1aDfb