### PR TITLE
ci: cache PHPStan result cache in static-analysis.yml

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -85,6 +85,17 @@ jobs:
       - name: Install dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
+      # PHPStan invalidates cache entries per-file by content hash, so a
+      # cache restored from an older commit is still safe to reuse — it just
+      # skips re-analyzing files that haven't changed since. A miss (new
+      # cache key) costs nothing beyond a normal cold run.
+      - name: Cache PHPStan result cache
+        uses: actions/cache@v6
+        with:
+          path: .phpstan-cache
+          key: ${{ runner.os }}-phpstan-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-phpstan-
+
       - name: Run PHPStan (full repo — level 5, baselined)
         run: vendor/bin/phpstan analyse --error-format=github --no-progress --memory-limit=512M
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ usersc/vericode_secret.php
 ########################################
 .php_cs.cache
 .phpunit.cache
+.phpstan-cache/
 .scannerwork/*
 error_log
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,13 @@ includes:
 parameters:
     level: 5
 
+    # Explicit, stable path so CI can cache PHPStan's result cache across runs
+    # (actions/cache in .github/workflows/static-analysis.yml) instead of
+    # paying for a cold full-repo analysis on every PR. PHPStan invalidates
+    # cache entries per-file by content hash, so a stale/mismatched cache
+    # restore is harmless — worst case is a cache miss, not a wrong result.
+    tmpDir: .phpstan-cache
+
     paths:
         # Application
         - app


### PR DESCRIPTION
## Summary
- Mirrors the CI-relevant piece of a workflow-efficiency change landing on `milestone/v2.29.1` — CI's PHPStan job ran cold every time (no persisted result cache), even though PHPStan invalidates cache entries per-file by content hash and would otherwise skip re-analyzing unchanged files.
- Sets an explicit `tmpDir` in `phpstan.neon` so the cache path is stable, and caches it via `actions/cache` keyed on `composer.lock` with an OS-scoped restore-key fallback.
- Same PHPStan config/scope on `main` — nothing about what's checked changes, only removes redundant re-analysis on unchanged files.

Opened directly against `main` (not via a milestone branch) since this file needs to match between branches for CI to run correctly, and `main`'s copy of `static-analysis.yml`/`phpstan.neon` would otherwise be out of sync with the milestone branch's version until the full milestone ships.

## Test plan
- [x] Ran `vendor/bin/phpstan analyse` locally against this branch's `phpstan.neon` — confirms cache directory (`.phpstan-cache/`, gitignored) is created and analysis still passes cleanly
- [ ] Confirm the `PHPStan Analysis` required check passes on this PR