### PR TITLE
test: wire AdminContactSanitizationTest #660 tests to the real process-admin-contact.php regex

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.29.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.1.md
@@ -98,3 +98,4 @@ Do the following, in order, **separately for each environment** (test, then prod
 - [#1603](https://github.com/elan-registry/registry/issues/1603) — test: LocationServiceResponseTest only exercises ApiResponse literals, never the location-search/reverse endpoints
 - [#1572](https://github.com/elan-registry/registry/issues/1572) — test: extract shared authenticated-session helper for integration tests, migrating 10 files off the duplicated login idiom
 - [#1573](https://github.com/elan-registry/registry/issues/1573) — test: CarActionsTest.php's 10 tests are tautologies — deleted the file, moved 2 real gaps to CarDatabaseOperationsTest.php/CarImageLifecycleTest.php, and 1 to a new save.php action-routing wiring test
+- [#1597](https://github.com/elan-registry/registry/issues/1597) — test: AdminContactSanitizationTest reimplements CR/LF-strip regex from process-admin-contact.php — added a source-inspection guard against the real production regex

--- a/tests/unit/admin/AdminContactSanitizationTest.php
+++ b/tests/unit/admin/AdminContactSanitizationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Admin;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Regression tests for admin contact sanitization bugs.
@@ -13,18 +14,48 @@ use PHPUnit\Framework\TestCase;
  * #661: filter_var validation on target_email in the Multiple-owner path.
  *
  * The action file (process-admin-contact.php) cannot be unit-tested directly
- * (requires full framework bootstrap), so these tests validate the sanitization
- * and validation patterns in isolation.
+ * (requires full framework bootstrap), so the #660 behavioral tests validate
+ * a mirrored copy of the sanitization pattern in isolation, covering
+ * input/output edge cases (CR, LF, tabs, combined injection, clean values,
+ * null). Those behavioral tests are backed by a source-inspection guard (see
+ * the source-inspection guard section below) that reads the real
+ * process-admin-contact.php source and asserts the exact sanitization is
+ * present, so a regression in production would be caught even though the
+ * file itself cannot be executed in a unit test.
  */
 class AdminContactSanitizationTest extends TestCase
 {
+    private const PROCESS_ADMIN_CONTACT_FILE = 'app/admin/includes/process-admin-contact.php';
+
+    /**
+     * Mirrors the pattern in process-admin-contact.php — kept as one constant
+     * so the mirror below and the source-inspection guard can't drift apart.
+     */
+    private const HEADER_STRIP_PATTERN = '/[\r\n\t]/';
+
+    private string $rootDir = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->rootDir = dirname(__DIR__, 3);
+    }
+
     /**
      * Mirrors the CR/LF-stripping pattern used in process-admin-contact.php
      * for header-bound values ($toEmail, $fromEmail, $qualityIssue).
      */
     private function stripHeaderChars(?string $value): string
     {
-        return preg_replace('/[\r\n\t]/', '', (string) $value);
+        return preg_replace(self::HEADER_STRIP_PATTERN, '', (string) $value);
+    }
+
+    private function readProcessAdminContactSource(): string
+    {
+        $filePath = $this->rootDir . '/' . self::PROCESS_ADMIN_CONTACT_FILE;
+        $this->assertFileExists($filePath, 'process-admin-contact.php must exist (#660)');
+
+        return (string) file_get_contents($filePath);
     }
 
     // -------------------------------------------------------------------------
@@ -69,6 +100,63 @@ class AdminContactSanitizationTest extends TestCase
     public function testQualityIssueNullHandledSafely(): void
     {
         $this->assertSame('', $this->stripHeaderChars(null));
+    }
+
+    // -------------------------------------------------------------------------
+    // #660 — source-inspection guard against the real process-admin-contact.php
+    // -------------------------------------------------------------------------
+
+    /**
+     * Deliberately checks only "preg_replace(PATTERN, '', ... <expression> ..."
+     * rather than pinning the full statement (assignment target, casts,
+     * ternary wrapper) — a harmless refactor of the surrounding syntax
+     * shouldn't break this guard; only a change to the regex itself or to
+     * which value it's applied to should.
+     */
+    #[DataProvider('headerStripCallSitesProvider')]
+    public function testProductionStripsHeaderCharsForCallSite(string $description, string $targetExpression): void
+    {
+        $content = $this->readProcessAdminContactSource();
+
+        $pattern = '/' . preg_quote("preg_replace('" . self::HEADER_STRIP_PATTERN . "', ''", '/')
+            . '.*?' . preg_quote($targetExpression, '/') . '/';
+
+        $this->assertSame(
+            1,
+            preg_match($pattern, $content),
+            "process-admin-contact.php must strip CR/LF/tab from {$description} ({$targetExpression}) (#660)"
+        );
+    }
+
+    public static function headerStripCallSitesProvider(): array
+    {
+        return [
+            'owner email' => ['owner email', '$ownerData->email'],
+            'admin email' => ['admin email', '$adminData->email'],
+            'quality issue' => ['quality issue', '$qualityIssue'],
+            'delivery error message' => ['delivery error message', '$result'],
+        ];
+    }
+
+    /**
+     * This is a review gate, not proof every header-bound value is
+     * sanitized: it only catches an existing call site being silently
+     * dropped or duplicated. A newly added, unsanitized header-bound value
+     * would leave the count unchanged and this test green — it must be
+     * caught by review, not by this count.
+     */
+    public function testProductionSanitizationPatternAppliesExactlyFourTimes(): void
+    {
+        $content = $this->readProcessAdminContactSource();
+
+        $sanitizationCount = substr_count($content, "preg_replace('" . self::HEADER_STRIP_PATTERN . "', ''");
+        $this->assertSame(
+            4,
+            $sanitizationCount,
+            'process-admin-contact.php should apply the header-char sanitization pattern exactly 4 times ' .
+            '(owner email, admin email, quality issue, delivery error message) — update this count deliberately ' .
+            'when adding or removing a sanitized call site (#660)'
+        );
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The `#660` CR/LF-stripping regression tests in `AdminContactSanitizationTest.php` only exercised a private test-helper copy of the sanitization regex (`stripHeaderChars()`), never the production code in `app/admin/includes/process-admin-contact.php`. A regression in the shipped regex (e.g. narrowing the character class, or dropping it from one of the 4 call sites) would have kept the test suite green.
- Adds a source-inspection guard — a `#[DataProvider]`-based test plus a call-site-count test — that reads the real `process-admin-contact.php` source and asserts the CR/LF/tab-stripping regex is applied at all 4 call sites (owner email, admin email, quality issue, delivery-error message). This mirrors the established pattern already used in this codebase for files that can't be bootstrapped for unit testing (`RouteLookupsThroughClassesTest.php`, `PageRobotsTest.php`).
- The existing 6 behavioral tests and the `stripHeaderChars()` helper are left unchanged — the new tests are additive, per the issue's acceptance criteria.
- A shared `HEADER_STRIP_PATTERN` constant ties the mirrored helper and the guard assertions to one source of truth, so they can't silently drift apart from each other.
- No production code changed — `app/admin/includes/process-admin-contact.php` is untouched.

## Found in passing

While reviewing this PR, the `#661` `target_email` validation tests in the same file (`testTargetEmailValidAccepted` etc.) were found to have the same tautology defect — they assert PHP's own `filter_var()` behavior, never touching production. This is out of scope for #1597 (different issue), so it was filed separately and deferred: #1633.

## Test plan

- `vendor/bin/phpunit tests/unit/admin/AdminContactSanitizationTest.php` — 15/15 pass
- `composer test:quick` — 1369/1369 pass
- `vendor/bin/phpstan analyse tests/unit/admin/AdminContactSanitizationTest.php` — no errors
- Manually verified the guard actually catches a regression: temporarily broke the production regex (dropped CR/LF stripping on `$qualityIssue`), confirmed 2 tests failed, then restored — confirmed empty diff
- Manually verified the guard tolerates a harmless refactor (swapped `(string)(...)` cast for `strval(...)`) without a false failure, confirming it targets the security-relevant regex + variable, not incidental syntax

Closes #1597

https://claude.ai/code/session_01KtyBe31Hortswi7zL7Kh7e