### PR TITLE
fix: register base pages/permissions during provisioning (#1671)

### DIFF
--- a/database/seeds/PageRegistrationSeed.php
+++ b/database/seeds/PageRegistrationSeed.php
@@ -137,10 +137,14 @@ final class PageRegistrationSeed extends AbstractSeed
 
     private function registerNewPage(string $page): void
     {
+        // `z_us_root.php` carries `core=1` on dev/prod (see the ROOT_PAGES docblock); every
+        // other discovered page is `core=0`, matching what lazy registration would have inserted.
+        $core = $page === 'z_us_root.php' ? 1 : 0;
+
         $inserted = $this->execute(
             'INSERT INTO `pages` (`page`, `title`, `private`, `re_auth`, `core`, `lang_key`) ' .
-            'VALUES (?, NULL, ?, 0, 0, NULL)',
-            [$page, $this->classifyPrivate($page)]
+            'VALUES (?, NULL, ?, 0, ?, NULL)',
+            [$page, $this->classifyPrivate($page), $core]
         );
 
         if ($inserted !== 1) {

--- a/database/seeds/PageRegistrationSeed.php
+++ b/database/seeds/PageRegistrationSeed.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+use ElanRegistry\Admin\PagePermissionClassifier;
+use Phinx\Seed\AbstractSeed;
+
+/**
+ * Register every `securePage()`-protected page into `pages` and
+ * `permission_page_matches` (#1671).
+ *
+ * UserSpice populates `pages` lazily: a row is only written the first time an
+ * Administrator visits that page and `securePage()` runs `createPages()`. A
+ * scripted install (`scripts/provision-schema.sh`) never visits any page as
+ * an admin, so on a fresh database both tables stay empty and the
+ * application is effectively unusable until someone manually clicks through
+ * every protected page while logged in as an admin.
+ * `app/admin/scripts/maintenance/21-Fix-Page-Permissions.php` looks like the
+ * fix but is not: it only reconciles permissions for pages already present
+ * in `pages` — on an empty table it is a no-op.
+ *
+ * This seed walks the real page inventory and inserts the missing rows
+ * directly, using `ElanRegistry\Admin\PagePermissionClassifier` (the same
+ * classifier `21-Fix-Page-Permissions.php` uses) so the two never disagree
+ * about how a page should be classified. It does not duplicate that
+ * classifier's logic, and it does not touch `permission_page_matches` for a
+ * page that already exists in `pages` — reconciling drift on already-known
+ * pages remains `21-Fix-Page-Permissions.php`'s job.
+ *
+ * A small fixed list (`ROOT_PAGES`) covers the two lone repo-root pages that
+ * sit outside every scanned directory. Everything else uses two strategies
+ * depending on directory. For `app/`,
+ * `usersc/`, and `docs/`, whether a given `.php` file is a "page" is
+ * determined by grepping its own contents for a genuine `securePage()` call
+ * (`if (!securePage(...))`, the only call shape used anywhere in this
+ * codebase). That single check is what naturally excludes files that must
+ * never be registered — `app/action/`, `app/api/cars/`, `app/api/shared/`
+ * (CLAUDE.md requires these skip `securePage()` entirely) — and what
+ * naturally includes `app/api/contact/*.php`, without hardcoding either
+ * list. A handful of files still need explicit exclusion because they match
+ * the call pattern for reasons unrelated to being a real, independently
+ * routable page:
+ *
+ * - `users/helpers/permissions.php` defines `securePage()`; it doesn't call it.
+ * - `usersc/plugins/ai_prompts/**` are AI-context documentation files
+ *   (`*.md.php`) that contain the call pattern only inside example code blocks.
+ * - `usersc/includes/example_*.php` is UserSpice's unrenamed example
+ *   scaffolding — never `require`d by anything until a site owner copies and
+ *   renames it.
+ * - `users/_blank_pages/**` is UserSpice's stock unused page template — never
+ *   `require`d by anything, referenced only from documentation.
+ * - `users/modules/**` and `users/views/**` are includes/partials consumed by
+ *   another page (e.g. `users/admin.php`), not independently routable pages
+ *   in their own right.
+ * - `app/admin/scripts/fix/_ARCHIVE/**` and `_TEMPLATE_Fix-Script.php` are
+ *   retired/template fix scripts. `21-Fix-Page-Permissions.php` already
+ *   skips `_TEMPLATE_` paths when reconciling; this seed skips both so it
+ *   never registers dead or non-runnable scripts as live pages.
+ *
+ * `users/` is walked unconditionally instead — every `.php` file found there
+ * (minus the same includes/partials exclusions) is registered regardless of
+ * whether it calls `securePage()` directly. Most core UserSpice pages
+ * (`login.php`, `join.php`, `logout.php`, `index.php`, the passkey/TOTP/
+ * verification flows, etc.) never call `securePage()` themselves — they're
+ * public by UserSpice installer convention, or gate access some other way —
+ * so grepping for the call would silently skip them.
+ * `PagePermissionClassifier::getUserSpiceInstallerSpec()` already encodes
+ * the correct default for every `users/*.php` file, including the
+ * public-by-default fallback for anything not in its explicit map, so
+ * classification doesn't depend on the grep either.
+ *
+ * Idempotent: every insert is individually guarded by a `SELECT` first,
+ * mirroring the duplicate-guard pattern `21-Fix-Page-Permissions.php` uses
+ * when applying its own fixes. Neither `pages` nor `permission_page_matches`
+ * has a unique constraint to lean on instead.
+ */
+final class PageRegistrationSeed extends AbstractSeed
+{
+    /** UserSpice built-in permission id for the "User" (owner) tier. */
+    private const PERM_USER = 1;
+
+    /** UserSpice built-in permission id for the "Administrator" tier. */
+    private const PERM_ADMIN = 2;
+
+    /** UserSpice built-in permission id for the "Editor" tier. */
+    private const PERM_EDITOR = 3;
+
+    /** @var list<string> Repo-root-relative directories grep-scanned for a genuine `securePage()` call. */
+    private const SECURE_PAGE_SCAN_DIRECTORIES = ['app', 'usersc', 'docs'];
+
+    /** Repo-root-relative directory walked unconditionally, classified via `getUserSpiceInstallerSpec()`. */
+    private const USERSPICE_INSTALLER_DIRECTORY = 'users';
+
+    /**
+     * @var list<string> Lone repo-root `.php` files that are real pages but sit outside every
+     *                    scanned directory. `index.php` genuinely calls `securePage()` (would be
+     *                    found by the grep strategy if root were scanned recursively, which it
+     *                    isn't, to avoid pulling in every other root-level script). `z_us_root.php`
+     *                    is the front-controller/bootstrap file — it never calls `securePage()`
+     *                    itself, but dev and prod both carry a `core=1`, public `pages` row for it,
+     *                    and CLAUDE.md documents it as the holder of the `$path` routing array, so
+     *                    it is registered unconditionally to match existing installs.
+     */
+    private const ROOT_PAGES = ['index.php', 'z_us_root.php'];
+
+    /** @var list<string> Path substrings that exclude a file from discovery outright. */
+    private const EXCLUDED_PATH_SUBSTRINGS = [
+        '/vendor/',
+        '/node_modules/',
+        '/tests/',
+        'usersc/plugins/ai_prompts/',
+        'usersc/includes/example_',
+        'users/_blank_pages/',
+        'users/modules/',
+        'users/views/',
+        'users/helpers/',
+        'app/admin/scripts/fix/_ARCHIVE/',
+        '_TEMPLATE_',
+    ];
+
+    /** Regex matching a genuine `securePage()` call site, not a mention in a comment or doc string. */
+    private const SECURE_PAGE_CALL_PATTERN = '/if\s*\(\s*!\s*securePage\s*\(/';
+
+    public function run(): void
+    {
+        $repoRoot = dirname(__DIR__, 2);
+        $pages = $this->discoverPages($repoRoot);
+
+        foreach ($pages as $page) {
+            if ($this->findPageId($page) !== null) {
+                continue;
+            }
+
+            $this->registerNewPage($page);
+        }
+    }
+
+    private function registerNewPage(string $page): void
+    {
+        $inserted = $this->execute(
+            'INSERT INTO `pages` (`page`, `title`, `private`, `re_auth`, `core`, `lang_key`) ' .
+            'VALUES (?, NULL, ?, 0, 0, NULL)',
+            [$page, $this->classifyPrivate($page)]
+        );
+
+        if ($inserted !== 1) {
+            throw new RuntimeException(
+                "PageRegistrationSeed: inserting `pages`.`page` = '{$page}' reported {$inserted} " .
+                'affected rows, expected 1.'
+            );
+        }
+
+        $pageId = $this->findPageId($page);
+        if ($pageId === null) {
+            throw new RuntimeException(
+                "PageRegistrationSeed: `pages`.`page` = '{$page}' was just inserted but cannot be " .
+                're-selected.'
+            );
+        }
+
+        foreach ($this->classifyPermissions($page) as $permissionId) {
+            $this->insertPermissionMatch($pageId, $permissionId);
+        }
+    }
+
+    private function findPageId(string $page): ?int
+    {
+        $row = $this->query('SELECT id FROM `pages` WHERE `page` = ?', [$page])->fetch(\PDO::FETCH_ASSOC);
+
+        return $row !== false ? (int) $row['id'] : null;
+    }
+
+    /**
+     * Walk the known page directories and return every repo-root-relative
+     * path that should be registered — either because it genuinely calls
+     * `securePage()` (`app/`, `usersc/`, `docs/`) or because it lives under
+     * `users/`, where `getUserSpiceInstallerSpec()`'s own default already
+     * determines the correct classification regardless of whether the file
+     * calls `securePage()` itself.
+     *
+     * @return list<string>
+     */
+    private function discoverPages(string $repoRoot): array
+    {
+        $pages = [
+            ...self::ROOT_PAGES,
+            ...$this->discoverSecurePageCallers($repoRoot),
+            ...$this->discoverUserSpiceInstallerPages($repoRoot),
+        ];
+
+        sort($pages);
+
+        return $pages;
+    }
+
+    /**
+     * @return list<string> repo-root-relative paths under `app/`, `usersc/`, `docs/` that
+     *                       genuinely call `securePage()`.
+     */
+    private function discoverSecurePageCallers(string $repoRoot): array
+    {
+        $pages = [];
+
+        foreach (self::SECURE_PAGE_SCAN_DIRECTORIES as $directory) {
+            foreach ($this->walkPhpFiles($repoRoot, $directory) as $relativePath) {
+                $contents = file_get_contents($repoRoot . '/' . $relativePath);
+                if ($contents === false) {
+                    throw new RuntimeException(
+                        "PageRegistrationSeed: unable to read '{$relativePath}' during page discovery."
+                    );
+                }
+
+                if (preg_match(self::SECURE_PAGE_CALL_PATTERN, $contents) === 1) {
+                    $pages[] = $relativePath;
+                }
+            }
+        }
+
+        return $pages;
+    }
+
+    /**
+     * Every top-level `.php` file directly under `users/` (not recursive), unconditionally —
+     * `getUserSpiceInstallerSpec()` already supplies the correct classification (including its
+     * public-by-default fallback) whether or not the file calls `securePage()` itself. Every
+     * routable UserSpice page (`login.php`, `admin.php`, `join.php`, etc.) lives directly under
+     * `users/` — every subdirectory (`users/classes/`, `users/auth/`, `users/includes/`,
+     * `users/lang/`, `users/parsers/`, `users/updates/components/`, `users/cron/`, ...) holds
+     * libraries, includes, language packs, or upgrade scripts, never an independently routable
+     * page. Recursing into those would misregister hundreds of non-pages as public (the fallback
+     * in `getUserSpiceInstallerSpec()` defaults anything not in its explicit map to public).
+     *
+     * @return list<string>
+     */
+    private function discoverUserSpiceInstallerPages(string $repoRoot): array
+    {
+        return $this->walkPhpFiles($repoRoot, self::USERSPICE_INSTALLER_DIRECTORY, recursive: false);
+    }
+
+    /**
+     * @return list<string> repo-root-relative, non-excluded `.php` file paths under $directory.
+     */
+    private function walkPhpFiles(string $repoRoot, string $directory, bool $recursive = true): array
+    {
+        $absoluteDirectory = $repoRoot . '/' . $directory;
+        if (!is_dir($absoluteDirectory)) {
+            return [];
+        }
+
+        $paths = [];
+
+        $directoryIterator = new RecursiveDirectoryIterator($absoluteDirectory, FilesystemIterator::SKIP_DOTS);
+        $iterator = $recursive ? new RecursiveIteratorIterator($directoryIterator) : $directoryIterator;
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relativePath = substr($file->getPathname(), strlen($repoRoot) + 1);
+
+            if (!$this->isExcludedPath($relativePath)) {
+                $paths[] = $relativePath;
+            }
+        }
+
+        return $paths;
+    }
+
+    private function isExcludedPath(string $relativePath): bool
+    {
+        foreach (self::EXCLUDED_PATH_SUBSTRINGS as $excluded) {
+            if (str_contains($relativePath, $excluded)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function classifyPrivate(string $page): int
+    {
+        if (str_starts_with($page, 'users/')) {
+            $spec = PagePermissionClassifier::getUserSpiceInstallerSpec($page);
+
+            return ($spec['private'] ?? 0) ? 1 : 0;
+        }
+
+        return PagePermissionClassifier::shouldBePrivate($page) ? 1 : 0;
+    }
+
+    /**
+     * Determine which permission ids a newly-registered page should receive,
+     * mirroring `21-Fix-Page-Permissions.php`'s bucketing exactly.
+     *
+     * @return list<int>
+     */
+    private function classifyPermissions(string $page): array
+    {
+        if (str_starts_with($page, 'users/')) {
+            $spec = PagePermissionClassifier::getUserSpiceInstallerSpec($page);
+
+            /** @var list<int> $perms */
+            $perms = $spec['perms'] ?? [];
+
+            return $perms;
+        }
+
+        $private = PagePermissionClassifier::shouldBePrivate($page);
+
+        if (!$private) {
+            return [];
+        }
+
+        if (!PagePermissionClassifier::shouldHaveAdminPermissions($page)) {
+            return [self::PERM_USER];
+        }
+
+        if (PagePermissionClassifier::shouldBeAdminOnly($page)) {
+            return [self::PERM_ADMIN];
+        }
+
+        return [self::PERM_ADMIN, self::PERM_EDITOR];
+    }
+
+    private function insertPermissionMatch(int $pageId, int $permissionId): void
+    {
+        $existing = $this->query(
+            'SELECT id FROM `permission_page_matches` WHERE `page_id` = ? AND `permission_id` = ?',
+            [$pageId, $permissionId]
+        )->fetch(\PDO::FETCH_ASSOC);
+
+        if ($existing !== false) {
+            return;
+        }
+
+        $inserted = $this->execute(
+            'INSERT INTO `permission_page_matches` (`permission_id`, `page_id`) VALUES (?, ?)',
+            [$permissionId, $pageId]
+        );
+
+        if ($inserted !== 1) {
+            throw new RuntimeException(
+                "PageRegistrationSeed: inserting permission_page_matches for page_id={$pageId}, " .
+                "permission_id={$permissionId} reported {$inserted} affected rows, expected 1."
+            );
+        }
+    }
+}

--- a/tests/integration/database/PageRegistrationSeedTest.php
+++ b/tests/integration/database/PageRegistrationSeedTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../IntegrationTestCase.php';
+
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration tests for database/seeds/PageRegistrationSeed.php (#1671).
+ *
+ * The seed is a Phinx `AbstractSeed` subclass, discovered by filename glob
+ * and executed under Phinx's own CLI runtime (adapter, input/output) — it is
+ * not autoloaded by Composer and cannot be instantiated directly from
+ * PHPUnit. This test therefore runs it the same way
+ * `scripts/provision-schema.sh` does: as a real `vendor/bin/phinx seed:run`
+ * subprocess against the dedicated integration test schema, then asserts on
+ * the `pages`/`permission_page_matches` rows it leaves behind. This mirrors
+ * `LogDeploymentScriptTest`'s subprocess pattern, including propagating this
+ * run's DB_* env vars via putenv() so the subprocess connects to the same
+ * test schema instead of falling back to the project's real .env.
+ *
+ * `pages` and `permission_page_matches` are truncated in setUp() so every
+ * test starts from the empty-table state a fresh install actually has, and
+ * restored from a snapshot in tearDown() so this suite never leaves the
+ * shared integration schema missing its real page inventory for other tests.
+ */
+#[Group('integration')]
+#[Group('migration')]
+final class PageRegistrationSeedTest extends IntegrationTestCase
+{
+    /** @var list<string> */
+    private const DB_ENV_VARS = ['DB_HOST', 'DB_PORT', 'DB_NAME', 'DB_USER', 'DB_PASS'];
+
+    /** @var list<array<string, mixed>> Snapshot of `pages` rows before this suite truncates the table. */
+    private array $pagesSnapshot = [];
+
+    /** @var list<array<string, mixed>> Snapshot of `permission_page_matches` rows before truncation. */
+    private array $permissionMatchesSnapshot = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requireDatabase();
+
+        $this->pagesSnapshot = $this->fetchAllRows('SELECT * FROM `pages`');
+        $this->permissionMatchesSnapshot = $this->fetchAllRows('SELECT * FROM `permission_page_matches`');
+
+        $this->db->query('SET FOREIGN_KEY_CHECKS = 0');
+        $this->db->query('TRUNCATE TABLE `permission_page_matches`');
+        $this->db->query('TRUNCATE TABLE `pages`');
+        $this->db->query('SET FOREIGN_KEY_CHECKS = 1');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->databaseConnected) {
+            $this->db->query('SET FOREIGN_KEY_CHECKS = 0');
+            $this->db->query('TRUNCATE TABLE `permission_page_matches`');
+            $this->db->query('TRUNCATE TABLE `pages`');
+
+            foreach ($this->pagesSnapshot as $row) {
+                $this->db->insert('pages', $row);
+            }
+            foreach ($this->permissionMatchesSnapshot as $row) {
+                $this->db->insert('permission_page_matches', $row);
+            }
+            $this->db->query('SET FOREIGN_KEY_CHECKS = 1');
+        }
+
+        parent::tearDown();
+    }
+
+    public function testSeedRegistersKnownPagesAcrossAllBranchesAndIsIdempotent(): void
+    {
+        [$returnCode, $output] = $this->runSeed();
+        $this->assertSame(0, $returnCode, 'Seed must exit 0. Output: ' . implode("\n", $output));
+
+        // Admin-only page: private=1, exactly one permission_page_matches row (Administrator = 2).
+        $adminPage = $this->fetchAllRows(
+            "SELECT * FROM `pages` WHERE `page` = 'app/admin/scripts/maintenance/21-Fix-Page-Permissions.php'"
+        );
+        $this->assertCount(1, $adminPage, 'Admin-only page must be registered exactly once');
+        $this->assertSame(1, (int) $adminPage[0]['private'], 'Admin-only page must be private');
+
+        $adminPageId = (int) $adminPage[0]['id'];
+        $adminPermissions = $this->fetchAllRows(
+            'SELECT * FROM `permission_page_matches` WHERE `page_id` = ?',
+            [$adminPageId]
+        );
+        $this->assertCount(1, $adminPermissions, 'Admin-only page must have exactly one permission row');
+        $this->assertSame(2, (int) $adminPermissions[0]['permission_id'], 'Admin-only page must grant Administrator (2)');
+
+        // Public page: private=0, zero permission rows. docs/pdf-viewer.php calls
+        // securePage() only for permission-table registration consistency, not to
+        // require login (see that file's own header comment).
+        $publicPage = $this->fetchAllRows("SELECT * FROM `pages` WHERE `page` = 'docs/pdf-viewer.php'");
+        $this->assertCount(1, $publicPage, 'Public page must be registered exactly once');
+        $this->assertSame(0, (int) $publicPage[0]['private'], 'Public page must not be private');
+
+        $publicPageId = (int) $publicPage[0]['id'];
+        $publicPermissions = $this->fetchAllRows(
+            'SELECT * FROM `permission_page_matches` WHERE `page_id` = ?',
+            [$publicPageId]
+        );
+        $this->assertCount(0, $publicPermissions, 'Public page must have no permission rows');
+
+        // users/* page: a distinct code path (getUserSpiceInstallerSpec()) from the
+        // app/usersc/docs branch exercised above. users/account.php is a known
+        // UserSpice installer default: private=1, User permission only.
+        $usersPage = $this->fetchAllRows("SELECT * FROM `pages` WHERE `page` = 'users/account.php'");
+        $this->assertCount(1, $usersPage, 'users/account.php must be registered exactly once');
+        $this->assertSame(1, (int) $usersPage[0]['private'], 'users/account.php must be private');
+
+        $usersPageId = (int) $usersPage[0]['id'];
+        $usersPagePermissions = $this->fetchAllRows(
+            'SELECT * FROM `permission_page_matches` WHERE `page_id` = ?',
+            [$usersPageId]
+        );
+        $this->assertCount(1, $usersPagePermissions, 'users/account.php must have exactly one permission row');
+        $this->assertSame(1, (int) $usersPagePermissions[0]['permission_id'], 'users/account.php must grant User (1)');
+
+        $pagesCountAfterFirstRun = $this->countRows('pages');
+        $matchesCountAfterFirstRun = $this->countRows('permission_page_matches');
+        $this->assertGreaterThan(0, $pagesCountAfterFirstRun, 'Seed must have registered at least one page');
+
+        // Re-running must be a no-op.
+        [$secondReturnCode, $secondOutput] = $this->runSeed();
+        $this->assertSame(
+            0,
+            $secondReturnCode,
+            'Re-running the seed must exit 0. Output: ' . implode("\n", $secondOutput)
+        );
+
+        $this->assertSame(
+            $pagesCountAfterFirstRun,
+            $this->countRows('pages'),
+            'Re-running the seed must not change the pages row count'
+        );
+        $this->assertSame(
+            $matchesCountAfterFirstRun,
+            $this->countRows('permission_page_matches'),
+            'Re-running the seed must not change the permission_page_matches row count'
+        );
+    }
+
+    /**
+     * @return array{0: int, 1: list<string>}
+     */
+    private function runSeed(): array
+    {
+        $this->exposeTestDatabaseToSubprocess();
+
+        $phinxBinary = __DIR__ . '/../../../vendor/bin/phinx';
+        $phinxConfig = __DIR__ . '/../../../phinx.php';
+
+        $command = 'php ' . escapeshellarg($phinxBinary)
+            . ' seed:run'
+            . ' -c ' . escapeshellarg($phinxConfig)
+            . ' -s ' . escapeshellarg('PageRegistrationSeed')
+            . ' 2>&1';
+
+        $output = [];
+        $returnCode = 0;
+        exec($command, $output, $returnCode);
+
+        return [$returnCode, $output];
+    }
+
+    /**
+     * Propagate this test run's DB credentials into the process environment so the
+     * `phinx` subprocess connects to the same dedicated test schema instead of
+     * falling back to the project's real .env. Mirrors LogDeploymentScriptTest.
+     */
+    private function exposeTestDatabaseToSubprocess(): void
+    {
+        foreach (self::DB_ENV_VARS as $var) {
+            $value = $_ENV[$var] ?? getenv($var);
+            if (is_string($value) && $value !== '') {
+                putenv("$var=$value");
+            }
+        }
+    }
+
+    /**
+     * @param list<mixed> $bindings
+     * @return list<array<string, mixed>>
+     */
+    private function fetchAllRows(string $sql, array $bindings = []): array
+    {
+        $rows = $this->db->query($sql, $bindings)->results();
+
+        return array_map(static fn(object $row): array => (array) $row, $rows);
+    }
+
+    private function countRows(string $table): int
+    {
+        $quotedTable = '`' . str_replace('`', '``', $table) . '`';
+        $row = $this->db->query("SELECT COUNT(*) AS cnt FROM {$quotedTable}")->first();
+
+        return is_object($row) ? (int) $row->cnt : 0;
+    }
+}


### PR DESCRIPTION
## Summary

- Fresh installs never populate the `pages`/`permission_page_matches` tables because UserSpice registers pages lazily, only on an admin's first visit (`securePage()`/`createPages()` in `users/helpers/permissions.php`). A scripted provision never visits any page as an admin, so a fresh install ends up with an empty permissions table and every page effectively unreachable.
- Adds `database/seeds/PageRegistrationSeed.php`, a new idempotent Phinx seed that walks the known page inventory and registers each page with baseline permissions using the existing `PagePermissionClassifier` logic, so classification stays in one place. `scripts/provision-schema.sh` already auto-discovers seed classes via glob — no script changes needed.
- Discovery uses three parts:
  - `ROOT_PAGES`: fixed list (`index.php`, `z_us_root.php`) for the two lone repo-root pages that sit outside every scanned directory
  - Recursive walk of `app/`, `usersc/`, `docs/`, filtered by grep for `if (!securePage(`
  - Non-recursive top-level walk of `users/`, classified via the classifier's `USERS_PAGE_DEFAULTS` map
- Seed is insert-only — never deletes or prunes existing `pages`/`permission_page_matches` rows, matching `21-Fix-Page-Permissions.php`'s non-destructive philosophy.
- Verified discovery output against a screenshot of a stock UserSpice install's `pages` table (18 rows, all `core=1`) — this surfaced the `ROOT_PAGES` gap (`index.php`/`z_us_root.php` were missing from discovery before this fix). All 17 applicable screenshot pages (`users/admin_pin.php` doesn't exist in this repo) are now discovered with matching `private` classification.

## Test plan

- [x] `vendor/bin/phpstan analyse database/seeds/PageRegistrationSeed.php` — no errors
- [x] `php -l database/seeds/PageRegistrationSeed.php` — no syntax errors
- [x] New integration test `tests/integration/database/PageRegistrationSeedTest.php` — 1 test, 16 assertions, passing
- [x] Full unit suite (1630 tests) passing via pre-commit hook
- [x] Manually diffed discovery output against a real test DB's `pages` table (61 rows) — no unexpected gaps beyond the pre-fix `ROOT_PAGES` omission (now fixed)

Closes #1671

Claude-Session: https://claude.ai/code/session_01HkJrYfuBTwHcRNyUS7WXUo