### PR TITLE
chore: add per-command thinking triggers and brief-output style to Claude commands

### DIFF
--- a/.claude/commands/address-pr-comments.md
+++ b/.claude/commands/address-pr-comments.md
@@ -5,6 +5,11 @@ model: claude-opus-4-8
 
 # Address PR Comments
 
+Think hard when triaging blocking vs. advisory findings — a wrong call
+either ships a real issue or wastes a fix/re-verify cycle.
+
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 After a PR is created and CI runs, this command fetches all review comments
 and check annotations, triages them, fixes blocking items, and prepares the
 PR for `/finish-issue`.

--- a/.claude/commands/architecture-update.md
+++ b/.claude/commands/architecture-update.md
@@ -5,6 +5,11 @@ model: claude-opus-4-8
 
 # Architecture Documentation Update
 
+Think through the codebase audit before writing documentation — verify
+what the code actually does rather than what existing docs claim.
+
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 ## Step 0: Initialize TaskList
 
 Before any other action, create one tracking task per major step below using

--- a/.claude/commands/finish-issue.md
+++ b/.claude/commands/finish-issue.md
@@ -5,6 +5,8 @@ model: claude-sonnet-5
 
 # Finish Issue
 
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 ## Step 0: Initialize TaskList
 
 Before any other action, create one tracking task per major step below using

--- a/.claude/commands/finish-milestone.md
+++ b/.claude/commands/finish-milestone.md
@@ -5,6 +5,8 @@ model: claude-sonnet-5
 
 # Finish Milestone
 
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 Create a PR to merge a completed milestone branch into main, finalize release
 notes, update wiki documentation, and prepare for release.
 

--- a/.claude/commands/found.md
+++ b/.claude/commands/found.md
@@ -5,6 +5,8 @@ model: claude-haiku-4-5-20251001
 
 # Found: Capture Pre-Existing Issue
 
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 Capture an issue discovered incidentally during planning or development work,
 classify it using the containment + severity framework, and take the appropriate
 action without disrupting the current task.

--- a/.claude/commands/new-issue.md
+++ b/.claude/commands/new-issue.md
@@ -5,6 +5,11 @@ model: claude-sonnet-5
 
 # Create Issue Command
 
+Think through scope, acceptance criteria, and decomposition before
+drafting the issue.
+
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 ## Step 0: Initialize TaskList
 
 Before any other action, create one tracking task per major step below using

--- a/.claude/commands/release-milestone.md
+++ b/.claude/commands/release-milestone.md
@@ -5,6 +5,8 @@ model: claude-opus-4-8
 
 # Release Milestone
 
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 Merge a milestone PR into main, create an annotated tag, push to remotes, and
 publish a GitHub release. This command picks up where `/finish-milestone` left
 off — after the milestone PR has been created and reviewed.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -5,6 +5,11 @@ argument-hint: "[aspects: code|errors|comments|tests|simplify|all]"
 
 # PR Review (Full Branch)
 
+Think hard when verifying findings and judging false positives — a wrong
+triage call either ships a bug or burns a CI round-trip.
+
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 Run a comprehensive review against the **full accumulated branch diff** — the
 same view the CI `pr-to-milestone-review` check uses. This catches cross-commit
 issues (dead code, broken call interactions, unreachable paths) that per-file or

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -5,6 +5,11 @@ model: claude-haiku-4-5-20251001
 
 # Security Review
 
+Think hard about attack vectors and exploit paths before drawing
+conclusions — reason through how each input reaches each sink.
+
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 Perform a comprehensive security audit of recent code changes in this project.
 
 ## Steps

--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -5,6 +5,11 @@ model: claude-haiku-4-5-20251001
 
 # Simplify
 
+Think hard about whether each proposed simplification preserves behavior
+exactly — including edge cases, error paths, and side effects.
+
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 Review the recently modified code for opportunities to simplify, improve
 clarity, reduce redundancy, and align with project coding standards — without
 changing any behavior. Focus only on files changed in the current session

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -5,6 +5,12 @@ model: claude-opus-4-8
 
 # GitHub Issue Workflow Command
 
+Think hard throughout this workflow — especially when assessing the
+complexity tier, triaging pre-existing issues, and writing the
+implementation plan. Plan quality gates everything downstream.
+
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 ## Hard Constraints (non-negotiable)
 
 > **1. PLAN APPROVAL IS REQUIRED before writing any code.**

--- a/.claude/commands/start-milestone.md
+++ b/.claude/commands/start-milestone.md
@@ -5,6 +5,8 @@ model: claude-opus-4-8
 
 # Start Milestone
 
+Keep output brief — terse status lines, no preamble, no restating of steps.
+
 ## Step 0: Initialize TaskList
 
 Before any other action, create one tracking task per major step below using


### PR DESCRIPTION
## Summary

With `alwaysThinkingEnabled` now off by default, the judgment-heavy commands get explicit extended-thinking triggers, and all 12 runtime commands get a uniform brief-output instruction.

**Thinking triggers (think hard):** `start-issue`, `review-pr`, `security-review`, `address-pr-comments`, `simplify`
**Thinking triggers (moderate):** `new-issue`, `architecture-update`
**Brief-output line (all 12):** `Keep output brief — terse status lines, no preamble, no restating of steps.` — added as body prose since command frontmatter has no output-style field.

Mechanical commands (`commit`-family lives outside this repo; `finish-issue`, `finish-milestone`, `found`, `release-milestone`, `start-milestone`) intentionally get no thinking trigger — they're checklist-driven.

`start-issue-examples.md` untouched (reference-only, not loaded at runtime).

## Testing

- Pre-commit markdownlint: 0 issues across the 12 files
- Content-only changes to command prompts; no code affected

https://claude.ai/code/session_015UmgkcoupA8ijJbtPGmnQt