### PR TITLE
test: wire LocationServiceUserAgentTest to real getUserAgent() fallback logic

### DIFF
--- a/docs/releases/RELEASE_NOTES_v2.29.1.md
+++ b/docs/releases/RELEASE_NOTES_v2.29.1.md
@@ -92,6 +92,7 @@ Do the following, in order, **separately for each environment** (test, then prod
 - [#1566](https://github.com/elan-registry/registry/issues/1566) — test: retire ad-hoc User double in RegistrationRecoveryNotifierTest.php that pollutes PHPStan analysis project-wide
 - [#1556](https://github.com/elan-registry/registry/issues/1556) — test: audit remaining unit test files for undetected mock/fake usage
 - [#1551](https://github.com/elan-registry/registry/issues/1551) — test: cars_hist DELETE-order leak in TransferRequestConstraintTest and CarsYearSmallintMigrationTest
+- [#1602](https://github.com/elan-registry/registry/issues/1602) — test: 2 LocationServiceUserAgentTest cases seed the cache directly, bypassing the real fallback branch — extracted the guarded fallback to `LocationService::resolveVersion()` so tests drive real temp files
 - [#1542](https://github.com/elan-registry/registry/issues/1542) — test: RobotsTxtPolicyTest verifies repo robots.txt, not the as-served file with Cloudflare's injection
 - [#1604](https://github.com/elan-registry/registry/issues/1604) — test: VerificationWorkflowTest tests a wholly fictional class — zero coupling to production code
 - [#1609](https://github.com/elan-registry/registry/issues/1609) — test: VerificationSecurityTest has tautological tests asserting local data against itself

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -517,12 +517,6 @@ parameters:
 			path: tests/unit/location/LocationServiceCacheTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with string will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/unit/location/LocationServiceUserAgentTest.php
-
-		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''ElanRegistry\\\\Resize'' and ElanRegistry\\Resize will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 2

--- a/tests/unit/location/LocationServiceUserAgentTest.php
+++ b/tests/unit/location/LocationServiceUserAgentTest.php
@@ -15,10 +15,18 @@ use PHPUnit\Framework\Attributes\Group;
  * the file is absent or empty.
  *
  * getUserAgent() is private + static, so it is exercised via Reflection.
+ * The fallback logic itself lives in the path-parameterized
+ * resolveVersion() helper (#1602), which is also invoked directly via
+ * Reflection so tests can drive the absent/empty-file branches with real
+ * temporary files instead of seeding $cachedVersion — mirrors the
+ * path-parameterized extraction technique used by
+ * AssetVersionResolver::resolve() (#1598); the fallback semantics differ
+ * ('unknown' vs. 'dev', no allow-list regex).
  * $cachedVersion is also reset via Reflection between tests to prevent
  * static-state pollution.
  *
  * @issue 1070
+ * @issue 1602
  * @link https://github.com/unibrain1/elanregistry/issues/1070
  * @see usersc/classes/LocationService.php
  */
@@ -29,15 +37,17 @@ final class LocationServiceUserAgentTest extends TestCase
 {
     private \ReflectionClass $ref;
     private \ReflectionMethod $getUserAgent;
+    private \ReflectionMethod $resolveVersion;
     private \ReflectionProperty $cachedVersion;
     private LocationService $service;
 
     protected function setUp(): void
     {
-        $this->service       = new LocationService();
-        $this->ref           = new \ReflectionClass(LocationService::class);
-        $this->getUserAgent  = $this->ref->getMethod('getUserAgent');
-        $this->cachedVersion = $this->ref->getProperty('cachedVersion');
+        $this->service        = new LocationService();
+        $this->ref            = new \ReflectionClass(LocationService::class);
+        $this->getUserAgent   = $this->ref->getMethod('getUserAgent');
+        $this->resolveVersion = $this->ref->getMethod('resolveVersion');
+        $this->cachedVersion  = $this->ref->getProperty('cachedVersion');
         // Reset static cache before every test
         $this->cachedVersion->setValue(null, null);
     }
@@ -51,6 +61,22 @@ final class LocationServiceUserAgentTest extends TestCase
     private function invokeGetUserAgent(): string
     {
         return (string) $this->getUserAgent->invoke($this->service);
+    }
+
+    /**
+     * Drives resolveVersion() with $path, asserts it falls back to 'unknown',
+     * seeds the cache with that result, and asserts the formatted
+     * User-Agent string.
+     */
+    private function assertResolveVersionFallsBackToUnknown(string $path): void
+    {
+        $resolved = $this->resolveVersion->invoke(null, $path);
+        $this->assertSame('unknown', $resolved);
+
+        $this->cachedVersion->setValue(null, $resolved);
+        $ua = $this->invokeGetUserAgent();
+
+        $this->assertSame('ElanRegistry/unknown (https://elanregistry.org)', $ua);
     }
 
     public function testUserAgentContainsVersionFromFile(): void
@@ -68,20 +94,28 @@ final class LocationServiceUserAgentTest extends TestCase
         $this->assertStringContainsString('(https://elanregistry.org)', $ua);
     }
 
+    public function testResolveVersionReturnsTrimmedContentForRealFile(): void
+    {
+        $path = sys_get_temp_dir() . '/LocationServiceUserAgentTest_valid_' . uniqid() . '_VERSION';
+        file_put_contents($path, " v9.9.9 \n");
+
+        try {
+            $resolved = $this->resolveVersion->invoke(null, $path);
+        } finally {
+            unlink($path);
+        }
+
+        $this->assertSame('v9.9.9', $resolved);
+    }
+
     public function testUserAgentFallsBackToUnknownWhenVersionFileIsAbsent(): void
     {
-        // Point the class at a non-existent file by temporarily replacing
-        // $cachedVersion after clearing it, then patching via a stub method
-        // that returns the result of the private logic with a fake path.
-        // Since the method builds the path via __DIR__, we override via the
-        // static cache directly: set it to null, then call with the real
-        // file read but from a path that doesn't exist — not trivially possible
-        // without modifying the source. Instead, test via the cache: if
-        // cachedVersion is 'unknown', the output must reflect it.
-        $this->cachedVersion->setValue(null, 'unknown');
-        $ua = $this->invokeGetUserAgent();
+        // Construct a path guaranteed not to exist and drive resolveVersion()
+        // with it directly — exercises the real is_readable()/fallback logic.
+        $absentPath = sys_get_temp_dir() . '/LocationServiceUserAgentTest_absent_' . uniqid() . '_VERSION';
+        $this->assertFileDoesNotExist($absentPath, 'Precondition: temp path must not exist');
 
-        $this->assertSame('ElanRegistry/unknown (https://elanregistry.org)', $ua);
+        $this->assertResolveVersionFallsBackToUnknown($absentPath);
     }
 
     public function testStaticCachePreventsDuplicateFileReads(): void
@@ -99,17 +133,33 @@ final class LocationServiceUserAgentTest extends TestCase
 
     public function testEmptyVersionFallsBackToUnknown(): void
     {
-        // Simulate an empty VERSION file result via the cache property
-        $this->cachedVersion->setValue(null, null);
-        // We can't directly inject an empty file without modifying the source.
-        // Test the guard logic: if cachedVersion resolves to empty from file,
-        // it must store 'unknown'. Verify by seeding the cache as if the
-        // file-read path had stored the empty fallback.
-        $this->cachedVersion->setValue(null, 'unknown');
-        $ua = $this->invokeGetUserAgent();
+        // Write a real empty VERSION file and drive resolveVersion() with it
+        // directly — exercises the real trim()/!== '' fallback logic.
+        $path = sys_get_temp_dir() . '/LocationServiceUserAgentTest_empty_' . uniqid() . '_VERSION';
+        $written = file_put_contents($path, '');
+        $this->assertNotFalse($written, 'Precondition: failed to write empty temp VERSION file at ' . $path);
 
-        $this->assertSame('ElanRegistry/unknown (https://elanregistry.org)', $ua);
-        $this->assertStringNotContainsString('ElanRegistry/ (', $ua);
+        try {
+            $this->assertResolveVersionFallsBackToUnknown($path);
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function testWhitespaceOnlyVersionFallsBackToUnknown(): void
+    {
+        // Whitespace-only content is non-empty raw bytes that trim() must
+        // reduce to '' before the !== '' fallback check fires — distinct
+        // from testEmptyVersionFallsBackToUnknown(), where trim('') is a no-op.
+        $path = sys_get_temp_dir() . '/LocationServiceUserAgentTest_whitespace_' . uniqid() . '_VERSION';
+        $written = file_put_contents($path, "  \n\t  \n");
+        $this->assertNotFalse($written, 'Precondition: failed to write whitespace-only temp VERSION file at ' . $path);
+
+        try {
+            $this->assertResolveVersionFallsBackToUnknown($path);
+        } finally {
+            unlink($path);
+        }
     }
 
     /**

--- a/tests/unit/location/LocationServiceUserAgentTest.php
+++ b/tests/unit/location/LocationServiceUserAgentTest.php
@@ -97,7 +97,8 @@ final class LocationServiceUserAgentTest extends TestCase
     public function testResolveVersionReturnsTrimmedContentForRealFile(): void
     {
         $path = sys_get_temp_dir() . '/LocationServiceUserAgentTest_valid_' . uniqid() . '_VERSION';
-        file_put_contents($path, " v9.9.9 \n");
+        $written = file_put_contents($path, " v9.9.9 \n");
+        $this->assertNotFalse($written, 'Precondition: failed to write temp VERSION file at ' . $path);
 
         try {
             $resolved = $this->resolveVersion->invoke(null, $path);

--- a/tests/unit/location/LocationServiceUserAgentTest.php
+++ b/tests/unit/location/LocationServiceUserAgentTest.php
@@ -128,7 +128,6 @@ final class LocationServiceUserAgentTest extends TestCase
         // After the first call the static property must be a non-null string
         $cached = $this->cachedVersion->getValue(null);
         $this->assertIsString($cached);
-        $this->assertNotNull($cached);
     }
 
     public function testEmptyVersionFallsBackToUnknown(): void

--- a/usersc/classes/LocationService.php
+++ b/usersc/classes/LocationService.php
@@ -75,12 +75,29 @@ class LocationService
     private static function getUserAgent(): string
     {
         if (self::$cachedVersion === null) {
-            $versionFile = __DIR__ . '/../../VERSION';
-            $raw = is_readable($versionFile) ? trim((string) file_get_contents($versionFile)) : '';
-            self::$cachedVersion = ($raw !== '') ? $raw : 'unknown';
+            self::$cachedVersion = self::resolveVersion(__DIR__ . '/../../VERSION');
         }
 
         return 'ElanRegistry/' . self::$cachedVersion . ' (' . self::USER_AGENT_CONTACT . ')';
+    }
+
+    /**
+     * Resolve the version string from a VERSION file path, falling back to
+     * 'unknown' when the file is absent, unreadable, or empty.
+     *
+     * Extracted as a path-parameterized helper (#1602) so unit tests can drive
+     * the real fallback branches with real temporary files instead of seeding
+     * $cachedVersion directly — mirrors the extraction technique used by
+     * AssetVersionResolver::resolve() (#1598); fallback semantics differ
+     * ('unknown' vs. 'dev', no allow-list regex).
+     *
+     * @param string $versionFile Absolute path to the VERSION file.
+     * @return string The trimmed version string, or 'unknown' as fallback.
+     */
+    private static function resolveVersion(string $versionFile): string
+    {
+        $raw = is_readable($versionFile) ? trim((string) file_get_contents($versionFile)) : '';
+        return ($raw !== '') ? $raw : 'unknown';
     }
 
     /**


### PR DESCRIPTION
## Summary
- Two tests in `LocationServiceUserAgentTest.php` seeded the private static `$cachedVersion` cache directly instead of exercising `LocationService::getUserAgent()`'s real file-absent/empty-file fallback branch (tautological assertions).
- Extracted the guarded fallback logic into a new path-parameterized private static helper `resolveVersion(string $versionFile): string`, mirroring the `AssetVersionResolver::resolve()` extraction pattern from #1598. `getUserAgent()` now delegates to it; behavior is unchanged.
- Rewrote both tests to invoke `resolveVersion()` directly via Reflection against real temporary files (a guaranteed-nonexistent path, a real empty file) instead of seeding the cache.
- Added `testWhitespaceOnlyVersionFallsBackToUnknown` (proves `trim()` actually runs — the empty-file test's `trim('')` alone is a no-op) and `testResolveVersionReturnsTrimmedContentForRealFile` (deterministic success-path coverage, no longer dependent on/skippable via the real repo `VERSION` file).

## Bug Escape Analysis (tech-debt / test-quality)
- **Root cause:** The original tests couldn't drive the real fallback branch because `getUserAgent()` built the VERSION file path internally via `__DIR__` with no injection seam, so the tests worked around it by seeding the cached result directly — the tests' own comments admitted this ("not trivially possible without modifying the source").
- **Testing gap:** No test exercised the `is_readable()` / `trim()` / `!== ''` fallback logic itself — a regression (e.g. inverting the `!== ''` check) would have passed both tests undetected.
- **Preventive measure:** Extracting the logic into a path-parameterized helper (same shape as #1598) makes the branch directly testable. Verified via mutation check: inverting the fallback condition made both rewritten tests fail as expected; reverting made them pass again.

## Test plan
- `vendor/bin/phpunit --filter LocationServiceUserAgentTest` — 7/7 pass, 17 assertions
- `composer test:quick` — 1384/1384 pass
- `vendor/bin/phpstan analyse usersc/classes/LocationService.php tests/unit/location/LocationServiceUserAgentTest.php` — no errors
- Local multi-agent review (`/review-pr`) run before push: code-reviewer, silent-failure-hunter, comment-analyzer, pr-test-analyzer — one blocking finding (dead assertion) fixed, four recommendations applied

Closes #1602